### PR TITLE
Add ability to override host provider from configuration

### DIFF
--- a/Git-Credential-Manager.sln
+++ b/Git-Credential-Manager.sln
@@ -55,6 +55,16 @@ ProjectSection(SolutionItems) = preProject
 	assets\gcmweb.png = assets\gcmweb.png
 EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{83BD5957-AC75-4072-A3D1-ABF3A71951F5}"
+ProjectSection(SolutionItems) = preProject
+	docs\configuration.md = docs\configuration.md
+	docs\development.md = docs\development.md
+	docs\environment.md = docs\environment.md
+	docs\faq.md = docs\faq.md
+	docs\migration.md = docs\migration.md
+	docs\usage.md = docs\usage.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,4 +22,73 @@ For the complete list of settings GCM Core understands, see the list below.
 
 ## Available settings
 
-_Currently there are no available settings. This is a placeholder for the settings on the backlog._
+### credential.provider
+
+Define the host provider to use when authenticating.
+
+ID|Provider
+-|-
+`auto` _(default)_|_\[automatic\]_
+`azure-repos`|Azure Repos
+`github`|GitHub
+`generic`|Generic (any other provider not listed above)
+
+Automatic provider selection is based on the remote URL.
+
+This setting is typically used with a scoped URL to map a particular set of remote URLs to providers, for example to mark a host as a GitHub Enterprise instance.
+
+#### Example
+
+```shell
+git config --global credential.ghe.contoso.com.provider github
+```
+
+**Also see: [GCM_PROVIDER](environment.md#GCM_PROVIDER)**
+
+---
+
+### credential.authority _(deprecated)_
+
+> This setting is deprecated and should be replaced by `credential.provider` with the corresponding provider ID value.
+>
+> Click [here](https://aka.ms/gcmcore-authority) for more information.
+
+Select the host provider to use when authenticating by which authority is supported by the providers.
+
+Authority|Provider(s)
+-|-
+`auto` _(default)_|_\[automatic\]_
+`msa`, `microsoft`, `microsoftaccount`,<br/>`aad`, `azure`, `azuredirectory`,</br>`live`, `liveconnect`, `liveid`|Azure Repos<br/>_(supports Microsoft Authentication)_
+`github`|GitHub<br/>_(supports GitHub Authentication)_
+`basic`, `integrated`, `windows`, `kerberos`, `ntlm`,<br/>`tfs`, `sso`|Generic<br/>_(supports Basic and Windows Integrated Authentication)_
+
+#### Example
+
+```shell
+git config --global credential.ghe.contoso.com.authority github
+```
+
+**Also see: [GCM_AUTHORITY](environment.md#GCM_AUTHORITY-deprecated)**
+
+---
+
+### credential.allowWindowsAuth
+
+Allow detection of Windows Integrated Authentication (WIA) support for generic host providers. Setting this value to `false` will prevent the use of WIA and force a basic authentication prompt when using the Generic host provider.
+
+**Note:** WIA is only supported on Windows.
+
+**Note:** WIA is an umbrella term for NTLM and Kerberos (and Negotiate).
+
+Value|WIA detection
+-|-
+`true` _(default)_|Permitted
+`false`|Not permitted
+
+#### Example
+
+```shell
+git config --global credential.tfsonprem123.allowWindowsAuth false
+```
+
+**Also see: [GCM_ALLOW_WINDOWSAUTH](environment.md#GCM_ALLOW_WINDOWSAUTH)**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -37,6 +37,8 @@ Defaults to tracing disabled.
 
 _No configuration equivalent._
 
+---
+
 ### GCM_TRACE_SECRETS
 
 Enables tracing of secret and senstive information, which is by default masked in trace output.
@@ -63,6 +65,8 @@ If the value of `GCM_TRACE_SECRETS` is `true` or `1`, trace logs will include se
 Defaults to disabled.
 
 _No configuration equivalent._
+
+---
 
 ### GCM_TRACE_MSAUTH
 
@@ -91,6 +95,8 @@ Defaults to disabled.
 
 _No configuration equivalent._
 
+---
+
 ### GCM_DEBUG
 
 Pauses execution of GCM Core at launch to wait for a debugger to be attached.
@@ -112,3 +118,99 @@ export GCM_DEBUG=1
 Defaults to disabled.
 
 _No configuration equivalent._
+
+---
+### GCM_PROVIDER
+
+Define the host provider to use when authenticating.
+
+ID|Provider
+-|-
+`auto` _(default)_|_\[automatic\]_
+`azure-repos`|Azure Repos
+`github`|GitHub
+`generic`|Generic (any other provider not listed above)
+
+Automatic provider selection is based on the remote URL.
+
+This setting is typically used with a scoped URL to map a particular set of remote URLs to providers, for example to mark a host as a GitHub Enterprise instance.
+
+#### Example
+
+##### Windows
+
+```batch
+SET GCM_PROVIDER=github
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_PROVIDER=github
+```
+
+**Also see: [credential.provider](configuration.md#credentialprovider)**
+
+---
+
+### GCM_AUTHORITY _(deprecated)_
+
+> This setting is deprecated and should be replaced by `GCM_PROVIDER` with the corresponding provider ID value.
+>
+> Click [here](https://aka.ms/gcmcore-authority) for more information.
+
+Select the host provider to use when authenticating by which authority is supported by the providers.
+
+Authority|Provider(s)
+-|-
+`auto` _(default)_|_\[automatic\]_
+`msa`, `microsoft`, `microsoftaccount`,<br/>`aad`, `azure`, `azuredirectory`,</br>`live`, `liveconnect`, `liveid`|Azure Repos<br/>_(supports Microsoft Authentication)_
+`github`|GitHub<br/>_(supports GitHub Authentication)_
+`basic`, `integrated`, `windows`, `kerberos`, `ntlm`,<br/>`tfs`, `sso`|Generic<br/>_(supports Basic and Windows Integrated Authentication)_
+
+#### Example
+
+##### Windows
+
+```batch
+SET GCM_AUTHORITY=github
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_AUTHORITY=github
+```
+
+**Also see: [credential.authority](configuration.md#credentialauthority-deprecated)**
+
+---
+
+### GCM_ALLOW_WINDOWSAUTH
+
+Allow detection of Windows Integrated Authentication (WIA) support for generic host providers. Setting this value to `false` will prevent the use of WIA and force a basic authentication prompt when using the Generic host provider.
+
+**Note:** WIA is only supported on Windows.
+
+**Note:** WIA is an umbrella term for NTLM and Kerberos (and Negotiate).
+
+Value|WIA detection
+-|-
+`true`, `1`, `yes`, `on` _(default)_|Permitted
+`false`, `0`, `no`, `off`|Not permitted
+
+#### Example
+
+##### Windows
+
+```batch
+SET GCM_ALLOW_WINDOWSAUTH=0
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_ALLOW_WINDOWSAUTH=0
+```
+
+**Also see: [credential.allowWindowsAuth](environment.md#credentialallowWindowsAuth)**

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,32 @@
+# Migration Guide
+
+## Migrating from Git Credential Manager for Windows
+
+### GCM_AUTHORITY
+
+This setting (and the corresponding `credential.authority` configuration) is deprecated and should be replaced with the `GCM_PROVIDER` (or corresponding `credential.authority` configuration) setting.
+
+Because both Basic HTTP authentication and Windows Integrated Authentication (WIA) are now handled by one provider, if you specified `basic` as your authority you also need to disable WIA using `GCM_ALLOW_WINDOWSAUTH` / `credential.allowWindowsAuth`.
+
+The following table shows the correct replacement for all legacy authorities values:
+
+GCM_AUTHORITY<br/>(credential.authority)|&rarr;|GCM_PROVIDER<br/>(credential.provider)|GCM_ALLOW_WINDOWSAUTH<br/>(credential.allowWindowsAuth)
+-|-|-|-
+`msa`, `microsoft`, `microsoftaccount`,<br/>`aad`, `azure`, `azuredirectory`,</br>`live`, `liveconnect`, `liveid`|&rarr;|`azure-repos`|_N/A_
+`github`|&rarr;|`github`|_N/A_
+`basic`|&rarr;|`generic`|`false`
+`integrated`, `windows`, `kerberos`, `ntlm`,<br/>`tfs`, `sso`|&rarr;|`generic`|`true` _(default)_
+
+For example if you had previous set the authority for the `example.com` host to `basic`..
+
+```shell
+git config --global credential.example.com.authority basic
+```
+
+..then you can replace this with the following..
+
+```shell
+git config --global --unset credential.example.com.authority
+git config --global credential.example.com.provider generic
+git config --global credential.example.com.allowWindowsAuth false
+```

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Git.CredentialManager
             using (var app = new Application(context))
             {
                 // Register all supported host providers
-                app.ProviderRegistry.Register(
+                app.RegisterProviders(
                     new AzureReposHostProvider(context),
                     new GitHubHostProvider(context),
                     new GenericHostProvider(context)

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -19,6 +19,11 @@ namespace GitHub
 
     public class GitHubAuthentication : AuthenticationBase, IGitHubAuthentication
     {
+        public static readonly string[] AuthorityIds =
+        {
+            "github",
+        };
+
         public GitHubAuthentication(ICommandContext context)
             : base(context) {}
 
@@ -44,7 +49,7 @@ namespace GitHub
             {
                 EnsureTerminalPromptsEnabled();
 
-                Context.Terminal.WriteLine("Enter credentials for '{0}'...", targetUri);
+                Context.Terminal.WriteLine("Enter GitHub credentials for '{0}'...", targetUri);
 
                 userName = Context.Terminal.Prompt("Username");
                 password = Context.Terminal.PromptSecret("Password");

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 
@@ -30,7 +31,11 @@ namespace GitHub
             _gitHubAuth = gitHubAuth;
         }
 
+        public override string Id => "github";
+
         public override string Name => "GitHub";
+
+        public override IEnumerable<string> SupportedAuthorityIds => GitHubAuthentication.AuthorityIds;
 
         public override bool IsSupported(InputArguments input)
         {

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -143,6 +143,7 @@ namespace Microsoft.AzureRepos.Tests
             });
 
             var expectedOrgUri = new Uri("https://dev.azure.com/org");
+            var remoteUri = new Uri("https://dev.azure.com/org/proj/_git/repo");
             var authorityUrl = "https://login.microsoftonline.com/common";
             var expectedClientId = AzureDevOpsConstants.AadClientId;
             var expectedRedirectUri = AzureDevOpsConstants.AadRedirectUri;
@@ -159,7 +160,7 @@ namespace Microsoft.AzureRepos.Tests
                         .ReturnsAsync(personalAccessToken);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>();
-            msAuthMock.Setup(x => x.GetAccessTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedResource))
+            msAuthMock.Setup(x => x.GetAccessTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedResource, remoteUri))
                       .ReturnsAsync(accessToken);
 
             var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object);

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -53,6 +53,7 @@ namespace Microsoft.AzureRepos
             }
 
             Uri orgUri = UriHelpers.CreateOrganizationUri(input);
+            Uri remoteUri = input.GetRemoteUri();
 
             // Determine the MS authentication authority for this organization
             Context.Trace.WriteLine("Determining Microsoft Authentication Authority...");
@@ -65,7 +66,8 @@ namespace Microsoft.AzureRepos
                 authAuthority,
                 AzureDevOpsConstants.AadClientId,
                 AzureDevOpsConstants.AadRedirectUri,
-                AzureDevOpsConstants.AadResourceId);
+                AzureDevOpsConstants.AadResourceId,
+                remoteUri);
             Context.Trace.WriteLineSecrets("Acquired access token. Token='{0}'", new object[] {accessToken});
 
             // Ask the Azure DevOps instance to create a new PAT

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication;
@@ -13,9 +14,12 @@ namespace Microsoft.AzureRepos
         private readonly IMicrosoftAuthentication _msAuth;
 
         public AzureReposHostProvider(ICommandContext context)
-            : this(context, new AzureDevOpsRestApi(context), new MicrosoftAuthentication(context)) { }
+            : this(context, new AzureDevOpsRestApi(context), new MicrosoftAuthentication(context))
+        {
+        }
 
-        public AzureReposHostProvider(ICommandContext context, IAzureDevOpsRestApi azDevOps, IMicrosoftAuthentication msAuth)
+        public AzureReposHostProvider(ICommandContext context, IAzureDevOpsRestApi azDevOps,
+            IMicrosoftAuthentication msAuth)
             : base(context)
         {
             EnsureArgument.NotNull(azDevOps, nameof(azDevOps));
@@ -27,7 +31,11 @@ namespace Microsoft.AzureRepos
 
         #region HostProvider
 
+        public override string Id => "azure-repos";
+
         public override string Name => "Azure Repos";
+
+        public override IEnumerable<string> SupportedAuthorityIds => MicrosoftAuthentication.AuthorityIds;
 
         public override bool IsSupported(InputArguments input)
         {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
@@ -7,19 +7,19 @@ using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests.Authentication
 {
-    public class TtyPromptBasicAuthenticationTests
+    public class BasicAuthenticationTests
     {
         [Fact]
-        public void TtyPromptBasicAuthentication_GetCredentials_NullResource_ThrowsException()
+        public void BasicAuthentication_GetCredentials_NullResource_ThrowsException()
         {
             var context = new TestCommandContext();
-            var basicAuth = new TtyPromptBasicAuthentication(context);
+            var basicAuth = new BasicAuthentication(context);
 
             Assert.Throws<ArgumentNullException>(() => basicAuth.GetCredentials(null));
         }
 
         [Fact]
-        public void TtyPromptBasicAuthentication_GetCredentials_ResourceAndUserName_PasswordPromptReturnsCredentials()
+        public void BasicAuthentication_GetCredentials_ResourceAndUserName_PasswordPromptReturnsCredentials()
         {
             const string testResource = "https://example.com";
             const string testUserName = "john.doe";
@@ -28,7 +28,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             var context = new TestCommandContext();
             context.Terminal.SecretPrompts["Password"] = testPassword;
 
-            var basicAuth = new TtyPromptBasicAuthentication(context);
+            var basicAuth = new BasicAuthentication(context);
 
             GitCredential credential = basicAuth.GetCredentials(testResource, testUserName);
 
@@ -37,7 +37,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
         }
 
         [Fact]
-        public void TtyPromptBasicAuthentication_GetCredentials_Resource_UserPassPromptReturnsCredentials()
+        public void BasicAuthentication_GetCredentials_Resource_UserPassPromptReturnsCredentials()
         {
             const string testResource = "https://example.com";
             const string testUserName = "john.doe";
@@ -47,7 +47,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             context.Terminal.Prompts["Username"] = testUserName;
             context.Terminal.SecretPrompts["Password"] = testPassword;
 
-            var basicAuth = new TtyPromptBasicAuthentication(context);
+            var basicAuth = new BasicAuthentication(context);
 
             GitCredential credential = basicAuth.GetCredentials(testResource);
 
@@ -56,7 +56,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
         }
 
         [Fact]
-        public void TtyPromptBasicAuthentication_GetCredentials_NoTerminalPrompts_ThrowsException()
+        public void BasicAuthentication_GetCredentials_NoTerminalPrompts_ThrowsException()
         {
             const string testResource = "https://example.com";
 
@@ -65,7 +65,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
                 Settings = {IsTerminalPromptsEnabled = false},
             };
 
-            var basicAuth = new TtyPromptBasicAuthentication(context);
+            var basicAuth = new BasicAuthentication(context);
 
             Assert.Throws<InvalidOperationException>(() => basicAuth.GetCredentials(testResource));
         }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/EnumerableExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/EnumerableExtensionsTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class EnumerableExtensionsTests
+    {
+        [Fact]
+        public void EnumerableExtensions_ConcatMany_Null_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => EnumerableExtensions.ConcatMany((IEnumerable<object>)null).ToArray());
+        }
+
+        [Fact]
+        public void EnumerableExtensions_ConcatMany_OneSequence_ReturnsSequence()
+        {
+            int[] seq1 = {0, 1, 2, 3, 4, 4, 4, 4, 5, 6, 7, 8, 9};
+            int[] expectedResult = seq1;
+
+            int[] actualResult = EnumerableExtensions.ConcatMany(seq1).ToArray();
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void EnumerableExtensions_ConcatMany_TwoSequences_ReturnsConcatenateSequences()
+        {
+            int[] seq1 = {0, 1, 2, 3, 4, 4};
+            int[] seq2 = {4, 4, 5, 6, 7, 8, 9};
+            int[] expectedResult = {0, 1, 2, 3, 4, 4, 4, 4, 5, 6, 7, 8, 9};
+
+            int[] actualResult = EnumerableExtensions.ConcatMany(seq1, seq2).ToArray();
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void EnumerableExtensions_ConcatMany_ManySequences_ReturnsConcatenateSequences()
+        {
+            int[] seq1 = {0, 1};
+            int[] seq2 = {2, 3};
+            int[] seq3 = {4, 4};
+            int[] seq4 = {4, 4};
+            int[] seq5 = {5, 6};
+            int[] seq6 = {7, 8};
+            int[] seq7 = {9};
+            int[] expectedResult = {0, 1, 2, 3, 4, 4, 4, 4, 5, 6, 7, 8, 9};
+
+            int[] actualResult = EnumerableExtensions.ConcatMany(seq1, seq2, seq3, seq4, seq5, seq6, seq7).ToArray();
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using Microsoft.Git.CredentialManager.Tests.Objects;
 using Moq;
 using Xunit;
 
@@ -10,18 +11,42 @@ namespace Microsoft.Git.CredentialManager.Tests
     public class HostProviderRegistryTests
     {
         [Fact]
-        public void HostProviderRegistry_NoProviders_ThrowException()
+        public void HostProviderRegistry_Register_AutoProviderId_ThrowException()
         {
-            var registry = new HostProviderRegistry();
+            var context = new TestCommandContext();
+            var registry = new HostProviderRegistry(context);
+            var provider = new Mock<IHostProvider>();
+            provider.Setup(x => x.Id).Returns(Constants.ProviderIdAuto);
+
+            Assert.Throws<ArgumentException>(() => registry.Register(provider.Object));
+        }
+
+        [Fact]
+        public void HostProviderRegistry_Register_AutoAuthorityId_ThrowException()
+        {
+            var context = new TestCommandContext();
+            var registry = new HostProviderRegistry(context);
+            var provider = new Mock<IHostProvider>();
+            provider.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"foo", Constants.AuthorityIdAuto, "bar"});
+
+            Assert.Throws<ArgumentException>(() => registry.Register(provider.Object));
+        }
+
+        [Fact]
+        public void HostProviderRegistry_GetProvider_NoProviders_ThrowException()
+        {
+            var context = new TestCommandContext();
+            var registry = new HostProviderRegistry(context);
             var input = new InputArguments(new Dictionary<string, string>());
 
             Assert.Throws<Exception>(() => registry.GetProvider(input));
         }
 
         [Fact]
-        public void HostProviderRegistry_HasProviders_ReturnsSupportedProvider()
+        public void HostProviderRegistry_GetProvider_Auto_HasProviders_ReturnsSupportedProvider()
         {
-            var registry = new HostProviderRegistry();
+            var context = new TestCommandContext();
+            var registry = new HostProviderRegistry(context);
             var input = new InputArguments(new Dictionary<string, string>());
 
             var provider1Mock = new Mock<IHostProvider>();
@@ -39,9 +64,10 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
-        public void HostProviderRegistry_MultipleValidProviders_ReturnsFirstRegistered()
+        public void HostProviderRegistry_GetProvider_Auto_MultipleValidProviders_ReturnsFirstRegistered()
         {
-            var registry = new HostProviderRegistry();
+            var context = new TestCommandContext();
+            var registry = new HostProviderRegistry(context);
             var input = new InputArguments(new Dictionary<string, string>());
 
             var provider1Mock = new Mock<IHostProvider>();
@@ -56,6 +82,141 @@ namespace Microsoft.Git.CredentialManager.Tests
             IHostProvider result = registry.GetProvider(input);
 
             Assert.Same(provider1Mock.Object, result);
+        }
+
+        [Fact]
+        public void HostProviderRegistry_GetProvider_ProviderSpecified_ReturnsProvider()
+        {
+            var context = new TestCommandContext
+            {
+                Settings = {ProviderOverride = "provider3"}
+            };
+            var registry = new HostProviderRegistry(context);
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.Id).Returns("provider1");
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider2Mock.Setup(x => x.Id).Returns("provider2");
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider3Mock.Setup(x => x.Id).Returns("provider3");
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+
+            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+
+            IHostProvider result = registry.GetProvider(input);
+
+            Assert.Same(provider3Mock.Object, result);
+        }
+
+        [Fact]
+        public void HostProviderRegistry_GetProvider_AutoProviderSpecified_ReturnsFirstSupportedProvider()
+        {
+            var context = new TestCommandContext
+            {
+                Settings = {ProviderOverride = Constants.ProviderIdAuto}
+            };
+            var registry = new HostProviderRegistry(context);
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.Id).Returns("provider1");
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+            provider2Mock.Setup(x => x.Id).Returns("provider2");
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider3Mock.Setup(x => x.Id).Returns("provider3");
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+
+            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+
+            IHostProvider result = registry.GetProvider(input);
+
+            Assert.Same(provider2Mock.Object, result);
+        }
+
+        [Fact]
+        public void HostProviderRegistry_GetProvider_UnknownProviderSpecified_ReturnsFirstSupportedProvider()
+        {
+            var context = new TestCommandContext
+            {
+                Settings = {ProviderOverride = "provider42"}
+            };
+            var registry = new HostProviderRegistry(context);
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.Id).Returns("provider1");
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+            provider2Mock.Setup(x => x.Id).Returns("provider2");
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider3Mock.Setup(x => x.Id).Returns("provider3");
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+
+            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+
+            IHostProvider result = registry.GetProvider(input);
+
+            Assert.Same(provider2Mock.Object, result);
+        }
+
+        [Fact]
+        public void HostProviderRegistry_GetProvider_LegacyAuthoritySpecified_ReturnsProvider()
+        {
+            var context = new TestCommandContext
+            {
+                Settings = {LegacyAuthorityOverride = "authorityB"}
+            };
+            var registry = new HostProviderRegistry(context);
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityA"});
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+            provider2Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityB", "authorityC"});
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+            provider3Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityD"});
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+
+            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+
+            IHostProvider result = registry.GetProvider(input);
+
+            Assert.Same(provider2Mock.Object, result);
+        }
+
+        [Fact]
+        public void HostProviderRegistry_GetProvider_AutoLegacyAuthoritySpecified_ReturnsFirstSupportedProvider()
+        {
+            var context = new TestCommandContext
+            {
+                Settings = {LegacyAuthorityOverride = Constants.AuthorityIdAuto}
+            };
+            var registry = new HostProviderRegistry(context);
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityA"});
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+            provider2Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityB", "authorityC"});
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider3Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityD"});
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+
+            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+
+            IHostProvider result = registry.GetProvider(input);
+
+            Assert.Same(provider2Mock.Object, result);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientExtensionsTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -209,8 +209,12 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git);
-            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -229,8 +233,12 @@ namespace Microsoft.Git.CredentialManager.Tests
             var envars = new EnvironmentVariables(new Dictionary<string, string>());
             var git = new TestGit();
 
-            var settings = new Settings(envars, git);
-            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
 
             Assert.False(result);
             Assert.Null(actualValue);
@@ -254,8 +262,12 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue
             });
 
-            var settings = new Settings(envars, git);
-            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var result = settings.TryGetSetting( envarName, section, property, out string actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -280,8 +292,12 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue
             });
 
-            var settings = new Settings(envars, git);
-            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -310,8 +326,12 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{scope2}.{property}"] = expectedValue,
             });
 
-            var settings = new Settings(envars, git);
-            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -340,8 +360,12 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = otherValue
             });
 
