### PR TITLE
Cache environment variables dictionary

### DIFF
--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         ICredentialStore ICommandContext.CredentialStore => CredentialStore;
 
-        IReadOnlyDictionary<string, string> ICommandContext.GetEnvironmentVariables()
+        IReadOnlyDictionary<string, string> ICommandContext.EnvironmentVariables
             => new ReadOnlyDictionary<string, string>(EnvironmentVariables);
 
         #endregion


### PR DESCRIPTION
Cache the environment variables in a dictionary after first use and don't always reconstruct it per access.

This is also work which will be used for upcoming PRs to combine the environment variables and Git configuration layers into a 'settings' layer in GCM.