### PR TITLE
Use Git's HTTP proxy configuration

### DIFF
--- a/Git-Credential-Manager.sln
+++ b/Git-Credential-Manager.sln
@@ -63,6 +63,7 @@ ProjectSection(SolutionItems) = preProject
 	docs\faq.md = docs\faq.md
 	docs\migration.md = docs\migration.md
 	docs\usage.md = docs\usage.md
+	docs\netconfig.md = docs\netconfig.md
 EndProjectSection
 EndProject
 Global

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,3 +92,21 @@ git config --global credential.tfsonprem123.allowWindowsAuth false
 ```
 
 **Also see: [GCM_ALLOW_WINDOWSAUTH](environment.md#GCM_ALLOW_WINDOWSAUTH)**
+
+---
+
+### credential.httpProxy _(deprecated)_
+
+> This setting is deprecated and should be replaced by the [standard `http.proxy` Git configuration option](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy).
+>
+> Click [here](https://aka.ms/gcmcore-httpproxy) for more information.
+
+Configure GCM Core to use the a proxy for network operations.
+
+**Note:** Git itself does _not_ respect this setting; this affects GCM _only_.
+
+```shell
+git config --global credential.httpsProxy http://john.doe:password@proxy.contoso.com
+```
+
+**Also see: [GCM_HTTP_PROXY](environment.md#GCM_HTTP_PROXY-deprecated)**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -120,6 +120,7 @@ Defaults to disabled.
 _No configuration equivalent._
 
 ---
+
 ### GCM_PROVIDER
 
 Define the host provider to use when authenticating.
@@ -214,3 +215,29 @@ export GCM_ALLOW_WINDOWSAUTH=0
 ```
 
 **Also see: [credential.allowWindowsAuth](environment.md#credentialallowWindowsAuth)**
+
+---
+
+### GCM_HTTP_PROXY _(deprecated)_
+
+> This setting is deprecated and should be replaced by the [standard `http.proxy` Git configuration option](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy).
+>
+> Click [here](https://aka.ms/gcmcore-httpproxy) for more information.
+
+Configure GCM Core to use the a proxy for network operations.
+
+**Note:** Git itself does _not_ respect this setting; this affects GCM _only_.
+
+##### Windows
+
+```batch
+SET GCM_HTTP_PROXY=http://john.doe:password@proxy.contoso.com
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_HTTP_PROXY=http://john.doe:password@proxy.contoso.com
+```
+
+**Also see: [credential.httpProxy](configuration.md#credentialhttpProxy-deprecated)**

--- a/docs/netconfig.md
+++ b/docs/netconfig.md
@@ -1,0 +1,105 @@
+# Network and HTTP configuration
+
+Git Credential Manager Core's network and HTTP(S) behavior can be configured in a few different ways via [environment variables](environment.md) and [configuration options](configuration.md).
+
+## HTTP Proxy
+
+If your computer sits behind a network firewall that requires the use of a proxy server to reach repository remotes or the wider Internet, there are various methods for configuring GCM to use a proxy.
+
+The simplist way to configure a proxy for _all_ HTTP(S) remotes is to [use the standard Git HTTP(S) proxy setting `http.proxy`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy).
+
+For example to configure a proxy for all remotes for the current user:
+
+```shell
+git config --global http.proxy http://proxy.example.com
+```
+
+To specify a proxy for a particular remote you can [use the `remote.<name>.proxy` repository-level setting](https://git-scm.com/docs/git-config#Documentation/git-config.txt-remoteltnamegtproxy), for example:
+
+```shell
+git config --local remote.origin.proxy http://proxy.example.com
+```
+
+The advantage to using these standard configuration options is that in addition to GCM being configured to use the proxy, Git itself will be configured at the same time. This is probably the most commonly desired case in environments behind an Internet-blocking firewall.
+
+### Authenticated proxies
+
+Some proxy servers do not accept anonymous connections and require authentication. In order to specify the credentials to be used with a proxy, you can specify the username and password as part of the proxy URL setting.
+
+The format follows [RFC 3986 section 3.2.1](https://tools.ietf.org/html/rfc3986#section-3.2.1) by including the credentials in the 'user information' part of the URI. The password is optional.
+
+```text
+protocol://username[:password]@hostname
+```
+
+For example, to specify the username `john.doe` and the password `letmein123` for the proxy server `proxy.example.com`:
+
+```text
+https://john.doe:letmein123@proxy.example.com
+```
+
+If you have special characters (as defined by [RFC 3986 section 2.2](https://tools.ietf.org/html/rfc3986#section-2.2)) in your username or password such as `:`, `@`, or any other non-URL friendly character you can URL-encode them ([section 2.1](https://tools.ietf.org/html/rfc3986#section-2.2)).
+
+For example, a space character would be encoded with `%20`.
+
+### Other proxy options
+
+GCM Core supports other ways of configuring a proxy for convenience and compatibility.
+
+1. GCM-specific configuration options (_**only** respected by GCM; **deprecated**_):
+   - `credential.httpProxy`
+   - `credential.httpsProxy`
+1. cURL environment variables (_also respected by Git_):
+   - `HTTP_PROXY`
+   - `HTTPS_PROXY`
+   - `ALL_PROXY`
+1. `GCM_HTTP_PROXY` environment variable (_**only** respected by GCM; **deprecated**_)
+
+## TLS Verification
+
+If you are using self-signed TLS (SSL) certificates with a self-hosted host provider such as GitHub Enteprise Server or Azure DevOps Server (previously TFS), you may see the following error message when attempting to connect using Git and/or GCM:
+
+```shell
+$ git clone https://ghe.example.com/john.doe/myrepo
+fatal: The remote certificate is invalid according to the validation procedure.
+```
+
+The **recommended and safest option** is to acquire a TLS certificate signed by a public trusted certificate authority (CA). There are multiple public CAs; here is a non-exhaustive list to consider: [Let's Encrypt](https://letsencrypt.org/), [Comodo](https://www.comodoca.com/), [Digicert](https://www.digicert.com/), [GoDaddy](https://www.godaddy.com/web-security/ssl-certificate), [GlobalSign](https://www.globalsign.com/en/ssl/).
+
+If it is not possible to **obtain a TLS certifiate from a trusted 3rd party** then you should try to add the _specific_ self-signed certificate or one of the CA certificates in the verification chain to your operating system's trusted certificate store ([macOS](https://support.apple.com/en-gb/guide/keychain-access/kyca2431/mac), [Windows](https://blogs.technet.microsoft.com/sbs/2008/05/08/installing-a-self-signed-certificate-as-a-trusted-root-ca-in-windows-vista/)).
+
+If you are _unable_ to either **obtain a trusted certificate**, or trust the self-signed certificate you can disable certificate verification in Git and GCM.
+
+---
+**Security Warning** :warning:
+
+Disabling verification of TLS (SSL) certificates removes protection against a [man-in-the-middle (MITM) attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).
+
+Only disable certificate verification if you are sure you need to, are aware of all of the risks, and are unable to trust specific self-signed certificates (as described above).
+
+---
+
+The [environment variable `GIT_SSL_NO_VERIFY`](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_networking) and [Git configuration option `http.sslVerify`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpsslVerify) can be used to control TLS (SSL) certifcate verification.
+
+To disable verification for a specific remote (for example <https://example.com>):
+
+```shell
+git config --global http.https://example.com.sslVerify false
+```
+
+To disable verification for the current user for **_all remotes_** (**not recommended**):
+
+```shell
+# Environment variable (Windows)
+SET GIT_SSL_NO_VERIFY=1
+
+# Environment variable (macOS/Linux)
+export GIT_SSL_NO_VERIFY=1
+
+# Git configuration (Windows/macOS/Linux)
+git config --global http.sslVerify false
+```
+
+---
+
+**Note:** You may also experience similar verification errors if you are using a network traffic inspection tool such as [Telerik Fiddler](https://www.telerik.com/fiddler). If you are using such tools please consult their documentation for trusting the proxy root certificates.

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -107,7 +107,7 @@ namespace GitHub
                 // We currently only have a helper on Windows. If we failed to find the helper we should warn the user.
                 if (PlatformUtils.IsWindows())
                 {
-                    Context.StdError.WriteLine($"warning: missing '{helperName}' from installation.");
+                    Context.Streams.Error.WriteLine($"warning: missing '{helperName}' from installation.");
                 }
 
                 return false;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/EraseCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/EraseCommandTests.cs
@@ -45,7 +45,10 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
             providerMock.Setup(x => x.EraseCredentialAsync(It.IsAny<InputArguments>()))
                         .Returns(Task.CompletedTask);
             var providerRegistry = new TestHostProviderRegistry {Provider = providerMock.Object};
-            var context = new TestCommandContext {StdIn = stdin};
+            var context = new TestCommandContext
+            {
+                Streams = {In = stdin}
+            };
 
             string[] cmdArgs = {"erase"};
             var command = new EraseCommand(providerRegistry);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GetCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GetCommandTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
 
             await command.ExecuteAsync(context, cmdArgs);
 
-            IDictionary<string, string> actualStdOutDict = ParseDictionary(context.StdOut);
+            IDictionary<string, string> actualStdOutDict = ParseDictionary(context.Streams.Out);
 
             providerMock.Verify(x => x.GetCredentialAsync(It.IsAny<InputArguments>()), Times.Once);
             Assert.Equal(expectedStdOutDict, actualStdOutDict);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
         public async Task HostProviderCommandBase_ExecuteAsync_CallsExecuteInternalAsyncWithCorrectArgs()
         {
             var mockContext = new Mock<ICommandContext>();
+            var mockStreams = new Mock<IStandardStreams>();
             var mockProvider = new Mock<IHostProvider>();
             var mockHostRegistry = new Mock<IHostProviderRegistry>();
 
@@ -28,7 +29,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
             string standardIn = "protocol=test\nhost=example.com\npath=a/b/c\n\n";
             TextReader standardInReader = new StringReader(standardIn);
 
-            mockContext.Setup(x => x.StdIn).Returns(standardInReader);
+            mockStreams.Setup(x => x.In).Returns(standardInReader);
+            mockContext.Setup(x => x.Streams).Returns(mockStreams.Object);
             mockContext.Setup(x => x.Trace).Returns(Mock.Of<ITrace>());
             mockContext.Setup(x => x.Settings).Returns(Mock.Of<ISettings>());
 
@@ -51,6 +53,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
         public async Task HostProviderCommandBase_ExecuteAsync_ConfiguresSettingsRemoteUri()
         {
             var mockContext = new Mock<ICommandContext>();
+            var mockStreams = new Mock<IStandardStreams>();
             var mockProvider = new Mock<IHostProvider>();
             var mockSettings = new Mock<ISettings>();
             var mockHostRegistry = new Mock<IHostProviderRegistry>();
@@ -65,7 +68,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
 
             mockSettings.SetupProperty(x => x.RemoteUri);
 
-            mockContext.Setup(x => x.StdIn).Returns(standardInReader);
+            mockStreams.Setup(x => x.In).Returns(standardInReader);
+            mockContext.Setup(x => x.Streams).Returns(mockStreams.Object);
             mockContext.Setup(x => x.Trace).Returns(Mock.Of<ITrace>());
             mockContext.Setup(x => x.Settings).Returns(mockSettings.Object);
 

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/StoreCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/StoreCommandTests.cs
@@ -52,7 +52,10 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
             providerMock.Setup(x => x.StoreCredentialAsync(It.IsAny<InputArguments>()))
                         .Returns(Task.CompletedTask);
             var providerRegistry = new TestHostProviderRegistry {Provider = providerMock.Object};
-            var context = new TestCommandContext {StdIn = stdin};
+            var context = new TestCommandContext
+            {
+                Streams = {In = stdin}
+            };
 
             string[] cmdArgs = {"store"};
             var command = new StoreCommand(providerRegistry);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
+using System.Net;
 using System.Net.Http;
+using Moq;
+using Microsoft.Git.CredentialManager.Tests.Objects;
 using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests
@@ -10,7 +14,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void HttpClientFactory_GetClient_SetsDefaultHeaders()
         {
-            var factory = new HttpClientFactory();
+            var factory = new HttpClientFactory(Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
 
             HttpClient client = factory.CreateClient();
 
@@ -22,12 +26,105 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void HttpClientFactory_GetClient_MultipleCalls_ReturnsNewInstance()
         {
-            var factory = new HttpClientFactory();
+            var factory = new HttpClientFactory(Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
 
             HttpClient client1 = factory.CreateClient();
             HttpClient client2 = factory.CreateClient();
 
             Assert.NotSame(client1, client2);
+        }
+
+        [Fact]
+        public void HttpClientFactory_TryCreateProxy_NoProxy_ReturnsFalseOutNull()
+        {
+            const string repoPath = "/tmp/repos/foo";
+            const string repoRemote  = "https://remote.example.com/foo.git";
+            var repoRemoteUri = new Uri(repoRemote);
+
+            var settings = new TestSettings
+            {
+                RemoteUri = repoRemoteUri,
+                RepositoryPath = repoPath
+            };
+            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+
+            bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
+
+            Assert.False(result);
+            Assert.Null(proxy);
+        }
+
+        [Fact]
+        public void HttpClientFactory_TryCreateProxy_ProxyNoCredentials_ReturnsTrueOutProxyWithUrlDefaultCredentials()
+        {
+            const string repoPath = "/tmp/repos/foo";
+            const string repoRemote = "https://remote.example.com/foo.git";
+            var repoRemoteUri = new Uri(repoRemote);
+
+            string proxyConfigString = "https://proxy.example.com/git";
+            string expectedProxyUrl = proxyConfigString;
+
+            var settings = new TestSettings
+            {
+                RemoteUri = repoRemoteUri,
+                RepositoryPath = repoPath,
+                ProxyConfiguration = new Uri(proxyConfigString)
+            };
+            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+
+            bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
+
+            Assert.True(result);
+            Assert.NotNull(proxy);
+            var configuredProxyUrl = proxy.GetProxy(repoRemoteUri);
+            Assert.Equal(expectedProxyUrl, configuredProxyUrl.ToString());
+
+            AssertDefaultCredentials(proxy.Credentials);
+        }
+
+        [Fact]
+        public void HttpClientFactory_TryCreateProxy_ProxyWithCredentials_ReturnsTrueOutProxyWithUrlConfiguredCredentials()
+        {
+            const string proxyScheme = "https";
+            const string proxyUser   = "john.doe";
+            const string proxyPass   = "letmein";
+            const string proxyHost   = "proxy.example.com/git";
+            const string repoPath    = "/tmp/repos/foo";
+            const string repoRemote  = "https://remote.example.com/foo.git";
+
+            string proxyConfigString = $"{proxyScheme}://{proxyUser}:{proxyPass}@{proxyHost}";
+            string expectedProxyUrl  = $"{proxyScheme}://{proxyHost}";
+            var repoRemoteUri = new Uri(repoRemote);
+
+            var settings = new TestSettings
+            {
+                RemoteUri = repoRemoteUri,
+                RepositoryPath = repoPath,
+                ProxyConfiguration = new Uri(proxyConfigString)
+            };
+            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+
+            bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
+
+            Assert.True(result);
+            Assert.NotNull(proxy);
+            var configuredProxyUrl = proxy.GetProxy(repoRemoteUri);
+            Assert.Equal(expectedProxyUrl, configuredProxyUrl.ToString());
+
+            Assert.NotNull(proxy.Credentials);
+            Assert.IsType<NetworkCredential>(proxy.Credentials);
+            var configuredCredentials = (NetworkCredential) proxy.Credentials;
+            Assert.Equal(proxyUser, configuredCredentials.UserName);
+            Assert.Equal(proxyPass, configuredCredentials.Password);
+        }
+
+        private static void AssertDefaultCredentials(ICredentials credentials)
+        {
+            var netCred = (NetworkCredential) credentials;
+
+            Assert.Equal(string.Empty, netCred.Domain);
+            Assert.Equal(string.Empty, netCred.UserName);
+            Assert.Equal(string.Empty, netCred.Password);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -192,6 +192,266 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public void Settings_ProxyConfiguration_Unset_ReturnsNull()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri value = settings.GetProxyConfiguration(out _);
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void Settings_ProxyConfiguration_GcmHttpConfig_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.HttpProxy;
+            var remoteUri = new Uri(remoteUrl);
+
+            var expectedValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = expectedValue.ToString()
+            });
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+
+            Assert.Equal(expectedValue, actualValue);
+            Assert.True(actualIsDeprecated);
+        }
+
+        [Fact]
+        public void Settings_ProxyConfiguration_GcmHttpsConfig_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "https://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.HttpsProxy;
+            var remoteUri = new Uri(remoteUrl);
+
+            var expectedValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = expectedValue.ToString()
+            });
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+
+            Assert.Equal(expectedValue, actualValue);
+            Assert.True(actualIsDeprecated);
+        }
+
+        [Fact]
+        public void Settings_ProxyConfiguration_GitHttpConfig_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Http.SectionName;
+            const string property = Constants.GitConfiguration.Http.Proxy;
+            var remoteUri = new Uri(remoteUrl);
+
+            var expectedValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>());
+            var git = new TestGit(new Dictionary<string, string>
+            {
+                [$"{section}.{property}"] = expectedValue.ToString()
+            });
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+
+            Assert.Equal(expectedValue, actualValue);
+            Assert.False(actualIsDeprecated);
+        }
+
+        [Fact]
+        public void Settings_ProxyConfiguration_CurlHttpEnvar_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var expectedValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.CurlHttpProxy] = expectedValue.ToString()
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+
+            Assert.Equal(expectedValue, actualValue);
+            Assert.False(actualIsDeprecated);
+        }
+
+        [Fact]
+        public void Settings_ProxyConfiguration_CurlHttpsEnvar_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "https://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var expectedValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.CurlHttpsProxy] = expectedValue.ToString()
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+
+            Assert.Equal(expectedValue, actualValue);
+            Assert.False(actualIsDeprecated);
+        }
+
+        [Fact]
+        public void Settings_TryGetProxy_CurlAllEnvar_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "https://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var expectedValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.CurlAllProxy] = expectedValue.ToString()
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+
+            Assert.Equal(expectedValue, actualValue);
+            Assert.False(actualIsDeprecated);
+        }
+
+        [Fact]
+        public void Settings_ProxyConfiguration_LegacyGcmEnvar_ReturnsValue()
+        {
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var expectedValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new EnvironmentVariables(new Dictionary<string, string>
+            {
+                [Constants.EnvironmentVariables.GcmHttpProxy] = expectedValue.ToString()
+            });
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri,
+                RepositoryPath = repositoryPath
+            };
+            Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+
+            Assert.Equal(expectedValue, actualValue);
+            Assert.True(actualIsDeprecated);
+        }
+
+        [Fact]
+        public void Settings_ProxyConfiguration_Precedence_ReturnsValue()
+        {
+            // 1. GCM proxy Git configuration (deprecated)
+            //      credential.httpsProxy
+            //      credential.httpProxy
+            // 2. Standard Git configuration
+            //      http.proxy
+            // 3. cURL environment variables
+            //      HTTPS_PROXY
+            //      HTTP_PROXY
+            //      ALL_PROXY
+            // 4. GCM proxy environment variable (deprecated)
+            //      GCM_HTTP_PROXY
+
+            const string repositoryPath = "/tmp/repos/foo/.git";
+            const string remoteUrl = "http://example.com/foo.git";
+            var remoteUri = new Uri(remoteUrl);
+
+            var value1 = new Uri("http://proxy1.example.com");
+            var value2 = new Uri("http://proxy2.example.com");
+            var value3 = new Uri("http://proxy3.example.com");
+            var value4 = new Uri("http://proxy4.example.com");
+
+            var envarDict = new Dictionary<string, string>();
+            var configDict = new Dictionary<string, string>();
+
+            void RunTest(Uri expectedValue)
+            {
+                var settings = new Settings(new EnvironmentVariables(envarDict), new TestGit(configDict))
+                {
+                    RemoteUri = remoteUri,
+                    RepositoryPath = repositoryPath
+                };
+                Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
+                Assert.Equal(expectedValue, actualValue);
+            }
+
+             // Test case 1: cURL environment variables > GCM_HTTP_PROXY
+            envarDict[Constants.EnvironmentVariables.GcmHttpProxy] = value1.ToString();
+            envarDict[Constants.EnvironmentVariables.CurlHttpProxy] = value2.ToString();
+            RunTest(value2);
+
+             // Test case 2: http.proxy > cURL environment variables
+            configDict[$"{Constants.GitConfiguration.Http.SectionName}.{Constants.GitConfiguration.Http.Proxy}"] = value3.ToString();
+            RunTest(value3);
+
+             // Test case 3: credential.httpProxy > http.proxy
+            configDict[$"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.HttpProxy}"] = value4.ToString();
+            RunTest(value4);
+        }
+
+        [Fact]
         public void Settings_ProviderOverride_Unset_ReturnsNull()
         {
             const string repositoryPath = "/tmp/repos/foo/.git";

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
@@ -28,5 +28,36 @@ namespace Microsoft.Git.CredentialManager.Tests
             string[] actual = UriExtensions.GetGitConfigurationScopes(startUri).ToArray();
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData("http://example.com", false, null, null)]
+
+        [InlineData("http://john.doe:password123@example.com",
+            true, "john.doe", "password123")]
+
+        [InlineData("http://john.doe@example.com",
+            true, "john.doe", null)]
+
+        [InlineData("http://john.doe:@example.com",
+            true, "john.doe", "")]
+
+        [InlineData("http://:password123@example.com",
+            true, "", "password123")]
+
+        [InlineData("http://john.doe:::password123@example.com",
+            true, "john.doe", "::password123")]
+
+        [InlineData("http://john%20doe:password%20123@example.com",
+            true, "john doe", "password 123")]
+        public void UriExtensions_GetUserInfo(string input, bool expectedResult, string expectedUser, string expectedPass)
+        {
+            var uri = new Uri(input);
+
+            bool actualResult = UriExtensions.TryGetUserInfo(uri, out string actualUser, out string actualPass);
+
+            Assert.Equal(expectedResult, actualResult);
+            Assert.Equal(expectedUser, actualUser);
+            Assert.Equal(expectedPass, actualPass);
+        }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
-using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Commands;
 using Microsoft.Git.CredentialManager.Interop;
@@ -40,8 +39,8 @@ namespace Microsoft.Git.CredentialManager
 
             if (args.Length == 0)
             {
-                Context.StdError.WriteLine("Missing command.");
-                HelpCommand.PrintUsage(Context.StdError);
+                Context.Streams.Error.WriteLine("Missing command.");
+                HelpCommand.PrintUsage(Context.Streams.Error);
                 return -1;
             }
 
@@ -70,8 +69,8 @@ namespace Microsoft.Git.CredentialManager
                 }
             }
 
-            Context.StdError.WriteLine("Unrecognized command '{0}'.", args[0]);
-            HelpCommand.PrintUsage(Context.StdError);
+            Context.Streams.Error.WriteLine("Unrecognized command '{0}'.", args[0]);
+            HelpCommand.PrintUsage(Context.Streams.Error);
             return -1;
         }
 