-            var settings = new Settings(envars, git);
-            var result = settings.TryGetSetting(repositoryPath, remoteUri, envarName, section, property, out string actualValue);
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -378,8 +402,12 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"]          = value4
             });
 
-            var settings = new Settings(envars, git);
-            string[] actualValues = settings.GetSettingValues(repositoryPath, remoteUri, envarName, section, property).ToArray();
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            string[] actualValues = settings.GetSettingValues(envarName, section, property).ToArray();
 
             Assert.Equal(expectedValues, actualValues);
         }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -192,6 +192,212 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public void Settings_ProviderOverride_Unset_ReturnsNull()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            string value = settings.ProviderOverride;
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void Settings_ProviderOverride_EnvarSet_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "provider1";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmProvider] = expectedValue
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            string actualValue = settings.ProviderOverride;
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_ProviderOverride_ConfigSet_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Provider;
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "provider1";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = expectedValue
+            });
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            string actualValue = settings.ProviderOverride;
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_ProviderOverride_EnvarAndConfigSet_ReturnsEnvarValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Provider;
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "provider1";
+            const string otherValue = "provider2";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmProvider] = expectedValue
+            });
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = otherValue
+            });
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            string actualValue = settings.ProviderOverride;
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_LegacyAuthorityOverride_Unset_ReturnsNull()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            string value = settings.LegacyAuthorityOverride;
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void Settings_LegacyAuthorityOverride_EnvarSet_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "provider1";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmAuthority] = expectedValue
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            string actualValue = settings.LegacyAuthorityOverride;
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_LegacyAuthorityOverride_ConfigSet_ReturnsTrueOutValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Authority;
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "provider1";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = expectedValue
+            });
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var actualValue = settings.LegacyAuthorityOverride;
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void Settings_LegacyAuthorityOverride_EnvarAndConfigSet_ReturnsEnvarValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Authority;
+            var remoteUri = new Uri(remoteUrl);
+
+            const string expectedValue = "provider1";
+            const string otherValue = "provider2";
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmAuthority] = expectedValue
+            });
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = otherValue
+            });
+
+            var settings = new Settings(envars, git)
+            {
+                RepositoryPath = repositoryPath,
+                RemoteUri = remoteUri
+            };
+            var actualValue = settings.LegacyAuthorityOverride;
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
         public void Settings_TryGetSetting_EnvarSet_ReturnsTrueOutValue()
         {
             const string repositoryPath = "/tmp/repos/foo/.git";

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -10,19 +10,27 @@ namespace Microsoft.Git.CredentialManager
 {
     public class Application : ApplicationBase
     {
-        public IHostProviderRegistry ProviderRegistry { get; } = new HostProviderRegistry();
+        private readonly IHostProviderRegistry _providerRegistry;
 
         public Application(ICommandContext context)
-            : base(context) { }
+            : base(context)
+        {
+            _providerRegistry = new HostProviderRegistry(context);
+        }
+
+        public void RegisterProviders(params IHostProvider[] providers)
+        {
+            _providerRegistry.Register(providers);
+        }
 
         protected override async Task<int> RunInternalAsync(string[] args)
         {
             // Construct all supported commands
             var commands = new CommandBase[]
             {
-                new EraseCommand(ProviderRegistry),
-                new GetCommand(ProviderRegistry),
-                new StoreCommand(ProviderRegistry),
+                new EraseCommand(_providerRegistry),
+                new GetCommand(_providerRegistry),
+                new StoreCommand(_providerRegistry),
                 new VersionCommand(),
                 new HelpCommand(),
             };
@@ -71,7 +79,7 @@ namespace Microsoft.Git.CredentialManager
         {
             if (disposing)
             {
-                ProviderRegistry.Dispose();
+                _providerRegistry?.Dispose();
             }
 
             base.Dispose(disposing);

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
@@ -16,9 +16,14 @@ namespace Microsoft.Git.CredentialManager.Authentication
         }
     }
 
-    public class TtyPromptBasicAuthentication : AuthenticationBase, IBasicAuthentication
+    public class BasicAuthentication : AuthenticationBase, IBasicAuthentication
     {
-        public TtyPromptBasicAuthentication(ICommandContext context)
+        public static readonly string[] AuthorityIds =
+        {
+            "basic",
+        };
+
+        public BasicAuthentication(ICommandContext context)
             : base (context) { }
 
         public GitCredential GetCredentials(string resource, string userName)
@@ -27,7 +32,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
             EnsureTerminalPromptsEnabled();
 
-            Context.Terminal.WriteLine("Enter credentials for '{0}':", resource);
+            Context.Terminal.WriteLine("Enter basic credentials for '{0}':", resource);
 
             if (!string.IsNullOrWhiteSpace(userName))
             {

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
 {
     public interface IMicrosoftAuthentication
     {
-        Task<string> GetAccessTokenAsync(string authority, string clientId, Uri redirectUri, string resource);
+        Task<string> GetAccessTokenAsync(string authority, string clientId, Uri redirectUri, string resource, Uri remoteUri);
     }
 
     public class MicrosoftAuthentication : AuthenticationBase, IMicrosoftAuthentication
@@ -18,7 +18,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
         public MicrosoftAuthentication(ICommandContext context)
             : base(context) {}
 
-        public async Task<string> GetAccessTokenAsync(string authority, string clientId, Uri redirectUri, string resource)
+        public async Task<string> GetAccessTokenAsync(string authority, string clientId, Uri redirectUri, string resource, Uri remoteUri)
         {
             string helperPath = FindHelperExecutablePath();
 
@@ -28,6 +28,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
                 ["clientId"]    = clientId,
                 ["redirectUri"] = redirectUri.AbsoluteUri,
                 ["resource"]    = resource,
+                ["remoteUrl"]   = remoteUri.ToString(),
             };
 
             IDictionary<string, string> resultDict = await InvokeHelperAsync(helperPath, null, inputDict);

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -15,6 +15,13 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
     public class MicrosoftAuthentication : AuthenticationBase, IMicrosoftAuthentication
     {
+        public static readonly string[] AuthorityIds =
+        {
+            "msa",  "microsoft",   "microsoftaccount",
+            "aad",  "azure",       "azuredirectory",
+            "live", "liveconnect", "liveid",
+        };
+
         public MicrosoftAuthentication(ICommandContext context)
             : base(context) {}
 

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/WindowsIntegratedAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/WindowsIntegratedAuthentication.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
     public class WindowsIntegratedAuthentication : IWindowsIntegratedAuthentication
     {
+        public static readonly string[] AuthorityIds =
+        {
+            "integrated", "windows", "kerberos", "ntlm",
+            "tfs", "sso",
+        };
+
         private readonly ICommandContext _context;
 
         public WindowsIntegratedAuthentication(ICommandContext context)

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -56,19 +56,9 @@ namespace Microsoft.Git.CredentialManager
         ICredentialStore CredentialStore { get; }
 
         /// <summary>
-        /// Git functions and information.
-        /// </summary>
-        IGit Git { get; }
-
         /// Factory for creating new <see cref="System.Net.Http.HttpClient"/> instances.
         /// </summary>
         IHttpClientFactory HttpClientFactory { get; }
-
-        /// <summary>
-        /// Access the environment variables for the current GCM process.
-        /// </summary>
-        /// <returns>Set of all current environment variables.</returns>
-        IEnvironmentVariables EnvironmentVariables { get; }
     }
 
     /// <summary>
@@ -86,12 +76,17 @@ namespace Microsoft.Git.CredentialManager
 
         public CommandContext()
         {
-            EnvironmentVariables = new EnvironmentVariables(Environment.GetEnvironmentVariables());
             Trace = new Trace();
             FileSystem = new FileSystem();
-            Git = new LibGit2();
+
+            var git = new LibGit2();
+            var envars = new EnvironmentVariables(Environment.GetEnvironmentVariables());
+            Settings = new Settings(envars, git)
+            {
+                RepositoryPath = git.GetRepositoryPath(FileSystem.GetCurrentDirectory())
+            };
+
             HttpClientFactory = new HttpClientFactory();
-            Settings = new Settings(EnvironmentVariables, Git);
 
             if (PlatformUtils.IsWindows())
             {
@@ -172,11 +167,7 @@ namespace Microsoft.Git.CredentialManager
 
         public ICredentialStore CredentialStore { get; }
 
-        public IGit Git { get; }
-
         public IHttpClientFactory HttpClientFactory { get; }
-
-        public IEnvironmentVariables EnvironmentVariables { get; }
 
         #endregion
     }

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Git.CredentialManager.Commands
             IDictionary<string, string> inputDict = await context.StdIn.ReadDictionaryAsync(StringComparer.Ordinal);
             var input = new InputArguments(inputDict);
 
+            // Set the remote URI to scope settings to throughout the process from now on
+            context.Settings.RemoteUri = input.GetRemoteUri();
+
             // Determine the host provider
             context.Trace.WriteLine("Detecting host provider for input:");
             context.Trace.WriteDictionarySecrets(inputDict, new []{ "password" }, StringComparer.OrdinalIgnoreCase);

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -10,13 +10,19 @@ namespace Microsoft.Git.CredentialManager
         public const string PersonalAccessTokenUserName = "PersonalAccessToken";
         public const string MicrosoftAuthHelperName = "Microsoft.Authentication.Helper";
 
+        public const string ProviderIdAuto  = "auto";
+        public const string AuthorityIdAuto = "auto";
+
         public static class EnvironmentVariables
         {
             public const string GcmTrace           = "GCM_TRACE";
             public const string GcmTraceSecrets    = "GCM_TRACE_SECRETS";
             public const string GcmTraceMsAuth     = "GCM_TRACE_MSAUTH";
             public const string GcmDebug           = "GCM_DEBUG";
+            public const string GcmProvider        = "GCM_PROVIDER";
+            public const string GcmAuthority       = "GCM_AUTHORITY";
             public const string GitTerminalPrompts = "GIT_TERMINAL_PROMPT";
+            public const string GcmAllowWia        = "GCM_ALLOW_WINDOWSAUTH";
         }
 
         public static class Http
@@ -37,6 +43,7 @@ namespace Microsoft.Git.CredentialManager
                 public const string Helper      = "helper";
                 public const string Provider    = "provider";
                 public const string Authority   = "authority";
+                public const string AllowWia    = "allowWindowsAuth";
             }
 
             public static class Http
@@ -44,6 +51,12 @@ namespace Microsoft.Git.CredentialManager
                 public const string SectionName = "http";
                 public const string Proxy = "proxy";
             }
+        }
+
+        public static class HelpUrls
+        {
+            public const string GcmProjectUrl = "https://aka.ms/gcmcore";
+            public const string GcmAuthorityDeprecated = "https://aka.ms/gcmcore-authority";
         }
 
         private static string _gcmVersion;

--- a/src/shared/Microsoft.Git.CredentialManager/EnumerableExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/EnumerableExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Git.CredentialManager
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Concatenates multiple sequences.
+        /// </summary>
+        /// <param name="first">Initial sequence to concatenate other sequences with.</param>
+        /// <param name="others">Other sequences to concatenate together with <paramref name="first"/>.</param>
+        /// <typeparam name="TSource">Type of the sequence elements.</typeparam>
+        /// <returns>Concatenated sequence.</returns>
+        public static IEnumerable<TSource> ConcatMany<TSource>(this IEnumerable<TSource> first, params IEnumerable<TSource>[] others)
+        {
+            IEnumerable<TSource> result = first;
+
+            foreach (IEnumerable<TSource> other in others)
+            {
+                result = result.Concat(other);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Authentication;

--- a/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Authentication;
 
@@ -12,7 +14,7 @@ namespace Microsoft.Git.CredentialManager
         private readonly IWindowsIntegratedAuthentication _winAuth;
 
         public GenericHostProvider(ICommandContext context)
-            : this(context, new TtyPromptBasicAuthentication(context), new WindowsIntegratedAuthentication(context)) { }
+            : this(context, new BasicAuthentication(context), new WindowsIntegratedAuthentication(context)) { }
 
         public GenericHostProvider(ICommandContext context,
                                    IBasicAuthentication basicAuth,
@@ -28,7 +30,15 @@ namespace Microsoft.Git.CredentialManager
 
         #region HostProvider
 
+        public override string Id => "generic";
+
         public override string Name => "Generic";
+
+        public override IEnumerable<string> SupportedAuthorityIds =>
+            EnumerableExtensions.ConcatMany(
+                BasicAuthentication.AuthorityIds,
+                WindowsIntegratedAuthentication.AuthorityIds
+            );
 
         public override bool IsSupported(InputArguments input)
         {
@@ -46,31 +56,63 @@ namespace Microsoft.Git.CredentialManager
             Uri uri = GetUriFromInput(input);
 
             // Determine the if the host supports Windows Integration Authentication (WIA)
-            if (PlatformUtils.IsWindows())
+            if (IsWindowsAuthAllowed)
             {
-                Context.Trace.WriteLine($"Checking host '{uri.AbsoluteUri}' for Windows Integrated Authentication...");
-                bool isWiaSupported = await _winAuth.GetIsSupportedAsync(uri);
-
-                if (!isWiaSupported)
+                if (PlatformUtils.IsWindows())
                 {
-                    Context.Trace.WriteLine("Host does not support WIA.");
+                    Context.Trace.WriteLine($"Checking host '{uri.AbsoluteUri}' for Windows Integrated Authentication...");
+                    bool isWiaSupported = await _winAuth.GetIsSupportedAsync(uri);
+
+                    if (!isWiaSupported)
+                    {
+                        Context.Trace.WriteLine("Host does not support WIA.");
+                    }
+                    else
+                    {
+                        Context.Trace.WriteLine("Host supports WIA - generating empty credential...");
+
+                        // WIA is signaled to Git using an empty username/password
+                        return new GitCredential(string.Empty, string.Empty);
+                    }
                 }
                 else
                 {
-                    Context.Trace.WriteLine($"Host supports WIA - generating empty credential...");
-
-                    // WIA is signaled to Git using an empty username/password
-                    return new GitCredential(string.Empty, string.Empty);
+                    string osType = PlatformUtils.GetPlatformInformation().OperatingSystemType;
+                    Context.Trace.WriteLine($"Skipping check for Windows Integrated Authentication on {osType}.");
                 }
             }
             else
             {
-                string osType = PlatformUtils.GetPlatformInformation().OperatingSystemType;
-                Context.Trace.WriteLine($"Skipping check for Windows Integrated Authentication on {osType}.");
+                Context.Trace.WriteLine("Windows Integrated Authentication detection has been disabled.");
             }
 
             Context.Trace.WriteLine("Prompting for basic credentials...");
             return _basicAuth.GetCredentials(uri.AbsoluteUri, uri.UserInfo);
+        }
+
+        /// <summary>
+        /// Check if the user permits checking for Windows Integrated Authentication.
+        /// </summary>
+        /// <remarks>
+        /// Checks the explicit 'GCM_ALLOW_WINDOWSAUTH' setting and also the legacy 'GCM_AUTHORITY' setting iif equal to "basic".
+        /// </remarks>
+        private bool IsWindowsAuthAllowed
+        {
+            get
+            {
+                if (Context.Settings.IsWindowsIntegratedAuthenticationEnabled)
+                {
+                    /* COMPAT: In the old GCM one workaround for common authentication problems was to specify "basic" as the authority
+                     *         which prevents any smart detection of provider or NTLM etc, allowing the user a chance to manually enter
+                     *         a username/password or PAT.
+                     *
+                     *         We take this old setting into account to ensure a good migration experience.
+                     */
+                    return !BasicAuthentication.AuthorityIds.Contains(Context.Settings.LegacyAuthorityOverride, StringComparer.OrdinalIgnoreCase);
+                }
+
+                return false;
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager
@@ -11,9 +13,19 @@ namespace Microsoft.Git.CredentialManager
     public interface IHostProvider : IDisposable
     {
         /// <summary>
+        /// Unique identifier of the hosting provider.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
         /// Name of the hosting provider.
         /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Supported authority identifiers.
+        /// </summary>
+        IEnumerable<string> SupportedAuthorityIds { get; }
 
         /// <summary>
         /// Determine if the <see cref="InputArguments"/> are recognized by this particular Git hosting provider.
@@ -58,7 +70,11 @@ namespace Microsoft.Git.CredentialManager
         /// </summary>
         protected ICommandContext Context { get; }
 
+        public abstract string Id { get; }
+
         public abstract string Name { get; }
+
+        public virtual IEnumerable<string> SupportedAuthorityIds => Enumerable.Empty<string>();
 
         public abstract bool IsSupported(InputArguments input);
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/InteropException.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/InteropException.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stdlib.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stdlib.cs
@@ -1,4 +1,5 @@
-using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Git.CredentialManager.Interop.Posix.Native

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using KnownEnvars = Microsoft.Git.CredentialManager.Constants.EnvironmentVariables;
 using KnownGitCfg = Microsoft.Git.CredentialManager.Constants.GitConfiguration;
+using GitCredCfg  = Microsoft.Git.CredentialManager.Constants.GitConfiguration.Credential;
 
 namespace Microsoft.Git.CredentialManager
 {
@@ -49,6 +50,21 @@ namespace Microsoft.Git.CredentialManager
         /// True if MSAL tracing is enabled, false otherwise.
         /// </summary>
         bool IsMsalTracingEnabled { get; }
+
+        /// <summary>
+        /// Get the host provider configured to override auto-detection if set, null otherwise.
+        /// </summary>
+        string ProviderOverride { get; }
+
+        /// <summary>
+        /// Get the authority name configured to override host provider auto-detection if set, null otherwise.
+        /// </summary>
+        string LegacyAuthorityOverride { get; }
+
+        /// <summary>
+        /// True if Windows Integrated Authentication (NTLM, Kerberos) should be detected and used if available, false otherwise.
+        /// </summary>
+        bool IsWindowsIntegratedAuthenticationEnabled { get; }
     }
 
     public class Settings : ISettings
@@ -78,6 +94,15 @@ namespace Microsoft.Git.CredentialManager
         public bool IsSecretTracingEnabled => _environment.GetBooleanyOrDefault(KnownEnvars.GcmTraceSecrets, false);
 
         public bool IsMsalTracingEnabled => _environment.GetBooleanyOrDefault(Constants.EnvironmentVariables.GcmTraceMsAuth, false);
+
+        public string ProviderOverride =>
+            TryGetSetting(KnownEnvars.GcmProvider, GitCredCfg.SectionName, GitCredCfg.Provider, out string providerId) ? providerId : null;
+
+        public string LegacyAuthorityOverride =>
+            TryGetSetting(KnownEnvars.GcmAuthority, GitCredCfg.SectionName, GitCredCfg.Authority, out string authority) ? authority : null;
+
+        public bool IsWindowsIntegratedAuthenticationEnabled =>
+            TryGetSetting(KnownEnvars.GcmAllowWia, GitCredCfg.SectionName, GitCredCfg.AllowWia, out string value) && value.ToBooleanyOrDefault(true);
 
         /// <summary>
         /// Try and get the value of a specified setting as specified in the environment and Git configuration,

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -16,9 +15,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         public ITrace Trace { get; set; } = new NullTrace();
         public TestFileSystem FileSystem { get; set; } = new TestFileSystem();
         public TestCredentialStore CredentialStore { get; set; } = new TestCredentialStore();
-        public TestGit Git { get; set; } = new TestGit();
         public TestHttpClientFactory HttpClientFactory { get; set; } = new TestHttpClientFactory();
-        public Dictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
         public string NewLine { get; set; } = "\n";
 
         #region ICommandContext
@@ -39,12 +36,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         ICredentialStore ICommandContext.CredentialStore => CredentialStore;
 
-        IGit ICommandContext.Git => Git;
-
         IHttpClientFactory ICommandContext.HttpClientFactory => HttpClientFactory;
-
-        IEnvironmentVariables ICommandContext.EnvironmentVariables
-            => new EnvironmentVariables(EnvironmentVariables);
 
         #endregion
     }

--- a/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
@@ -14,11 +14,17 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public string CredentialKey { get; set; }
 
+        public string LegacyAuthorityIdValue { get; set; }
+
         public Func<InputArguments, ICredential> GenerateCredentialFunc { get; set; }
 
         #region HostProvider
 
+        public override string Id { get; } = "test-provider";
+
         public override string Name { get; } = "TestHostProvider";
+
+        public string LegacyAuthorityId => LegacyAuthorityIdValue;
 
         public override bool IsSupported(InputArguments input) => IsSupportedFunc(input);
 

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -14,7 +14,13 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public bool IsSecretTracingEnabled { get; set; }
 
+        public bool IsMsalTracingEnabled { get; set; }
+
         #region ISettings
+
+        public string RepositoryPath { get; set; }
+
+        public Uri RemoteUri { get; set; }
 
         bool ISettings.IsDebuggingEnabled => IsDebuggingEnabled;
 
@@ -27,6 +33,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         }
 
         bool ISettings.IsSecretTracingEnabled => IsSecretTracingEnabled;
+
+        bool ISettings.IsMsalTracingEnabled => IsMsalTracingEnabled;
 
         #endregion
     }

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -16,6 +16,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public bool IsMsalTracingEnabled { get; set; }
 
+        public string ProviderOverride { get; set; }
+
+        public string LegacyAuthorityOverride { get; set; }
+
+        public bool IsWindowsIntegratedAuthenticationEnabled { get; set; } = true;
+
         #region ISettings
 
         public string RepositoryPath { get; set; }
@@ -35,6 +41,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         bool ISettings.IsSecretTracingEnabled => IsSecretTracingEnabled;
 
         bool ISettings.IsMsalTracingEnabled => IsMsalTracingEnabled;
+
+        string ISettings.ProviderOverride => ProviderOverride;
+
+        string ISettings.LegacyAuthorityOverride => LegacyAuthorityOverride;
+
+        bool ISettings.IsWindowsIntegratedAuthenticationEnabled => IsWindowsIntegratedAuthenticationEnabled;
 
         #endregion
     }

--- a/src/windows/Microsoft.Authentication.Helper.Windows.Tests/ApplicationTests.cs
+++ b/src/windows/Microsoft.Authentication.Helper.Windows.Tests/ApplicationTests.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Authentication.Helper.Tests
             const string expectedClientId    = "test-clientid";
             const string expectedRedirectUri = "https://test-redirecturi/";
             const string expectedResource    = "test-resource";
+            const string expectedRemoteUrl   = "test://remote";
 
             var inputDict = new Dictionary<string, string>
             {
@@ -108,6 +109,7 @@ namespace Microsoft.Authentication.Helper.Tests
                 ["clientId"]    = expectedClientId,
                 ["redirectUri"] = expectedRedirectUri,
                 ["resource"]    = expectedResource,
+                ["remoteUrl"]   = expectedRemoteUrl,
             };
             var context = new TestCommandContext {StdIn = DictionaryToString(inputDict)};
             var app = new TestApplication(context)

--- a/src/windows/Microsoft.Authentication.Helper.Windows/Application.cs
+++ b/src/windows/Microsoft.Authentication.Helper.Windows/Application.cs
@@ -25,6 +25,10 @@ namespace Microsoft.Authentication.Helper
                 string clientId    = GetArgument(inputDict, "clientId");
                 string redirectUri = GetArgument(inputDict, "redirectUri");
                 string resource    = GetArgument(inputDict, "resource");
+                string remoteUrl   = GetArgument(inputDict, "remoteUrl");
+
+                // Set the remote URI to scope settings to throughout the process from now on
+                Context.Settings.RemoteUri = new Uri(remoteUrl);
 
                 string accessToken = await GetAccessTokenAsync(authority, clientId, new Uri(redirectUri), resource);
 
@@ -68,7 +72,7 @@ namespace Microsoft.Authentication.Helper
                                                            .WithRedirectUri(redirectUri.ToString());
 
             // Listen to MSAL logs if GCM_TRACE_MSAUTH is set
-            if (Context.EnvironmentVariables.GetBooleanyOrDefault(Constants.EnvironmentVariables.GcmTraceMsAuth, false))
+            if (Context.Settings.IsMsalTracingEnabled)
             {
                 // If GCM secret tracing is enabled also enable "PII" logging in MSAL
                 bool enablePiiLogging = Context.Trace.IsSecretTracingEnabled;


### PR DESCRIPTION
Check the Git configuration for a specified host provider for the current repository remote URI.

We look for the `credential.authority` configuration entry (and any URL scoped variants) for backwards compatibility with older GCMs, as well as the new `credential.provider` entry.

Also provides a way for various on-prem providers to have instances specified manually (such as GHE).

Fixes #59