### PR TITLE
Introduce ISettings component to consolidate envar and Git cfg settings

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/TtyPromptBasicAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/TtyPromptBasicAuthenticationTests.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Authentication;
 using Microsoft.Git.CredentialManager.Tests.Objects;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests.Authentication
@@ -65,7 +62,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
 
             var context = new TestCommandContext
             {
-                EnvironmentVariables = {[Constants.EnvironmentVariables.GitTerminalPrompts] = "0"}
+                Settings = {IsTerminalPromptsEnabled = false},
             };
 
             var basicAuth = new TtyPromptBasicAuthentication(context);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
@@ -62,5 +62,80 @@ namespace Microsoft.Git.CredentialManager.Tests
             Assert.Equal("bar", inputArgs["foo"]);
             Assert.Equal("bar", inputArgs.GetArgumentOrDefault("foo"));
         }
+
+        [Fact]
+        public void InputArguments_GetRemoteUri_NoAuthority_ReturnsNull()
+        {
+            var dict = new Dictionary<string, string>();
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri();
+
+            Assert.Null(actualUri);
+        }
+
+        [Fact]
+        public void InputArguments_GetRemoteUri_Authority_ReturnsUriWithAuthority()
+        {
+            var expectedUri = new Uri("https://example.com/");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri();
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
+        public void InputArguments_GetRemoteUri_AuthorityPath_ReturnsUriWithAuthorityAndPath()
+        {
+            var expectedUri = new Uri("https://example.com/an/example/path");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com",
+                ["path"]     = "an/example/path"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri();
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
+        public void InputArguments_GetRemoteUri_AuthorityPathUserInfo_ReturnsUriWithAuthorityAndPath()
+        {
+            var expectedUri = new Uri("https://example.com/an/example/path");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com",
+                ["path"]     = "an/example/path",
+
+                // Username and password are not expected to appear in the returned URI
+                ["username"] = "john.doe",
+                ["password"] = "password123"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri();
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/LibGit2Tests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/LibGit2Tests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
         }
 
         [Fact]
-        public void LibGit2Configuration_TryGetString_Name_Exists_ReturnsTrueOutString()
+        public void LibGit2Configuration_TryGetValue_Name_Exists_ReturnsTrueOutString()
         {
             string repoPath = CreateRepository();
             Git(repoPath, "config --local user.name john.doe").AssertSuccess();
@@ -44,7 +44,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                bool result = config.TryGetString("user.name", out string value);
+                bool result = config.TryGetValue("user.name", out string value);
                 Assert.True(result);
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
@@ -52,7 +52,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
         }
 
         [Fact]
-        public void LibGit2Configuration_TryGetString_Name_DoesNotExists_ReturnsFalse()
+        public void LibGit2Configuration_TryGetValue_Name_DoesNotExists_ReturnsFalse()
         {
             string repoPath = CreateRepository();
 
@@ -60,14 +60,14 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             using (var config = git.GetConfiguration(repoPath))
             {
                 string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
-                bool result = config.TryGetString(randomName, out string value);
+                bool result = config.TryGetValue(randomName, out string value);
                 Assert.False(result);
                 Assert.Null(value);
             }
         }
 
         [Fact]
-        public void LibGit2Configuration_TryGetString_SectionProperty_Exists_ReturnsTrueOutString()
+        public void LibGit2Configuration_TryGetValue_SectionProperty_Exists_ReturnsTrueOutString()
         {
             string repoPath = CreateRepository();
             Git(repoPath, "config --local user.name john.doe").AssertSuccess();
@@ -75,7 +75,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                bool result = config.TryGetString("user", "name", out string value);
+                bool result = config.TryGetValue("user", "name", out string value);
                 Assert.True(result);
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
@@ -83,7 +83,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
         }
 
         [Fact]
-        public void LibGit2Configuration_TryGetString_SectionProperty_DoesNotExists_ReturnsFalse()
+        public void LibGit2Configuration_TryGetValue_SectionProperty_DoesNotExists_ReturnsFalse()
         {
             string repoPath = CreateRepository();
 
@@ -92,14 +92,14 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             {
                 string randomSection  = Guid.NewGuid().ToString("N");
                 string randomProperty = Guid.NewGuid().ToString("N");
-                bool result = config.TryGetString(randomSection, randomProperty, out string value);
+                bool result = config.TryGetValue(randomSection, randomProperty, out string value);
                 Assert.False(result);
                 Assert.Null(value);
             }
         }
 
         [Fact]
-        public void LibGit2Configuration_TryGetString_SectionScopeProperty_Exists_ReturnsTrueOutString()
+        public void LibGit2Configuration_TryGetValue_SectionScopeProperty_Exists_ReturnsTrueOutString()
         {
             string repoPath = CreateRepository();
             Git(repoPath, "config --local user.example.com.name john.doe").AssertSuccess();
@@ -107,7 +107,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                bool result = config.TryGetString("user", "example.com", "name", out string value);
+                bool result = config.TryGetValue("user", "example.com", "name", out string value);
                 Assert.True(result);
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
@@ -115,7 +115,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
         }
 
         [Fact]
-        public void LibGit2Configuration_TryGetString_SectionScopeProperty_NullScope_ReturnsTrueOutUnscopedString()
+        public void LibGit2Configuration_TryGetValue_SectionScopeProperty_NullScope_ReturnsTrueOutUnscopedString()
         {
             string repoPath = CreateRepository();
             Git(repoPath, "config --local user.name john.doe").AssertSuccess();
@@ -123,7 +123,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                bool result = config.TryGetString("user", null, "name", out string value);
+                bool result = config.TryGetValue("user", null, "name", out string value);
                 Assert.True(result);
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
@@ -131,7 +131,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
         }
 
         [Fact]
-        public void LibGit2Configuration_TryGetString_SectionScopeProperty_DoesNotExists_ReturnsFalse()
+        public void LibGit2Configuration_TryGetValue_SectionScopeProperty_DoesNotExists_ReturnsFalse()
         {
             string repoPath = CreateRepository();
 
@@ -141,7 +141,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
                 string randomSection  = Guid.NewGuid().ToString("N");
                 string randomScope    = Guid.NewGuid().ToString("N");
                 string randomProperty = Guid.NewGuid().ToString("N");
-                bool result = config.TryGetString(randomSection, randomScope, randomProperty, out string value);
+                bool result = config.TryGetValue(randomSection, randomScope, randomProperty, out string value);
                 Assert.False(result);
                 Assert.Null(value);
             }
@@ -156,7 +156,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                string value = config.GetString("user.name");
+                string value = config.GetValue("user.name");
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
             }
@@ -171,7 +171,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             using (var config = git.GetConfiguration(repoPath))
             {
                 string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
-                Assert.Throws<KeyNotFoundException>(() => config.GetString(randomName));
+                Assert.Throws<KeyNotFoundException>(() => config.GetValue(randomName));
             }
         }
 