@@ -91,10 +90,10 @@ namespace Microsoft.Git.CredentialManager
             switch (ex)
             {
                 case InteropException interopEx:
-                    Context.StdError.WriteLine("fatal: {0} [0x{1:x}]", interopEx.Message, interopEx.ErrorCode);
+                    Context.Streams.Error.WriteLine("fatal: {0} [0x{1:x}]", interopEx.Message, interopEx.ErrorCode);
                     break;
                 default:
-                    Context.StdError.WriteLine("fatal: {0}", ex.Message);
+                    Context.Streams.Error.WriteLine("fatal: {0}", ex.Message);
                     break;
             }
 

--- a/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Git.CredentialManager
             // Launch debugger
             if (Context.Settings.IsDebuggingEnabled)
             {
-                Context.StdError.WriteLine("Waiting for debugger to be attached...");
+                Context.Streams.Error.WriteLine("Waiting for debugger to be attached...");
                 WaitForDebuggerAttached();
 
                 // Now the debugger is attached, break!
@@ -41,7 +41,7 @@ namespace Microsoft.Git.CredentialManager
             {
                 if (traceValue.IsTruthy()) // Trace to stderr
                 {
-                    Context.Trace.AddListener(Context.StdError);
+                    Context.Trace.AddListener(Context.Streams.Error);
                 }
                 else if (Path.IsPathRooted(traceValue)) // Trace to a file
                 {
@@ -54,12 +54,12 @@ namespace Microsoft.Git.CredentialManager
                     }
                     catch (Exception ex)
                     {
-                        Context.StdError.WriteLine($"warning: unable to trace to file '{traceValue}': {ex.Message}");
+                        Context.Streams.Error.WriteLine($"warning: unable to trace to file '{traceValue}': {ex.Message}");
                     }
                 }
                 else
                 {
-                    Context.StdError.WriteLine($"warning: unknown value for {Constants.EnvironmentVariables.GcmTrace} '{traceValue}'");
+                    Context.Streams.Error.WriteLine($"warning: unknown value for {Constants.EnvironmentVariables.GcmTrace} '{traceValue}'");
                 }
             }
 

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -21,19 +21,9 @@ namespace Microsoft.Git.CredentialManager
         ISettings Settings { get; }
 
         /// <summary>
