### PR TITLE
Move `IHttpClientFactory to `ICommandContext`

### DIFF
--- a/src/shared/GitHub.Tests/GitHubRestApiTests.cs
+++ b/src/shared/GitHub.Tests/GitHubRestApiTests.cs
@@ -44,8 +44,8 @@ namespace GitHub.Tests
 
             var httpHandler = new TestHttpMessageHandler {SimulateNoNetwork = true};
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             await Assert.ThrowsAsync<HttpRequestException>(
                 () => api.AcquireTokenAsync(uri, testUserName, testPassword, testAuthCode, testScopes)
@@ -81,8 +81,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, testAuthCode, testScopes);
@@ -120,8 +120,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, testAuthCode, testScopes);
@@ -158,8 +158,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, testAuthCode, testScopes);
@@ -192,8 +192,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, null, testScopes);
@@ -224,8 +224,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, null, testScopes);
@@ -258,8 +258,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testOAuthToken, null, testScopes);
@@ -295,8 +295,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, testAuthCode, testScopes);
@@ -330,8 +330,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, testAuthCode, testScopes);
@@ -367,8 +367,8 @@ namespace GitHub.Tests
                 return httpResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new GitHubRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new GitHubRestApi(context);
 
             AuthenticationResult authResult = await api.AcquireTokenAsync(
                 uri, testUserName, testPassword, testAuthCode, testScopes);

--- a/src/shared/GitHub/GitHubRestApi.cs
+++ b/src/shared/GitHub/GitHubRestApi.cs
@@ -31,18 +31,12 @@ namespace GitHub
         private const int RequestTimeout = 15 * 1000; // 15 second limit
 
         private readonly ICommandContext _context;
-        private readonly IHttpClientFactory _httpFactory;
 
         public GitHubRestApi(ICommandContext context)
-            : this(context, new HttpClientFactory()) { }
-
-        public GitHubRestApi(ICommandContext context, IHttpClientFactory httpFactory)
         {
             EnsureArgument.NotNull(context, nameof(context));
-            EnsureArgument.NotNull(httpFactory, nameof(httpFactory));
 
             _context = context;
-            _httpFactory = httpFactory;
         }
 
         #region IGitHubApi
@@ -203,7 +197,7 @@ namespace GitHub
             {
                 if (_httpClient is null)
                 {
-                    _httpClient = _httpFactory.CreateClient();
+                    _httpClient = _context.HttpClientFactory.CreateClient();
 
                     // Set the common headers and timeout
                     _httpClient.Timeout = TimeSpan.FromMilliseconds(RequestTimeout);

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
@@ -36,8 +36,8 @@ namespace Microsoft.AzureRepos.Tests
 
             var httpHandler = new TestHttpMessageHandler {SimulateNoNetwork = true};
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             await Assert.ThrowsAsync<HttpRequestException>(() => api.GetAuthorityAsync(uri));
         }
@@ -55,8 +55,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, httpResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualAuthority = await api.GetAuthorityAsync(uri);
 
@@ -77,8 +77,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, httpResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualAuthority = await api.GetAuthorityAsync(uri);
 
@@ -101,8 +101,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, httpResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualAuthority = await api.GetAuthorityAsync(uri);
 
@@ -126,8 +126,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, httpResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualAuthority = await api.GetAuthorityAsync(uri);
 
@@ -158,8 +158,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, httpResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualAuthority = await api.GetAuthorityAsync(uri);
 
@@ -183,8 +183,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, httpResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualAuthority = await api.GetAuthorityAsync(uri);
 
@@ -208,8 +208,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, httpResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualAuthority = await api.GetAuthorityAsync(uri);
 
@@ -248,8 +248,8 @@ namespace Microsoft.AzureRepos.Tests
                 return identSvcResponse;
             });
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             string actualPat = await api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes);
 
@@ -270,8 +270,8 @@ namespace Microsoft.AzureRepos.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Get, locSvcRequestUri, HttpStatusCode.InternalServerError);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             await Assert.ThrowsAsync<Exception>(() => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));
         }
@@ -301,8 +301,8 @@ namespace Microsoft.AzureRepos.Tests
             });
             httpHandler.Setup(HttpMethod.Post, identSvcRequestUri, HttpStatusCode.InternalServerError);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             await Assert.ThrowsAsync<Exception>(() => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));
         }
@@ -335,8 +335,8 @@ namespace Microsoft.AzureRepos.Tests
             });
             httpHandler.Setup(HttpMethod.Post, identSvcRequestUri, _ => identSvcError);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var api = new AzureDevOpsRestApi(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var api = new AzureDevOpsRestApi(context);
 
             Exception exception = await Assert.ThrowsAsync<Exception>(
                 () => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
@@ -21,18 +21,12 @@ namespace Microsoft.AzureRepos
     public class AzureDevOpsRestApi : IAzureDevOpsRestApi
     {
         private readonly ICommandContext _context;
-        private readonly IHttpClientFactory _httpFactory;
 
         public AzureDevOpsRestApi(ICommandContext context)
-            : this(context, new HttpClientFactory()) { }
-
-        public AzureDevOpsRestApi(ICommandContext context, IHttpClientFactory httpFactory)
         {
             EnsureArgument.NotNull(context, nameof(context));
-            EnsureArgument.NotNull(httpFactory, nameof(httpFactory));
 
             _context = context;
-            _httpFactory = httpFactory;
         }
 
         public async Task<string> GetAuthorityAsync(Uri organizationUri)
@@ -185,7 +179,7 @@ namespace Microsoft.AzureRepos
             {
                 if (_httpClient is null)
                 {
-                    _httpClient = _httpFactory.CreateClient();
+                    _httpClient = _context.HttpClientFactory.CreateClient();
 
                     // Configure the HTTP client with standard headers for Azure Repos API calls
                     _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(Constants.Http.MimeTypeJson));

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/WindowsIntegratedAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/WindowsIntegratedAuthenticationTests.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Head, uri, wiaResponse);
 
-            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
-            var wiaAuth = new WindowsIntegratedAuthentication(context, httpFactory);
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            var wiaAuth = new WindowsIntegratedAuthentication(context);
 
             bool actual = await wiaAuth.GetIsSupportedAsync(uri);
 

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/WindowsIntegratedAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/WindowsIntegratedAuthentication.cs
@@ -15,15 +15,10 @@ namespace Microsoft.Git.CredentialManager.Authentication
     public class WindowsIntegratedAuthentication : IWindowsIntegratedAuthentication
     {
         private readonly ICommandContext _context;
-        private readonly IHttpClientFactory _httpFactory;
 
         public WindowsIntegratedAuthentication(ICommandContext context)
-            : this(context, new HttpClientFactory()) { }
-
-        public WindowsIntegratedAuthentication(ICommandContext context, IHttpClientFactory httpFactory)
         {
             _context = context;
-            _httpFactory = httpFactory;
         }
 
         public async Task<bool> GetIsSupportedAsync(Uri uri)
@@ -57,7 +52,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
         }
 
         private HttpClient _httpClient;
-        private HttpClient HttpClient => _httpClient ?? (_httpClient = _httpFactory.CreateClient());
+        private HttpClient HttpClient => _httpClient ?? (_httpClient = _context.HttpClientFactory.CreateClient());
 
         #region IDisposable
 

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         public TestFileSystem FileSystem { get; set; } = new TestFileSystem();
         public TestCredentialStore CredentialStore { get; set; } = new TestCredentialStore();
         public TestGit Git { get; set; } = new TestGit();
+        public TestHttpClientFactory HttpClientFactory { get; set; } = new TestHttpClientFactory();
         public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
         public string NewLine { get; set; } = "\n";
 
@@ -37,6 +38,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         ICredentialStore ICommandContext.CredentialStore => CredentialStore;
 
         IGit ICommandContext.Git => Git;
+
+        IHttpClientFactory ICommandContext.HttpClientFactory => HttpClientFactory;
 
         IReadOnlyDictionary<string, string> ICommandContext.EnvironmentVariables
             => new ReadOnlyDictionary<string, string>(EnvironmentVariables);


### PR DESCRIPTION
Move the `IHttpClientFactory` to the `ICommandContext` and simplify the instantiation points for the various `*RestApi` types.