@@ -184,7 +184,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                string value = config.GetString("user", "name");
+                string value = config.GetValue("user", "name");
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
             }
@@ -200,7 +200,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             {
                 string randomSection  = Guid.NewGuid().ToString("N");
                 string randomProperty = Guid.NewGuid().ToString("N");
-                Assert.Throws<KeyNotFoundException>(() => config.GetString(randomSection, randomProperty));
+                Assert.Throws<KeyNotFoundException>(() => config.GetValue(randomSection, randomProperty));
             }
         }
 
@@ -213,7 +213,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                string value = config.GetString("user", "example.com", "name");
+                string value = config.GetValue("user", "example.com", "name");
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
             }
@@ -228,7 +228,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
             var git = new LibGit2();
             using (var config = git.GetConfiguration(repoPath))
             {
-                string value = config.GetString("user", null, "name");
+                string value = config.GetValue("user", null, "name");
                 Assert.NotNull(value);
                 Assert.Equal("john.doe", value);
             }
@@ -245,7 +245,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop
                 string randomSection  = Guid.NewGuid().ToString("N");
                 string randomScope    = Guid.NewGuid().ToString("N");
                 string randomProperty = Guid.NewGuid().ToString("N");
-                Assert.Throws<KeyNotFoundException>(() => config.GetString(randomSection, randomScope, randomProperty));
+                Assert.Throws<KeyNotFoundException>(() => config.GetValue(randomSection, randomScope, randomProperty));
             }
         }
 

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -1,0 +1,387 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class SettingsTests
+    {
+        [Fact]
+        public void Settings_IsDebuggingEnabled_EnvarUnset_ReturnsFalse()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsDebuggingEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsDebuggingEnabled_EnvarTruthy_ReturnsTrue()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmDebug] = "1"
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsDebuggingEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsDebuggingEnabled_EnvarFalsey_ReturnsFalse()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmDebug] = "0"
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsDebuggingEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsTerminalPromptsEnabled_EnvarUnset_ReturnsTrue()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsTerminalPromptsEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsTerminalPromptsEnabled_EnvarTruthy_ReturnsTrue()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GitTerminalPrompts] = "1"
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsTerminalPromptsEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsTerminalPromptsEnabled_EnvarFalsey_ReturnsFalse()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GitTerminalPrompts] = "0"
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsTerminalPromptsEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsTracingEnabled_EnvarUnset_ReturnsFalse()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+            var result = settings.GetTracingEnabled(out string actualValue);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Settings_IsTracingEnabled_EnvarTruthy_ReturnsTrueOutValue()
+        {
+            const string expectedValue = "1";
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmTrace] = expectedValue
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+            var result = settings.GetTracingEnabled(out string actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_IsTracingEnabled_EnvarFalsey_ReturnsFalseOutValue()
+        {
+            const string expectedValue = "0";
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmTrace] = expectedValue
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+            var result = settings.GetTracingEnabled(out string actualValue);
+
+            Assert.False(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+
+        [Fact]
+        public void Settings_IsTracingEnabled_EnvarPathy_ReturnsTrueOutValue()
+        {
+            const string expectedValue = "/tmp/gcm.log";
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmTrace] = expectedValue
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+            var result = settings.GetTracingEnabled(out string actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_IsSecretTracingEnabled_EnvarUnset_ReturnsFalse()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsSecretTracingEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsSecretTracingEnabled_EnvarTruthy_ReturnsTrue()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmTraceSecrets] = "1"
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsSecretTracingEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsSecretTracingEnabled_EnvarFalsey_ReturnsFalse()
+        {
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmTraceSecrets] = "0"
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsSecretTracingEnabled);
+        }
+
+        [Fact]
+        public void Settings_TryGetSetting_EnvarSet_ReturnsTrueOutValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string envarName = "GCM_TESTVAR";
+            const string section = "gcmtest";
+            const string property = "bar";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "Hello, World!";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [envarName] = expectedValue,
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_TryGetSetting_EnvarUnset_ReturnsFalse()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string envarName = "GCM_TESTVAR";
+            const string section = "gcmtest";
+            const string property = "bar";
+            var remoteUri = new Uri(remoteUrl);
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+
+            Assert.False(result);
+            Assert.Null(actualValue);
+        }
+
+        [Fact]
+        public void Settings_TryGetSetting_GlobalConfig_ReturnsTrueAndValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string envarName = "GCM_TESTVAR";
+            const string section = "gcmtest";
+            const string property = "bar";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "Hello, World!";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = expectedValue
+            });
+
+            var settings = new Settings(envars, git);
+            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_TryGetSetting_RepoConfig_ReturnsTrueAndValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string envarName = "GCM_TESTVAR";
+            const string section = "gcmtest";
+            const string property = "bar";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "Hello, World!";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+            git.AddRepository(repositoryPath, new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = expectedValue
+            });
+
+            var settings = new Settings(envars, git);
+            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_TryGetSetting_ScopedConfig()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo/bar/bazz.git";
+            const string scope1 = "example.com";
+            const string scope2 = "example.com/foo/bar";
+            const string envarName = "GCM_TESTVAR";
+            const string section = "gcmtest";
+            const string property = "bar";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "Hello, World!";
+            const string otherValue = "Goodbye, World!";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+            git.AddRepository(repositoryPath, new Dictionary<string, string>
+            {
+                [$"{section}.{scope1}.{property}"] = otherValue,
+                [$"{section}.{scope2}.{property}"] = expectedValue,
+            });
+
+            var settings = new Settings(envars, git);
+            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_TryGetSetting_EnvarAndConfig_EnvarTakesPrecedence()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string envarName = "GCM_TESTVAR";
+            const string section = "gcmtest";
+            const string property = "bar";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "Hello, World!";
+            const string otherValue = "Goodbye, World!";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [envarName] = expectedValue,
+            });
+            var git = new TestGit();
+            git.AddRepository(repositoryPath, new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = otherValue
+            });
+
+            var settings = new Settings(envars, git);
+            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_GetSettingValues_EnvarAndMultipleConfig_ReturnsAllWithCorrectPrecedence()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string scope1 = "http://example.com";
+            const string scope2 = "example.com";
+            const string envarName = "GCM_TESTVAR";
+            const string section = "gcmtest";
+            const string property = "bar";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string value1 = "First value";
+            const string value2 = "Second value";
+            const string value3 = "Third value";
+            const string value4 = "Last value";
+
+            string[] expectedValues = {value1, value2, value3, value4};
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [envarName] = value1,
+            });
+            var git = new TestGit();
+            git.AddRepository(repositoryPath, new Dictionary<string, string>
+            {
+                [$"{section}.{scope1}.{property}"] = value2,
+                [$"{section}.{scope2}.{property}"] = value3,
+                [$"{section}.{property}"]          = value4
+            });
+
+            var settings = new Settings(envars, git);
+            string[] actualValues = settings.GetSettingValues(repositoryPath, remoteUri, envarName, section, property).ToArray();
+
+            Assert.Equal(expectedValues, actualValues);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System.Collections.Generic;
+using System;
 using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests
@@ -34,6 +34,172 @@ namespace Microsoft.Git.CredentialManager.Tests
             {
                 Assert.False(StringExtensions.IsTruthy(input));
             }
+        }
+
+        [Theory]
+        [InlineData("false", true)]
+        [InlineData("FALSE", true)]
+        [InlineData("fAlSe", true)]
+        [InlineData("no", true)]
+        [InlineData("NO", true)]
+        [InlineData("nO", true)]
+        [InlineData("off", true)]
+        [InlineData("OFF", true)]
+        [InlineData("oFf", true)]
+        [InlineData("0", true)]
+        [InlineData("true", false)]
+        [InlineData("i am a random string", false)]
+        [InlineData("", false)]
+        [InlineData("     ", false)]
+        [InlineData("\t", false)]
+        [InlineData(null, false)]
+        public void StringExtensions_IsFalsey(string input, bool expected)
+        {
+            if (expected)
+            {
+                Assert.True(StringExtensions.IsFalsey(input));
+            }
+            else
+            {
+                Assert.False(StringExtensions.IsFalsey(input));
+            }
+        }
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("TRUE", true)]
+        [InlineData("tRuE", true)]
+        [InlineData("yes", true)]
+        [InlineData("YES", true)]
+        [InlineData("yEs", true)]
+        [InlineData("on", true)]
+        [InlineData("ON", true)]
+        [InlineData("oN", true)]
+        [InlineData("1", true)]
+        [InlineData("false", false)]
+        [InlineData("FALSE", false)]
+        [InlineData("fAlSe", false)]
+        [InlineData("no", false)]
+        [InlineData("NO", false)]
+        [InlineData("nO", false)]
+        [InlineData("off", false)]
+        [InlineData("OFF", false)]
+        [InlineData("oFf", false)]
+        [InlineData("0", false)]
+        [InlineData("i am a random string", null)]
+        [InlineData("", null)]
+        [InlineData("     ", null)]
+        [InlineData("\t", null)]
+        [InlineData(null, null)]
+        public void StringExtensions_ToBooleany(string input, bool? expected)
+        {
+            Assert.Equal(expected, StringExtensions.ToBooleany(input));
+        }
+
+        [Theory]
+        [InlineData("true", false, true)]
+        [InlineData("TRUE", false, true)]
+        [InlineData("tRuE", false, true)]
+        [InlineData("yes", false, true)]
+        [InlineData("YES", false, true)]
+        [InlineData("yEs", false, true)]
+        [InlineData("on", false, true)]
+        [InlineData("ON", false, true)]
+        [InlineData("oN", false, true)]
+        [InlineData("1", false, true)]
+        [InlineData("false", true, false)]
+        [InlineData("FALSE", true, false)]
+        [InlineData("fAlSe", true, false)]
+        [InlineData("no", true, false)]
+        [InlineData("NO", true, false)]
+        [InlineData("nO", true, false)]
+        [InlineData("off", true, false)]
+        [InlineData("OFF", true, false)]
+        [InlineData("oFf", true, false)]
+        [InlineData("0", true, false)]
+        [InlineData("i am a random string", true, true)]
+        [InlineData("", true, true)]
+        [InlineData("     ", true, true)]
+        [InlineData("\t", true, true)]
+        [InlineData(null, true, true)]
+        [InlineData("i am a random string", false, false)]
+        [InlineData("", false, false)]
+        [InlineData("     ", false, false)]
+        [InlineData("\t", false, false)]
+        [InlineData(null, false, false)]
+        public void StringExtensions_ToBooleanyOrDefault(string input, bool defaultValue, bool expected)
+        {
+            Assert.Equal(expected, StringExtensions.ToBooleanyOrDefault(input, defaultValue));
+        }
+
+        [Theory]
+        [InlineData("", '/', "")]
+        [InlineData("/", '/', "")]
+        [InlineData("foo", '/', "foo")]
+        [InlineData("foo/", '/', "foo")]
+        [InlineData("foo/bar", '/', "foo")]
+        [InlineData("foo/bar/", '/', "foo/bar")]
+        public void StringExtensions_TruncateFromLastIndexOf(string input, char c, string expected)
+        {
+            string actual = StringExtensions.TruncateFromLastIndexOf(input, c);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void StringExtensions_TruncateFromLastIndexOf_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => StringExtensions.TruncateFromLastIndexOf(null, '/'));
+        }
+
+        [Theory]
+        [InlineData("", '/', "")]
+        [InlineData("/", '/', "")]
+        [InlineData("foo", '/', "foo")]
+        [InlineData("foo/", '/', "")]
+        [InlineData("foo/bar", '/', "bar")]
+        [InlineData("foo/bar/", '/', "bar/")]
+        public void StringExtensions_TrimUntilIndexOf_Character(string input, char c, string expected)
+        {
+            string actual = StringExtensions.TrimUntilIndexOf(input, c);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void StringExtensions_TrimUntilIndexOf_Character_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => StringExtensions.TrimUntilIndexOf(null, '/'));
+        }
+
+        [Theory]
+        [InlineData("", "://", "")]
+        [InlineData("://", "://", "")]
+        [InlineData("foo", "://", "foo")]
+        [InlineData("foo://", "://", "")]
+        [InlineData("foo://bar", "://", "bar")]
+        [InlineData("foo://bar/", "://", "bar/")]
+        public void StringExtensions_TrimUntilIndexOf_String(string input, string trim, string expected)
+        {
+            string actual = StringExtensions.TrimUntilIndexOf(input, trim);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("fooTRIMbar", "TRIM", StringComparison.Ordinal, "bar")]
+        [InlineData("fooTRIMbar", "trim", StringComparison.Ordinal, "fooTRIMbar")]
+        [InlineData("fooTRIMbar", "tRiM", StringComparison.Ordinal, "fooTRIMbar")]
+        [InlineData("fooTRIMbar", "TRIM", StringComparison.OrdinalIgnoreCase, "bar")]
+        [InlineData("fooTRIMbar", "trim", StringComparison.OrdinalIgnoreCase, "bar")]
+        [InlineData("fooTRIMbar", "tRiM", StringComparison.OrdinalIgnoreCase, "bar")]
+        public void StringExtensions_TrimUntilIndexOf_String_ComparisonType(string input, string trim, StringComparison comparisonType, string expected)
+        {
+            string actual = StringExtensions.TrimUntilIndexOf(input, trim, comparisonType);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void StringExtensions_TrimUntilIndexOf_String_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => StringExtensions.TrimUntilIndexOf(null, "://"));
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class UriExtensionsTests
+    {
+        [Theory]
+        [InlineData("http://com")]
+        [InlineData("http://example.com",
+            "http://example.com")]
+        [InlineData("http://foo.example.com",
+            "http://foo.example.com", "http://example.com")]
+        [InlineData("http://example.com/foo",
+            "http://example.com/foo", "http://example.com")]
+        [InlineData("http://example.com/foo/",
+            "http://example.com/foo", "http://example.com")]
+        [InlineData("http://example.com/foo?query=true#fragment",
+            "http://example.com/foo", "http://example.com")]
+        [InlineData("http://buzz.foo.example.com/bar/baz",
+            "http://buzz.foo.example.com/bar/baz", "http://buzz.foo.example.com/bar", "http://buzz.foo.example.com", "http://foo.example.com", "http://example.com")]
+        public void UriExtensions_GetGitConfigurationScopes(string start, params string[] expected)
+        {
+            var startUri = new Uri(start);
+            string[] actual = UriExtensions.GetGitConfigurationScopes(startUri).ToArray();
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -62,8 +64,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
         protected void EnsureTerminalPromptsEnabled()
         {
-            if (Context.TryGetEnvironmentVariable(Constants.EnvironmentVariables.GitTerminalPrompts, out string envarPrompts)
-                && envarPrompts == "0")
+            if (!Context.Settings.IsTerminalPromptsEnabled)
             {
                 Context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; terminal prompts have been disabled.");
 

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
 using Microsoft.Git.CredentialManager.Interop;
@@ -18,6 +15,11 @@ namespace Microsoft.Git.CredentialManager
     /// </summary>
     public interface ICommandContext
     {
+        /// <summary>
+        /// Settings and configuration for Git Credential Manager.
+        /// </summary>
+        ISettings Settings { get; }
+
         /// <summary>
         /// The standard input text stream from the calling process, typically Git.
         /// </summary>
@@ -66,7 +68,7 @@ namespace Microsoft.Git.CredentialManager
         /// Access the environment variables for the current GCM process.
         /// </summary>
         /// <returns>Set of all current environment variables.</returns>
-        IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
+        IEnvironmentVariables EnvironmentVariables { get; }
     }
 
     /// <summary>
@@ -81,14 +83,15 @@ namespace Microsoft.Git.CredentialManager
         private TextReader _stdIn;
         private TextWriter _stdOut;
         private TextWriter _stdErr;
-        private IReadOnlyDictionary<string, string> _envars;
 
         public CommandContext()
         {
+            EnvironmentVariables = new EnvironmentVariables(Environment.GetEnvironmentVariables());
             Trace = new Trace();
             FileSystem = new FileSystem();
             Git = new LibGit2();
             HttpClientFactory = new HttpClientFactory();
+            Settings = new Settings(EnvironmentVariables, Git);
 
             if (PlatformUtils.IsWindows())
             {
@@ -111,6 +114,8 @@ namespace Microsoft.Git.CredentialManager
         }
 
         #region ICommandContext
+
+        public ISettings Settings { get; }
 
         public TextReader StdIn
         {
@@ -171,79 +176,8 @@ namespace Microsoft.Git.CredentialManager
 
         public IHttpClientFactory HttpClientFactory { get; }
 
-        public IReadOnlyDictionary<string, string> EnvironmentVariables
-        {
-            get
-            {
-                if (_envars is null)
-                {
-                    IDictionary variables = Environment.GetEnvironmentVariables();
-
-                    // On Windows it is technically possible to get env vars which differ only by case
-                    // even though the general assumption is that they are case insensitive on Windows.
-                    // For example, some of the standard .NET types like System.Diagnostics.Process
-                    // will fail to start a process on Windows if given duplicate environment variables.
-                    // See this issue for more information: https://github.com/dotnet/corefx/issues/13146
-
-                    // If we're on the Windows platform we should de-duplicate by setting the string
-                    // comparer to OrdinalIgnoreCase.
-                    var comparer = PlatformUtils.IsWindows()
-                        ? StringComparer.OrdinalIgnoreCase
-                        : StringComparer.Ordinal;
-
-                    var dict = new Dictionary<string, string>(comparer);
-
-                    foreach (var key in variables.Keys)
-                    {
-                        if (key is string name && variables[key] is string value)
-                        {
-                            dict[name] = value;
-                        }
-                    }
-
-                    _envars = new ReadOnlyDictionary<string, string>(dict);
-                }
-
-                return _envars;
-            }
-        }
+        public IEnvironmentVariables EnvironmentVariables { get; }
 
         #endregion
-    }
-
-    public static class CommandContextExtensions
-    {
-        /// <summary>
-        /// Try to get the current value of the specified environment variable.
-        /// </summary>
-        /// <param name="context"><see cref="ICommandContext"/></param>
-        /// <param name="key">The name of environment variable.</param>
-        /// <param name="value">The current value of the environment variable.</param>
-        /// <returns>True if the environment variable was set and has a value, false otherwise.</returns>
-        public static bool TryGetEnvironmentVariable(this ICommandContext context, string key, out string value)
-        {
-            return context.EnvironmentVariables.TryGetValue(key, out value);
-        }
-
-        /// <summary>
-        /// Test if the specified environment variable is 'truthy' (considered to be equivalent to a 'true' value
-        /// by <see cref="StringExtensions.IsTruthy"/>).
-        /// </summary>
-        /// <param name="context"><see cref="ICommandContext"/></param>
-        /// <param name="key">The name of environment variable.</param>
-        /// <param name="defaultValue">
-        /// The assumed default value of the environment variable if it does not
-        /// exist/has not been set.
-        /// </param>
-        /// <returns>True if the environment variable was set and has a 'truthy' value, <see cref="defaultValue"/> otherwise.</returns>
-        public static bool IsEnvironmentVariableTruthy(this ICommandContext context, string key, bool defaultValue)
-        {
-            if (context.TryGetEnvironmentVariable(key, out string valueStr) && valueStr.IsTruthy())
-            {
-                return true;
-            }
-
-            return defaultValue;
-        }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -29,6 +29,23 @@ namespace Microsoft.Git.CredentialManager
             public const string MimeTypeJson = "application/json";
         }
 
+        public static class GitConfiguration
+        {
+            public static class Credential
+            {
+                public const string SectionName = "credential";
+                public const string Helper      = "helper";
+                public const string Provider    = "provider";
+                public const string Authority   = "authority";
+            }
+
+            public static class Http
+            {
+                public const string SectionName = "http";
+                public const string Proxy = "proxy";
+            }
+        }
+
         private static string _gcmVersion;
 
         /// <summary>

--- a/src/shared/Microsoft.Git.CredentialManager/EnvironmentVariables.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/EnvironmentVariables.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Simple wrapper dictionary around environment variables.
+    /// </summary>
+    public interface IEnvironmentVariables : IReadOnlyDictionary<string, string> { }
+
+    public class EnvironmentVariables : IEnvironmentVariables
+    {
+        private readonly IReadOnlyDictionary<string, string> _envars;
+
+        public EnvironmentVariables(IDictionary variables)
+        {
+            EnsureArgument.NotNull(variables, nameof(variables));
+
+            // On Windows it is technically possible to get env vars which differ only by case
+            // even though the general assumption is that they are case insensitive on Windows.
+            // For example, some of the standard .NET types like System.Diagnostics.Process
+            // will fail to start a process on Windows if given duplicate environment variables.
+            // See this issue for more information: https://github.com/dotnet/corefx/issues/13146
+
+            // If we're on the Windows platform we should de-duplicate by setting the string
+            // comparer to OrdinalIgnoreCase.
+            var comparer = PlatformUtils.IsWindows()
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+
+            var dict = new Dictionary<string, string>(comparer);
+
+            foreach (var key in variables.Keys)
+            {
+                if (key is string name && variables[key] is string value)
+                {
+                    dict[name] = value;
+                }
+            }
+
+            _envars = dict;
+        }
+
+        #region IReadOnlyDictionary<string, string>
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _envars.GetEnumerator();
+        public int Count => _envars.Count;
+        public bool ContainsKey(string key) => _envars.ContainsKey(key);
+
+        /// <summary>
+        /// Try and get the value of an environment variable as a string.
+        /// </summary>
+        /// <param name="name">Environment variable name.</param>
+        /// <param name="value">Environment variable value.</param>
+        /// <returns>True if the value was found, false otherwise.</returns>
+        public bool TryGetValue(string name, out string value) => _envars.TryGetValue(name, out value);
+
+        public string this[string name] => _envars[name];
+        public IEnumerable<string> Keys => _envars.Keys;
+        public IEnumerable<string> Values => _envars.Values;
+
+        #endregion
+    }
+
+    public static class EnvironmentVariablesExtensions
+    {
+        /// <summary>
+        /// Get the value of an environment variable as a string.
+        /// </summary>
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException">An environment variable with the specified name was not found.</exception>
+        /// <param name="envars">Environment variables.</param>
+        /// <param name="name">Environment variable name.</param>
+        /// <returns>Environment variable value.</returns>
+        public static string GetValue(this IEnvironmentVariables envars, string name)
+        {
+            if (envars.TryGetValue(name, out string value))
+            {
+                return value;
+            }
+
+            throw new KeyNotFoundException("An environment variable with the specified name was not found.");
+        }
+
+        /// <summary>
+        /// Get the value of an environment variable as 'booleany' (either 'truthy' or 'falsey').
+        /// </summary>
+        /// <param name="envars">Environment variables.</param>
+        /// <param name="name">Environment variable name.</param>
+        /// <param name="defaultValue">Default value if the environment variable is not set, or was neither 'truthy' or 'falsey'.</param>
+        /// <returns>Environment variable value.</returns>
+        /// <remarks>
+        /// 'Truthy' and 'fasley' is defined by the implementation of <see cref="StringExtensions.IsTruthy"/> and <see cref="StringExtensions.IsFalsey"/>.
+        /// </remarks>
+        public static bool GetBooleanyOrDefault(this IEnvironmentVariables envars, string name, bool defaultValue)
+        {
+            if (envars.TryGetValue(name, out string value))
+            {
+                return value.ToBooleanyOrDefault(defaultValue);
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/IGit.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IGit.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="name">Configuration entry name.</param>
         /// <param name="value">Configuration entry value.</param>
         /// <returns>True if the value was found, false otherwise.</returns>
-        bool TryGetString(string name, out string value);
+        bool TryGetValue(string name, out string value);
     }
 
     public interface IGit : IDisposable
@@ -54,9 +54,9 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="config">Configuration object.</param>
         /// <param name="name">Configuration entry name.</param>
         /// <returns>Configuration entry value.</returns>
-        public static string GetString(this IGitConfiguration config, string name)
+        public static string GetValue(this IGitConfiguration config, string name)
         {
-            if (!config.TryGetString(name, out string value))
+            if (!config.TryGetValue(name, out string value))
             {
                 throw new KeyNotFoundException($"Git configuration entry with the name '{name}' was not found.");
             }
@@ -72,9 +72,9 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <exception cref="System.Collections.Generic.KeyNotFoundException">A configuration entry with the specified key was not found.</exception>
         /// <returns>Configuration entry value.</returns>
-        public static string GetString(this IGitConfiguration config, string section, string property)
+        public static string GetValue(this IGitConfiguration config, string section, string property)
         {
-            return GetString(config, $"{section}.{property}");
+            return GetValue(config, $"{section}.{property}");
         }
 
         /// <summary>
@@ -86,14 +86,14 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <exception cref="System.Collections.Generic.KeyNotFoundException">A configuration entry with the specified key was not found.</exception>
         /// <returns>Configuration entry value.</returns>
-        public static string GetString(this IGitConfiguration config, string section, string scope, string property)
+        public static string GetValue(this IGitConfiguration config, string section, string scope, string property)
         {
             if (scope is null)
             {
-                return GetString(config, section, property);
+                return GetValue(config, section, property);
             }
 
-            return GetString(config, $"{section}.{scope}.{property}");
+            return GetValue(config, $"{section}.{scope}.{property}");
         }
 
         /// <summary>
@@ -104,9 +104,9 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <param name="value">Configuration entry value.</param>
         /// <returns>True if the value was found, false otherwise.</returns>
-        public static bool TryGetString(this IGitConfiguration config, string section, string property, out string value)
+        public static bool TryGetValue(this IGitConfiguration config, string section, string property, out string value)
         {
-            return config.TryGetString($"{section}.{property}", out value);
+            return config.TryGetValue($"{section}.{property}", out value);
         }
 
         /// <summary>
@@ -118,14 +118,14 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <param name="value">Configuration entry value.</param>
         /// <returns>True if the value was found, false otherwise.</returns>
-        public static bool TryGetString(this IGitConfiguration config, string section, string scope, string property, out string value)
+        public static bool TryGetValue(this IGitConfiguration config, string section, string scope, string property, out string value)
         {
             if (scope is null)
             {
-                return TryGetString(config, section, property, out value);
+                return TryGetValue(config, section, property, out value);
             }
 
-            return config.TryGetString($"{section}.{scope}.{property}", out value);
+            return config.TryGetValue($"{section}.{scope}.{property}", out value);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/InputArguments.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/InputArguments.cs
@@ -51,6 +51,21 @@ namespace Microsoft.Git.CredentialManager
             return _dict.TryGetValue(key, out string value) ? value : null;
         }
 
+        public Uri GetRemoteUri()
+        {
+            if (Protocol is null || Host is null)
+            {
+                return null;
+            }
+
+            var ub = new UriBuilder(Protocol, Host)
+            {
+                Path = Path
+            };
+
+            return ub.Uri;
+        }
+
         #endregion
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/LibGit2.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/LibGit2.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Git.CredentialManager.Interop
 
         public string RepositoryPath { get; }
 
-        public unsafe bool TryGetString(string name, out string value)
+        public unsafe bool TryGetValue(string name, out string value)
         {
             int result = git_config_get_string(out value, _snapshot, name);
 

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KnownEnvars = Microsoft.Git.CredentialManager.Constants.EnvironmentVariables;
+using KnownGitCfg = Microsoft.Git.CredentialManager.Constants.GitConfiguration;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Component that represents settings for Git Credential Manager as found from the environment and Git configuration.
+    /// </summary>
+    public interface ISettings
+    {
+        /// <summary>
+        /// True if debugging is enabled, false otherwise.
+        /// </summary>
+        bool IsDebuggingEnabled { get; }
+
+        /// <summary>
+        /// True if terminal prompting is enabled, false otherwise.
+        /// </summary>
+        bool IsTerminalPromptsEnabled { get; }
+
+        /// <summary>
+        /// Get if tracing has been enabled, returning trace setting value in the out parameter.
+        /// </summary>
+        /// <param name="value">Trace setting value.</param>
+        /// <returns>True if tracing is enabled, false otherwise.</returns>
+        bool GetTracingEnabled(out string value);
+
+        /// <summary>
+        /// True if tracing of secrets and sensitive information is enabled, false otherwise.
+        /// </summary>
+        bool IsSecretTracingEnabled { get; }
+    }
+
+    public class Settings : ISettings
+    {
+        private readonly IEnvironmentVariables _environment;
+        private readonly IGit _git;
+
+        public Settings(IEnvironmentVariables environmentVariables, IGit git)
+        {
+            _environment = environmentVariables;
+            _git = git;
+        }
+
+        public bool IsDebuggingEnabled => _environment.GetBooleanyOrDefault(KnownEnvars.GcmDebug, false);
+
+        public bool IsTerminalPromptsEnabled => _environment.GetBooleanyOrDefault(KnownEnvars.GitTerminalPrompts, true);
+
+        public bool GetTracingEnabled(out string value) => _environment.TryGetValue(KnownEnvars.GcmTrace, out value) && !value.IsFalsey();
+
+        public bool IsSecretTracingEnabled => _environment.GetBooleanyOrDefault(KnownEnvars.GcmTraceSecrets, false);
+
+        /// <summary>
+        /// Try and get the value of a specified setting as specified in the environment and Git configuration,
+        /// with the environment taking precedence over Git.
+        /// </summary>
+        /// <param name="repositoryPath">Optional path of a repository to lookup local configuration from.</param>
+        /// <param name="remoteUri">Optional git remote address that settings should be scoped to.</param>
+        /// <param name="envarName">Optional environment variable name.</param>
+        /// <param name="section">Optional Git configuration section name.</param>
+        /// <param name="property">Git configuration property name. Required if <paramref name="section"/> is set, optional otherwise.</param>
+        /// <param name="value">Value of the requested setting.</param>
+        /// <returns>True if a setting value was found, false otherwise.</returns>
+        public bool TryGetSetting(string repositoryPath, Uri remoteUri, string envarName, string section, string property, out string value)
+        {
+            IEnumerable<string> allValues = GetSettingValues(repositoryPath, remoteUri, envarName, section, property);
+
+            value = allValues.FirstOrDefault();
+
+            return value != null;
+        }
+
+        /// <summary>
+        /// Try and get the all values of a specified setting as specified in the environment and Git configuration,
+        /// in the correct order or precedence.
+        /// </summary>
+        /// <param name="repositoryPath">Optional path of a repository to lookup local configuration from.</param>
+        /// <param name="remoteUri">Optional git remote address that settings should be scoped to.</param>
+        /// <param name="envarName">Optional environment variable name.</param>
+        /// <param name="section">Optional Git configuration section name.</param>
+        /// <param name="property">Git configuration property name. Required if <paramref name="section"/> is set, optional otherwise.</param>
+        /// <returns>All values for the specified setting, in order of precedence, or an empty collection if no such values are set.</returns>
+        public IEnumerable<string> GetSettingValues(string repositoryPath, Uri remoteUri, string envarName, string section, string property)
+        {
+            string value;
+
+            if (envarName != null)
+            {
+                if (_environment.TryGetValue(envarName, out value))
+                {
+                    yield return value;
+                }
+            }
+
+            if (section != null && property != null)
+            {
+                using (var config = _git.GetConfiguration(repositoryPath))
+                {
+                    if (remoteUri != null)
+                    {
+                        /*
+                         * Look for URL scoped "section" configuration entries, starting from the most specific
+                         * down to the least specific (stopping before the TLD).
+                         *
+                         * In a divergence from standard Git configuration rules, we also consider matching URL scopes
+                         * without a scheme ("protocol://").
+                         *
+                         * For each level of scope, we look for an entry with the scheme included (the default), and then
+                         * also one without it specified. This allows you to have one configuration scope for both "http" and
+                         * "https" without needing to repeat yourself, for example.
+                         *
+                         * For example, starting with "https://foo.example.com/bar/buzz" we have:
+                         *
+                         *   1a. [section "https://foo.example.com/bar/buzz"]
+                         *          property = value
+                         *
+                         *   1b. [section "foo.example.com/bar/buzz"]
+                         *          property = value
+                         *
+                         *   2a. [section "https://foo.example.com/bar"]
+                         *          property = value
+                         *
+                         *   2b. [section "foo.example.com/bar"]
+                         *          property = value
+                         *
+                         *   3a. [section "https://foo.example.com"]
+                         *          property = value
+                         *
+                         *   3b. [section "foo.example.com"]
+                         *          property = value
+                         *
+                         *   4a. [section "https://example.com"]
+                         *          property = value
+                         *
+                         *   4b. [section "example.com"]
+                         *          property = value
+                         *
+                         */
+                        foreach (string scope in remoteUri.GetGitConfigurationScopes())
+                        {
+                            // Look for a scoped entry that includes the scheme "protocol://example.com" first as this is more specific
+                            if (config.TryGetValue(section, scope, property, out value))
+                            {
+                                yield return value;
+                            }
+
+                            // Now look for a scoped entry that omits the scheme "example.com" second as this is less specific
+                            string scopeWithoutScheme = scope.TrimUntilIndexOf(Uri.SchemeDelimiter);
+                            if (config.TryGetValue(section, scopeWithoutScheme, property, out value))
+                            {
+                                yield return value;
+                            }
+                        }
+                    }
+
+                    /*
+                     * Try to look for an un-scoped "section" property setting:
+                     *
+                     *    [section]
+                     *        property = value
+                     *
+                     */
+                    if (config.TryGetValue(section, property, out value))
+                    {
+                        yield return value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/StringExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/StringExtensions.cs
@@ -25,5 +25,130 @@ namespace Microsoft.Git.CredentialManager
                    StringComparer.OrdinalIgnoreCase.Equals(str, "on") ||
                    StringComparer.OrdinalIgnoreCase.Equals(str, "yes");
         }
+
+        /// <summary>
+        /// Check if the string is considered to be 'falsey' (a value considered equivalent to 'false').
+        /// </summary>
+        /// <remarks>
+        /// Git considers several different values to be equivalent to 'false'; we try to be consistent with this
+        /// behavior.
+        /// <para/>
+        /// See the following Git documentation for a list of values considered to be equivalent to 'false':
+        /// https://git-scm.com/docs/git-config#git-config-boolean
+        /// </remarks>
+        /// <param name="str">String value to check.</param>
+        /// <returns>True if the value is 'falsey', false otherwise.</returns>
+        public static bool IsFalsey(this string str)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals(str, bool.FalseString) ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "0") ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "off") ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "no");
+        }
+
+        /// <summary>
+        /// Check if the string is considered to be either 'truthy' or 'falsey' (values considered equivalent to 'true' and 'false').
+        /// </summary>
+        /// <remarks>
+        /// Git considers several different values to be equivalent to 'true' and 'false'; we try to be consistent with this
+        /// behavior.
+        /// <para/>
+        /// See the following Git documentation for a list of values considered to be equivalent to 'true' and 'false':
+        /// https://git-scm.com/docs/git-config#git-config-boolean
+        /// </remarks>
+        /// <param name="str">String value to check.</param>
+        /// <returns>True if the value is 'truthy', 'false' if the value is 'falsey', null otherwise.</returns>
+        public static bool? ToBooleany(this string str)
+        {
+            if (IsTruthy(str))
+            {
+                return true;
+            }
+
+            if (IsFalsey(str))
+            {
+                return false;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Check if the string is considered to be either 'truthy' or 'falsey' (values considered equivalent to 'true' and 'false').
+        /// </summary>
+        /// <remarks>
+        /// Git considers several different values to be equivalent to 'true' and 'false'; we try to be consistent with this
+        /// behavior.
+        /// <para/>
+        /// See the following Git documentation for a list of values considered to be equivalent to 'true' and 'false':
+        /// https://git-scm.com/docs/git-config#git-config-boolean
+        /// </remarks>
+        /// <param name="str">String value to check.</param>
+        /// <param name="defaultValue">Default value to return if the string is neither 'truthy', 'falsey', or has not been set.</param>
+        /// <returns>True if the value is 'truthy', 'false' if the value is 'falsey', <paramref name="defaultValue"/> otherwise.</returns>
+        public static bool ToBooleanyOrDefault(this string str, bool defaultValue)
+        {
+            return ToBooleany(str) ?? defaultValue;
+        }
+
+        /// <summary>
+        /// Truncate the string from the last index of the given character, also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to truncate.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Truncated string.</returns>
+        public static string TruncateFromLastIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int last = str.LastIndexOf(c);
+            if (last > -1)
+            {
+                return str.Substring(0, last);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the first index of the given character,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.IndexOf(c);
+            if (first > -1)
+            {
+                return str.Substring(first + 1, str.Length - first - 1);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the first index of the given string,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="value">String to locate the index of.</param>
+        /// <param name="comparisonType">Comparison rule for locating the string.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilIndexOf(this string str, string value, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.IndexOf(value, comparisonType);
+            if (first > -1)
+            {
+                return str.Substring(first + value.Length, str.Length - first - value.Length);
+            }
+
+            return str;
+        }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Git.CredentialManager
+{
+    public static class UriExtensions
+    {
+        public static IEnumerable<string> GetGitConfigurationScopes(this Uri uri)
+        {
+            EnsureArgument.NotNull(uri, nameof(uri));
+
+            string schemeAndDelim = $"{uri.Scheme}{Uri.SchemeDelimiter}";
+            string host = uri.Host.TrimEnd('/');
+            string path = uri.AbsolutePath.Trim('/');
+
+            // Unfold the path by component, right-to-left
+            while (!string.IsNullOrWhiteSpace(path))
+            {
+                yield return $"{schemeAndDelim}{host}/{path}";
+
+                // Trim off the last path component
+                if (!TryTrimString(path, StringExtensions.TruncateFromLastIndexOf, '/', out path))
+                {
+                    break;
+                }
+            }
+
+            // Unfold the host by sub-domain, left-to-right
+            while (!string.IsNullOrWhiteSpace(host))
+            {
+                if (host.Contains(".")) // Do not emit just the TLD
+                {
+                    yield return $"{schemeAndDelim}{host}";
+                }
+
+                // Trim off the left-most sub-domain
+                if (!TryTrimString(host, StringExtensions.TrimUntilIndexOf, '.', out host))
+                {
+                    break;
+                }
+            }
+        }
+
+        private static bool TryTrimString(string input, Func<string, char, string> func, char c, out string output)
+        {
+            output = func(input, c);
+            return !StringComparer.Ordinal.Equals(input, output);
+        }
+    }
+}

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
 
@@ -9,6 +8,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestCommandContext : ICommandContext
     {
+        public TestSettings Settings { get; set; } = new TestSettings();
         public string StdIn { get; set; } = string.Empty;
         public StringBuilder StdOut { get; set; } = new StringBuilder();
         public StringBuilder StdError { get; set; } = new StringBuilder();
@@ -18,10 +18,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         public TestCredentialStore CredentialStore { get; set; } = new TestCredentialStore();
         public TestGit Git { get; set; } = new TestGit();
         public TestHttpClientFactory HttpClientFactory { get; set; } = new TestHttpClientFactory();
-        public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
         public string NewLine { get; set; } = "\n";
 
         #region ICommandContext
+
+        ISettings ICommandContext.Settings => Settings;
 
         TextReader ICommandContext.StdIn => new StringReader(StdIn);
 
@@ -41,8 +43,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         IHttpClientFactory ICommandContext.HttpClientFactory => HttpClientFactory;
 
-        IReadOnlyDictionary<string, string> ICommandContext.EnvironmentVariables
-            => new ReadOnlyDictionary<string, string>(EnvironmentVariables);
+        IEnvironmentVariables ICommandContext.EnvironmentVariables
+            => new EnvironmentVariables(EnvironmentVariables);
 
         #endregion
     }

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 
@@ -5,15 +7,34 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestGitConfiguration : IGitConfiguration
     {
-        public string RepositoryPath { get; set; }
+        public TestGitConfiguration() : this(null, null) { }
 
-        public IDictionary<string, string> Values { get; set; } = new Dictionary<string, string>();
+        public TestGitConfiguration(string repositoryPath) : this(repositoryPath, null) { }
+
+        public TestGitConfiguration(IDictionary<string,string> config) : this(null, config) { }
+
+        public TestGitConfiguration(string repositoryPath, IDictionary<string,string> config)
+        {
+            RepositoryPath = repositoryPath;
+            Dictionary = config ?? new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Backing dictionary for the test configuration entries.
+        /// </summary>
+        public IDictionary<string, string> Dictionary { get; }
+
+        /// <summary>
+        /// Convenience accessor for the backing <see cref="Dictionary"/> of configuration entries.
+        /// </summary>
+        /// <param name="key"></param>
+        public string this[string key] { get => Dictionary[key]; set => Dictionary[key] = value; }
 
         #region IGitConfiguration
 
-        string IGitConfiguration.RepositoryPath => RepositoryPath;
+        public string RepositoryPath { get; set; }
 
-        bool IGitConfiguration.TryGetString(string name, out string value) => Values.TryGetValue(name, out value);
+        public bool TryGetValue(string name, out string value) => Dictionary.TryGetValue(name, out value);
 
         void IDisposable.Dispose() { }
 

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+
+namespace Microsoft.Git.CredentialManager.Tests.Objects
+{
+    public class TestSettings : ISettings
+    {
+        public bool IsDebuggingEnabled { get; set; }
+
+        public bool IsTerminalPromptsEnabled { get; set; } = true;
+
+        public string Trace { get; set; }
+
+        public bool IsSecretTracingEnabled { get; set; }
+
+        #region ISettings
+
+        bool ISettings.IsDebuggingEnabled => IsDebuggingEnabled;
+
+        bool ISettings.IsTerminalPromptsEnabled => IsTerminalPromptsEnabled;
+
+        bool ISettings.GetTracingEnabled(out string value)
+        {
+            value = Trace;
+            return Trace != null;
+        }
+
+        bool ISettings.IsSecretTracingEnabled => IsSecretTracingEnabled;
+
+        #endregion
+    }
+}

--- a/src/windows/Microsoft.Authentication.Helper.Windows/Application.cs
+++ b/src/windows/Microsoft.Authentication.Helper.Windows/Application.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Authentication.Helper
                                                            .WithRedirectUri(redirectUri.ToString());
 
             // Listen to MSAL logs if GCM_TRACE_MSAUTH is set
-            if (Context.IsEnvironmentVariableTruthy(Constants.EnvironmentVariables.GcmTraceMsAuth, false))
+            if (Context.EnvironmentVariables.GetBooleanyOrDefault(Constants.EnvironmentVariables.GcmTraceMsAuth, false))
             {
                 // If GCM secret tracing is enabled also enable "PII" logging in MSAL
                 bool enablePiiLogging = Context.Trace.IsSecretTracingEnabled;


### PR DESCRIPTION
Introduce a new component `ISettings` that provides an interface for looking up the value of various GCM settings that can be specified from either the environment or Git configuration.