-        /// The standard input text stream from the calling process, typically Git.
+        /// Standard I/O text streams, typically connected to the parent Git process.
         /// </summary>
-        TextReader StdIn { get; }
-
-        /// <summary>
-        /// The standard output text stream connected back to the calling process, typically Git.
-        /// </summary>
-        TextWriter StdOut { get; }
-
-        /// <summary>
-        /// The standard error text stream connected back to the calling process, typically Git.
-        /// </summary>
-        TextWriter StdError { get; }
+        IStandardStreams Streams { get; }
 
         /// <summary>
         /// The attached terminal (TTY) to this process tree.
@@ -66,16 +56,9 @@ namespace Microsoft.Git.CredentialManager
     /// </summary>
     public class CommandContext : ICommandContext
     {
-        private const string LineFeed  = "\n";
-
-        private static readonly Encoding Utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
-        private TextReader _stdIn;
-        private TextWriter _stdOut;
-        private TextWriter _stdErr;
-
         public CommandContext()
         {
+            Streams = new StandardStreams();
             Trace = new Trace();
             FileSystem = new FileSystem();
 
@@ -112,52 +95,7 @@ namespace Microsoft.Git.CredentialManager
 
         public ISettings Settings { get; }
 
-        public TextReader StdIn
-        {
-            get
-            {
-                if (_stdIn == null)
-                {
-                    _stdIn = new StreamReader(Console.OpenStandardInput(), Utf8NoBomEncoding);
-                }
-
-                return _stdIn;
-            }
-        }
-
-        public TextWriter StdOut
-        {
-            get
-            {
-                if (_stdOut == null)
-                {
-                    _stdOut = new StreamWriter(Console.OpenStandardOutput(), Utf8NoBomEncoding)
-                    {
-                        AutoFlush = true,
-                        NewLine = LineFeed,
-                    };
-                }
-
-                return _stdOut;
-            }
-        }
-
-        public TextWriter StdError
-        {
-            get
-            {
-                if (_stdErr == null)
-                {
-                    _stdErr = new StreamWriter(Console.OpenStandardError(), Utf8NoBomEncoding)
-                    {
-                        AutoFlush = true,
-                        NewLine = LineFeed,
-                    };
-                }
-
-                return _stdErr;
-            }
-        }
+        public IStandardStreams Streams { get; }
 
         public ITerminal Terminal { get; }
 

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Git.CredentialManager
                 RepositoryPath = git.GetRepositoryPath(FileSystem.GetCurrentDirectory())
             };
 
-            HttpClientFactory = new HttpClientFactory();
+            HttpClientFactory = new HttpClientFactory(Trace, Settings, Streams);
 
             if (PlatformUtils.IsWindows())
             {

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Git.CredentialManager.Commands
 
         protected HostProviderCommandBase(IHostProviderRegistry hostProviderRegistry)
         {
+            EnsureArgument.NotNull(hostProviderRegistry, nameof(hostProviderRegistry));
+
             _hostProviderRegistry = hostProviderRegistry;
         }
 

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Git.CredentialManager.Commands
 
             // Parse standard input arguments
             // git-credential treats the keys as case-sensitive; so should we.
-            IDictionary<string, string> inputDict = await context.StdIn.ReadDictionaryAsync(StringComparer.Ordinal);
+            IDictionary<string, string> inputDict = await context.Streams.In.ReadDictionaryAsync(StringComparer.Ordinal);
             var input = new InputArguments(inputDict);
 
             // Set the remote URI to scope settings to throughout the process from now on

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Git.CredentialManager.Commands
             output["password"] = credential.Password;
 
             // Write the values to standard out
-            context.StdOut.WriteDictionary(output);
+            context.Streams.Out.WriteDictionary(output);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/HelpCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/HelpCommand.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Git.CredentialManager.Commands
 
         public override Task ExecuteAsync(ICommandContext context, string[] args)
         {
-            context.StdOut.WriteLine(Constants.GetProgramHeader());
+            context.Streams.Out.WriteLine(Constants.GetProgramHeader());
 
-            PrintUsage(context.StdOut);
+            PrintUsage(context.Streams.Out);
 
             return Task.CompletedTask;
         }

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/VersionCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/VersionCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Git.CredentialManager.Commands
         {
             string appHeader = Constants.GetProgramHeader();
 
-            context.StdOut.WriteLine(appHeader);
+            context.Streams.Out.WriteLine(appHeader);
 
             return Task.CompletedTask;
         }

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Git.CredentialManager
             public const string GcmAuthority       = "GCM_AUTHORITY";
             public const string GitTerminalPrompts = "GIT_TERMINAL_PROMPT";
             public const string GcmAllowWia        = "GCM_ALLOW_WINDOWSAUTH";
+            public const string CurlAllProxy       = "ALL_PROXY";
+            public const string CurlHttpProxy      = "HTTP_PROXY";
+            public const string CurlHttpsProxy     = "HTTPS_PROXY";
+            public const string GcmHttpProxy       = "GCM_HTTP_PROXY";
+            public const string GitSslNoVerify     = "GIT_SSL_NO_VERIFY";
         }
 
         public static class Http
@@ -44,19 +49,24 @@ namespace Microsoft.Git.CredentialManager
                 public const string Provider    = "provider";
                 public const string Authority   = "authority";
                 public const string AllowWia    = "allowWindowsAuth";
+                public const string HttpProxy   = "httpProxy";
+                public const string HttpsProxy  = "httpsProxy";
             }
 
             public static class Http
             {
                 public const string SectionName = "http";
                 public const string Proxy = "proxy";
+                public const string SslVerify = "sslVerify";
             }
         }
 
         public static class HelpUrls
         {
-            public const string GcmProjectUrl = "https://aka.ms/gcmcore";
+            public const string GcmProjectUrl          = "https://aka.ms/gcmcore";
             public const string GcmAuthorityDeprecated = "https://aka.ms/gcmcore-authority";
+            public const string GcmHttpProxyGuide      = "https://aka.ms/gcmcore-httpproxy";
+            public const string GcmTlsVerification     = "https://aka.ms/gcmcore-tlsverify";
         }
 
         private static string _gcmVersion;

--- a/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Git.CredentialManager
                     if (provider is null)
                     {
                         _context.Trace.WriteLine($"No host provider was found with ID '{providerId}'.. falling back to auto-detection.");
-                        _context.StdError.WriteLine($"warning: a host provider override was set but no such provider '{providerId}' was found. Falling back to auto-detection.");
+                        _context.Streams.Error.WriteLine($"warning: a host provider override was set but no such provider '{providerId}' was found. Falling back to auto-detection.");
                     }
                     else
                     {
@@ -104,8 +104,8 @@ namespace Microsoft.Git.CredentialManager
             else if (_context.Settings.LegacyAuthorityOverride is string authority)
             {
                 _context.Trace.WriteLine($"Host provider authority override was set authority='{authority}'");
-                _context.StdError.WriteLine("warning: the `credential.authority` and `GCM_AUTHORITY` settings are deprecated.");
-                _context.StdError.WriteLine($"warning: see {Constants.HelpUrls.GcmAuthorityDeprecated} for more information.");
+                _context.Streams.Error.WriteLine("warning: the `credential.authority` and `GCM_AUTHORITY` settings are deprecated.");
+                _context.Streams.Error.WriteLine($"warning: see {Constants.HelpUrls.GcmAuthorityDeprecated} for more information.");
 
                 if (!StringComparer.OrdinalIgnoreCase.Equals(Constants.AuthorityIdAuto, authority))
                 {
@@ -114,7 +114,7 @@ namespace Microsoft.Git.CredentialManager
                     if (provider is null)
                     {
                         _context.Trace.WriteLine($"No host provider was found with authority '{authority}'.. falling back to auto-detection.");
-                        _context.StdError.WriteLine($"warning: a supported authority override was set but no such provider supporting authority '{authority}' was found. Falling back to auto-detection.");
+                        _context.Streams.Error.WriteLine($"warning: a supported authority override was set but no such provider supporting authority '{authority}' was found. Falling back to auto-detection.");
                     }
                     else
                     {

--- a/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 
@@ -20,6 +23,9 @@ namespace Microsoft.Git.CredentialManager
         /// Creating a new <see cref="HttpClient"/> consumes one free socket which may not be released
         /// by the Operating System until sometime after the client is disposed, leading to possible free
         /// socket exhaustion.
+        /// <para/>
+        /// The client instance is configured for use behind a proxy using Git's http.proxy configuration
+        /// for the local repository (the current working directory), if found.
         /// </remarks>
         /// <returns>New client instance with default headers.</returns>
         HttpClient CreateClient();
@@ -27,10 +33,58 @@ namespace Microsoft.Git.CredentialManager
 
     public class HttpClientFactory : IHttpClientFactory
     {
+        private readonly ITrace _trace;
+        private readonly ISettings _settings;
+        private readonly IStandardStreams _streams;
+
+        public HttpClientFactory(ITrace trace, ISettings settings, IStandardStreams streams)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(settings, nameof(settings));
+            EnsureArgument.NotNull(streams, nameof(streams));
+
+            _trace = trace;
+            _settings = settings;
+            _streams = streams;
+        }
+
         public HttpClient CreateClient()
         {
-            // Initialize a new HttpClient
-            var client = new HttpClient();
+            _trace.WriteLine("Creating new HTTP client instance...");
+
+            HttpClientHandler handler;
+
+            if (TryCreateProxy(out IWebProxy proxy))
+            {
+                _trace.WriteLine("HTTP client is using the configured proxy.");
+
+                handler = new HttpClientHandler
+                {
+                    Proxy = proxy,
+                    UseProxy = true
+                };
+            }
+            else
+            {
+                handler = new HttpClientHandler();
+            }
+
+            if (!_settings.IsCertificateVerificationEnabled)
+            {
+                _trace.WriteLine("TLS certificate verification has been disabled.");
+                _streams.Error.WriteLine("warning: ┌──────────────── SECURITY WARNING ───────────────┐");
+                _streams.Error.WriteLine("warning: │ TLS certificate verification has been disabled! │");
+                _streams.Error.WriteLine("warning: └─────────────────────────────────────────────────┘");
+                _streams.Error.WriteLine($"warning: HTTPS connections may not be secure. See {Constants.HelpUrls.GcmTlsVerification} for more information.");
+
+#if NETFRAMEWORK
+                ServicePointManager.ServerCertificateValidationCallback = (req, cert, chain, errors) => true;
+#elif NETSTANDARD
+                handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true;
+#endif
+            }
+
+            var client = new HttpClient(handler);
 
             // Add default headers
             client.DefaultRequestHeaders.UserAgent.ParseAdd(Constants.GetHttpUserAgent());
@@ -40,6 +94,72 @@ namespace Microsoft.Git.CredentialManager
             };
 
             return client;
+        }
+
+        /// <summary>
+        /// Try to create an <see cref="IWebProxy"/> object from the configuration specified by environment variables,
+        /// or Git configuration for the specified repository, current user, and system.
+        /// </summary>
+        /// <param name="proxy">Configured <see cref="IWebProxy"/>, or null if no proxy configuration was found.</param>
+        /// <returns>True if proxy configuration was found, false otherwise.</returns>
+        public bool TryCreateProxy(out IWebProxy proxy)
+        {
+            // Try to extract the proxy URI from the environment or Git config
+            if (_settings.GetProxyConfiguration(out bool isDeprecatedConfiguration) is Uri proxyConfig)
+            {
+                // Inform the user if they are using a deprecated proxy configuration
+                if (isDeprecatedConfiguration)
+                {
+                    _trace.WriteLine("Using a deprecated proxy configuration.");
+                    _streams.Error.WriteLine($"warning: Using a deprecated proxy configuration. See {Constants.HelpUrls.GcmHttpProxyGuide} for more information.");
+                }
+
+                // Strip the userinfo, query, and fragment parts of the Uri retaining only the scheme, host, port, and path.
+                Uri proxyUri = GetProxyUri(proxyConfig);
+
+                // Dictionary of proxy info for tracing
+                var dict = new Dictionary<string, string> {["uri"] = proxyUri.ToString()};
+
+                // Try to extract and configure proxy credentials from the configured URI
+                if (proxyConfig.TryGetUserInfo(out string userName, out string password))
+                {
+                    proxy = new WebProxy(proxyUri)
+                    {
+                        Credentials = new NetworkCredential(userName, password)
+                    };
+
+                    // Add user/pass info to the trace dictionary
+                    if (!string.IsNullOrWhiteSpace(userName)) dict["username"] = userName;
+                    if (!string.IsNullOrEmpty(password))      dict["password"] = password;
+                }
+                else
+                {
+                    proxy = new WebProxy(proxyUri)
+                    {
+                        UseDefaultCredentials = true
+                    };
+                }
+
+                // Tracer out proxy info dictionary
+                _trace.WriteLine("Created a WebProxy instance:");
+                _trace.WriteDictionarySecrets(dict, new[] {"password"});
+
+                return true;
+            }
+
+            proxy = null;
+            return false;
+        }
+
+        private static Uri GetProxyUri(Uri uri)
+        {
+            return new UriBuilder(uri)
+            {
+                UserName = string.Empty,
+                Password = string.Empty,
+                Query    = string.Empty,
+                Fragment = string.Empty,
+            }.Uri;
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/StandardStreams.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/StandardStreams.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Represents the standard I/O streams (input, output, error) of a process.
+    /// </summary>
+    public interface IStandardStreams
+    {
+        /// <summary>
+        /// The standard input text stream from the calling process, typically Git.
+        /// </summary>
+        TextReader In { get; }
+
+        /// <summary>
+        /// The standard output text stream connected back to the calling process, typically Git.
+        /// </summary>
+        TextWriter Out { get; }
+
+        /// <summary>
+        /// The standard error text stream connected back to the calling process, typically Git.
+        /// </summary>
+        TextWriter Error { get; }
+    }
+
+    public class StandardStreams : IStandardStreams
+    {
+        private const string LineFeed  = "\n";
+
+        private static readonly Encoding Utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        private TextReader _stdIn;
+        private TextWriter _stdOut;
+        private TextWriter _stdErr;
+
+        public TextReader In
+        {
+            get
+            {
+                if (_stdIn == null)
+                {
+                    _stdIn = new StreamReader(Console.OpenStandardInput(), Utf8NoBomEncoding);
+                }
+
+                return _stdIn;
+            }
+        }
+
+        public TextWriter Out
+        {
+            get
+            {
+                if (_stdOut == null)
+                {
+                    _stdOut = new StreamWriter(Console.OpenStandardOutput(), Utf8NoBomEncoding)
+                    {
+                        AutoFlush = true,
+                        NewLine = LineFeed,
+                    };
+                }
+
+                return _stdOut;
+            }
+        }
+
+        public TextWriter Error
+        {
+            get
+            {
+                if (_stdErr == null)
+                {
+                    _stdErr = new StreamWriter(Console.OpenStandardError(), Utf8NoBomEncoding)
+                    {
+                        AutoFlush = true,
+                        NewLine = LineFeed,
+                    };
+                }
+
+                return _stdErr;
+            }
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
@@ -2,11 +2,42 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using System.Net;
 
 namespace Microsoft.Git.CredentialManager
 {
     public static class UriExtensions
     {
+        public static bool TryGetUserInfo(this Uri uri, out string userName, out string password)
+        {
+            EnsureArgument.NotNull(uri, nameof(uri));
+            userName = null;
+            password = null;
+
+            if (string.IsNullOrWhiteSpace(uri.UserInfo))
+            {
+                return false;
+            }
+
+            /* According to RFC 3986 section 3.2.1 (https://tools.ietf.org/html/rfc3986#section-3.2.1)
+             * the user information component of a URI should look like:
+             *
+             *     url-encode(username):url-encode(password)
+             */
+            string[] split = uri.UserInfo.Split(new[] {':'}, count: 2);
+
+            if (split.Length > 0)
+            {
+                userName = WebUtility.UrlDecode(split[0]);
+            }
+            if (split.Length > 1)
+            {
+                password = WebUtility.UrlDecode(split[1]);
+            }
+
+            return split.Length > 0;
+        }
+
         public static IEnumerable<string> GetGitConfigurationScopes(this Uri uri)
         {
             EnsureArgument.NotNull(uri, nameof(uri));

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -1,32 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System.IO;
-using System.Text;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestCommandContext : ICommandContext
     {
         public TestSettings Settings { get; set; } = new TestSettings();
-        public string StdIn { get; set; } = string.Empty;
-        public StringBuilder StdOut { get; set; } = new StringBuilder();
-        public StringBuilder StdError { get; set; } = new StringBuilder();
+        public TestStandardStreams Streams { get; set; } = new TestStandardStreams();
         public TestTerminal Terminal { get; set; } = new TestTerminal();
         public ITrace Trace { get; set; } = new NullTrace();
         public TestFileSystem FileSystem { get; set; } = new TestFileSystem();
         public TestCredentialStore CredentialStore { get; set; } = new TestCredentialStore();
         public TestHttpClientFactory HttpClientFactory { get; set; } = new TestHttpClientFactory();
-        public string NewLine { get; set; } = "\n";
 
         #region ICommandContext
 
+        IStandardStreams ICommandContext.Streams => Streams;
+
         ISettings ICommandContext.Settings => Settings;
-
-        TextReader ICommandContext.StdIn => new StringReader(StdIn);
-
-        TextWriter ICommandContext.StdOut => new StringWriter(StdOut){NewLine = NewLine};
-
-        TextWriter ICommandContext.StdError => new StringWriter(StdError){NewLine = NewLine};
 
         ITerminal ICommandContext.Terminal => Terminal;
 

--- a/src/shared/TestInfrastructure/Objects/TestHttpClientFactory.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHttpClientFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System.Net;
 using System.Net.Http;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public bool IsWindowsIntegratedAuthenticationEnabled { get; set; } = true;
 
+        public bool IsCertificateVerificationEnabled { get; set; } = true;
+
+        public Uri ProxyConfiguration { get; set; }
+
+        public bool IsDeprecatedProxyConfiguration { get; set; }
+
         #region ISettings
 
         public string RepositoryPath { get; set; }
@@ -47,6 +53,14 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         string ISettings.LegacyAuthorityOverride => LegacyAuthorityOverride;
 
         bool ISettings.IsWindowsIntegratedAuthenticationEnabled => IsWindowsIntegratedAuthenticationEnabled;
+
+        bool ISettings.IsCertificateVerificationEnabled => IsCertificateVerificationEnabled;
+
+        Uri ISettings.GetProxyConfiguration(out bool isDeprecatedConfiguration)
+        {
+            isDeprecatedConfiguration = IsDeprecatedProxyConfiguration;
+            return ProxyConfiguration;
+        }
 
         #endregion
     }

--- a/src/shared/TestInfrastructure/Objects/TestStandardStreams.cs
+++ b/src/shared/TestInfrastructure/Objects/TestStandardStreams.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Git.CredentialManager.Tests.Objects
+{
+    public class TestStandardStreams : IStandardStreams
+    {
+        public string NewLine { get; set; } = "\n";
+        public string In { get; set; } = string.Empty;
+        public StringBuilder Out { get; set; } = new StringBuilder();
+        public StringBuilder Error { get; set; } = new StringBuilder();
+
+        #region IStandardStreams
+
+        TextReader IStandardStreams.In => new StringReader(In);
+
+        TextWriter IStandardStreams.Out => new StringWriter(Out){NewLine = NewLine};
+
+        TextWriter IStandardStreams.Error => new StringWriter(Error){NewLine = NewLine};
+
+        #endregion
+    }
+}

--- a/src/windows/Microsoft.Authentication.Helper.Windows.Tests/ApplicationTests.cs
+++ b/src/windows/Microsoft.Authentication.Helper.Windows.Tests/ApplicationTests.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Authentication.Helper.Tests
                 ["resource"]    = "test-resource",
             };
 
-            var context = new TestCommandContext {StdIn = DictionaryToString(inputDict)};
+            var context = new TestCommandContext {Streams = {In = DictionaryToString(inputDict)}};
             var app = new TestApplication(context);
 
             int exitCode = await app.RunAsync(new string[0]);
-            IDictionary<string, string> outputDict = ParseDictionary(context.StdOut);
+            IDictionary<string, string> outputDict = ParseDictionary(context.Streams.Out);
 
             Assert.Equal(-1, exitCode);
             Assert.True(outputDict.ContainsKey("error"));
@@ -43,11 +43,11 @@ namespace Microsoft.Authentication.Helper.Tests
                 ["resource"]    = "test-resource",
             };
 
-            var context = new TestCommandContext {StdIn = DictionaryToString(inputDict)};
+            var context = new TestCommandContext {Streams = {In = DictionaryToString(inputDict)}};
             var app = new TestApplication(context);
 
             int exitCode = await app.RunAsync(new string[0]);
-            IDictionary<string, string> outputDict = ParseDictionary(context.StdOut);
+            IDictionary<string, string> outputDict = ParseDictionary(context.Streams.Out);
 
             Assert.Equal(-1, exitCode);
             Assert.True(outputDict.ContainsKey("error"));
@@ -63,11 +63,11 @@ namespace Microsoft.Authentication.Helper.Tests
                 ["resource"]    = "test-resource",
             };
 
-            var context = new TestCommandContext {StdIn = DictionaryToString(inputDict)};
+            var context = new TestCommandContext {Streams = {In = DictionaryToString(inputDict)}};
             var app = new TestApplication(context);
 
             int exitCode = await app.RunAsync(new string[0]);
-            IDictionary<string, string> outputDict = ParseDictionary(context.StdOut);
+            IDictionary<string, string> outputDict = ParseDictionary(context.Streams.Out);
 
             Assert.Equal(-1, exitCode);
             Assert.True(outputDict.ContainsKey("error"));
@@ -83,11 +83,11 @@ namespace Microsoft.Authentication.Helper.Tests
                 ["redirectUri"] = "https://test-redirecturi/",
             };
 
-            var context = new TestCommandContext {StdIn = DictionaryToString(inputDict)};
+            var context = new TestCommandContext {Streams = {In = DictionaryToString(inputDict)}};
             var app = new TestApplication(context);
 
             int exitCode = await app.RunAsync(new string[0]);
-            IDictionary<string, string> outputDict = ParseDictionary(context.StdOut);
+            IDictionary<string, string> outputDict = ParseDictionary(context.Streams.Out);
 
             Assert.Equal(-1, exitCode);
             Assert.True(outputDict.ContainsKey("error"));
@@ -111,7 +111,7 @@ namespace Microsoft.Authentication.Helper.Tests
                 ["resource"]    = expectedResource,
                 ["remoteUrl"]   = expectedRemoteUrl,
             };
-            var context = new TestCommandContext {StdIn = DictionaryToString(inputDict)};
+            var context = new TestCommandContext {Streams = {In = DictionaryToString(inputDict)}};
             var app = new TestApplication(context)
             {
                 GetAccessTokenCallback = (authority, clientId, redirectUri, resource) =>
@@ -125,7 +125,7 @@ namespace Microsoft.Authentication.Helper.Tests
             };
 
             int exitCode = await app.RunAsync(new string[0]);
-            IDictionary<string, string> outputDict = ParseDictionary(context.StdOut);
+            IDictionary<string, string> outputDict = ParseDictionary(context.Streams.Out);
 
             Assert.Equal(0, exitCode);
             Assert.True(outputDict.ContainsKey("accessToken"));

--- a/src/windows/Microsoft.Authentication.Helper.Windows/Application.cs
+++ b/src/windows/Microsoft.Authentication.Helper.Windows/Application.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Authentication.Helper
         {
             try
             {
-                IDictionary<string, string> inputDict = await Context.StdIn.ReadDictionaryAsync(StringComparer.OrdinalIgnoreCase);
+                IDictionary<string, string> inputDict = await Context.Streams.In.ReadDictionaryAsync(StringComparer.OrdinalIgnoreCase);
 
                 string authority   = GetArgument(inputDict, "authority");
                 string clientId    = GetArgument(inputDict, "clientId");
@@ -34,7 +34,7 @@ namespace Microsoft.Authentication.Helper
 
                 var resultDict = new Dictionary<string, string> {["accessToken"] = accessToken};
 
-                Context.StdOut.WriteDictionary(resultDict);
+                Context.Streams.Out.WriteDictionary(resultDict);
 
                 return 0;
             }
@@ -42,7 +42,7 @@ namespace Microsoft.Authentication.Helper
             {
                 var resultDict = new Dictionary<string, string> {["error"] = e.ToString()};
 
-                Context.StdOut.WriteDictionary(resultDict);
+                Context.Streams.Out.WriteDictionary(resultDict);
 
                 return -1;
             }


### PR DESCRIPTION
Use the Git HTTP proxy configuration to create new configured `HttpClient` instances with proxy support.

Introduce the `IWebProxyFactory` component that extracts proxy configuration from Git and the environment to create new `IWebProxy` objects.

Fixes #11