### PR TITLE
Quote bash variables in installation scripts

### DIFF
--- a/src/osx/Installer.Mac/build.sh
+++ b/src/osx/Installer.Mac/build.sh
@@ -8,16 +8,16 @@ echo "Building Installer.Mac..."
 
 # Directories
 THISDIR="$( cd "$(dirname "$0")" ; pwd -P )"
-ROOT="$( cd $THISDIR/../../.. ; pwd -P )"
-SRC=$ROOT/src
-OUT=$ROOT/out
-INSTALLER_SRC=$SRC/osx/Installer.Mac
-INSTALLER_OUT=$OUT/osx/Installer.Mac
+ROOT="$( cd "$THISDIR"/../../.. ; pwd -P )"
+SRC="$ROOT/src"
+OUT="$ROOT/out"
+INSTALLER_SRC="$SRC/osx/Installer.Mac"
+INSTALLER_OUT="$OUT/osx/Installer.Mac"
 
 # Parse script arguments
 for i in "$@"
 do
-case $i in
+case "$i" in
     --configuration=*)
     CONFIGURATION="${i#*=}"
     shift # past argument=value
@@ -33,16 +33,16 @@ esac
 done
 
 # Perform pre-execution checks
-CONFIGURATION=${CONFIGURATION:=Debug}
+CONFIGURATION="${CONFIGURATION:=Debug}"
 if [ -z "$VERSION" ]; then
     die "--version was not set"
 fi
 
-PAYLOAD=$INSTALLER_OUT/pkg/$CONFIGURATION/payload
-PKGOUT=$INSTALLER_OUT/pkg/$CONFIGURATION/gcmcore-osx-$VERSION.pkg
+PAYLOAD="$INSTALLER_OUT/pkg/$CONFIGURATION/payload"
+PKGOUT="$INSTALLER_OUT/pkg/$CONFIGURATION/gcmcore-osx-$VERSION.pkg"
 
 # Layout and pack
-$INSTALLER_SRC/layout.sh --configuration=$CONFIGURATION --output=$PAYLOAD || exit 1
-$INSTALLER_SRC/pack.sh --payload=$PAYLOAD --version=$VERSION --output=$PKGOUT || exit 1
+"$INSTALLER_SRC/layout.sh" --configuration="$CONFIGURATION" --output="$PAYLOAD" || exit 1
+"$INSTALLER_SRC/pack.sh" --payload="$PAYLOAD" --version="$VERSION" --output="$PKGOUT" || exit 1
 
 echo "Build of Installer.Mac complete."

--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -16,12 +16,12 @@ make_absolute () {
 
 # Directories
 THISDIR="$( cd "$(dirname "$0")" ; pwd -P )"
-ROOT="$( cd $THISDIR/../../.. ; pwd -P )"
-SRC=$ROOT/src
-OUT=$ROOT/out
-INSTALLER_SRC=$SRC/osx/Installer.Mac
-MSAUTH_OUT=$OUT/osx/Microsoft.Authentication.Helper.Mac
-GCM_SRC=$SRC/shared/Git-Credential-Manager
+ROOT="$( cd "$THISDIR"/../../.. ; pwd -P )"
+SRC="$ROOT/src"
+OUT="$ROOT/out"
+INSTALLER_SRC="$SRC/osx/Installer.Mac"
+MSAUTH_OUT="$OUT/osx/Microsoft.Authentication.Helper.Mac"
+GCM_SRC="$SRC/shared/Git-Credential-Manager"
 
 # Build parameters
 FRAMEWORK=netcoreapp2.1
@@ -30,7 +30,7 @@ RUNTIME=osx-x64
 # Parse script arguments
 for i in "$@"
 do
-case $i in
+case "$i" in
     --configuration=*)
     CONFIGURATION="${i#*=}"
     shift # past argument=value
@@ -49,7 +49,7 @@ esac
 done
 
 # Perform pre-execution checks
-CONFIGURATION=${CONFIGURATION:=Debug}
+CONFIGURATION="${CONFIGURATION:=Debug}"
 if [ -z "$PAYLOAD" ]; then
 	die "--output was not set"
 fi
@@ -57,45 +57,45 @@ if [ -z "$SYMBOLOUT" ]; then
     SYMBOLOUT="$PAYLOAD.sym"
 fi
 
-MSAUTH_BIN=$MSAUTH_OUT/bin/$CONFIGURATION/native
-MSAUTH_SYM=$MSAUTH_OUT/bin/$CONFIGURATION/native.sym
-if [ ! -d $MSAUTH_BIN ]; then
+MSAUTH_BIN="$MSAUTH_OUT/bin/$CONFIGURATION/native"
+MSAUTH_SYM="$MSAUTH_OUT/bin/$CONFIGURATION/native.sym"
+if [ ! -d "$MSAUTH_BIN" ]; then
 	die "No native helper binaries found. Did you build?"
 fi
 
 # Cleanup any old payload directory
-if [ -d $PAYLOAD ]; then
+if [ -d "$PAYLOAD" ]; then
     echo "Cleaning old payload directory '$PAYLOAD'..."
-    rm -rf $PAYLOAD
+    rm -rf "$PAYLOAD"
 fi
 
 # Ensure payload and symbol directories exists
-mkdir -p $PAYLOAD $SYMBOLOUT
+mkdir -p "$PAYLOAD" "$SYMBOLOUT"
 
 # Copy uninstaller script
 echo "Copying uninstall script..."
-cp $INSTALLER_SRC/uninstall.sh $PAYLOAD || exit 1
+cp "$INSTALLER_SRC/uninstall.sh" "$PAYLOAD" || exit 1
 
 # Copy native authentication helper executables
 echo "Copying native helpers..."
-cp -R $MSAUTH_BIN/ $PAYLOAD || exit 1
+cp -R "$MSAUTH_BIN/" "$PAYLOAD" || exit 1
 
 # Publish core application executables
 echo "Publishing core application..."
-dotnet publish $GCM_SRC \
-	--configuration=$CONFIGURATION \
-	--framework=$FRAMEWORK \
-	--runtime=$RUNTIME \
-	--output=$(make_absolute $PAYLOAD) || exit 1
+dotnet publish "$GCM_SRC" \
+	--configuration="$CONFIGURATION" \
+	--framework="$FRAMEWORK" \
+	--runtime="$RUNTIME" \
+	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 # Collect symbols
 echo "Collecting managed symbols..."
-mv $PAYLOAD/*.pdb $SYMBOLOUT || exit 1
+mv "$PAYLOAD"/*.pdb "$SYMBOLOUT" || exit 1
 echo "Collecting native symbols..."
-cp -R $MSAUTH_SYM/ $SYMBOLOUT || exit 1
+cp -R "$MSAUTH_SYM/" "$SYMBOLOUT" || exit 1
 
 # Remove any unwanted .DS_Store files
 echo "Removing unnecessary files..."
-find $PAYLOAD -name '*.DS_Store' -type f -delete || exit 1
+find "$PAYLOAD" -name '*.DS_Store' -type f -delete || exit 1
 
 echo "Layout complete."

--- a/src/osx/Installer.Mac/pack.sh
+++ b/src/osx/Installer.Mac/pack.sh
@@ -6,10 +6,10 @@ die () {
 
 # Directories
 THISDIR="$( cd "$(dirname "$0")" ; pwd -P )"
-ROOT="$( cd $THISDIR/../../.. ; pwd -P )"
-SRC=$ROOT/src
-OUT=$ROOT/out
-INSTALLER_SRC=$SRC/osx/Installer.Mac
+ROOT="$( cd "$THISDIR"/../../.. ; pwd -P )"
+SRC="$ROOT/src"
+OUT="$ROOT/out"
+INSTALLER_SRC="$SRC/osx/Installer.Mac"
 
 # Product information
 IDENTIFIER="com.microsoft.GitCredentialManager"
@@ -18,7 +18,7 @@ INSTALL_LOCATION="/usr/local/share/gcm-core"
 # Parse script arguments
 for i in "$@"
 do
-case $i in
+case "$i" in
     --version=*)
     VERSION="${i#*=}"
     shift # past argument=value
@@ -43,7 +43,7 @@ if [ -z "$VERSION" ]; then
 fi
 if [ -z "$PAYLOAD" ]; then
     die "--payload was not set"
-elif [ ! -d $PAYLOAD ]; then
+elif [ ! -d "$PAYLOAD" ]; then
     die "Could not find '$PAYLOAD'. Did you run layout.sh first?"
 fi
 if [ -z "$PKGOUT" ]; then
@@ -51,21 +51,21 @@ if [ -z "$PKGOUT" ]; then
 fi
 
 # Cleanup any old package file
-if [ -e $PKGOUT ]; then
+if [ -e "$PKGOUT" ]; then
     echo "Deleteing old package '$PKGOUT'..."
-    rm $PKGOUT
+    rm "$PKGOUT"
 fi
 
 # Ensure the parent directory for the package exists
-mkdir -p $(dirname "$PKGOUT")
+mkdir -p "$(dirname "$PKGOUT")"
 
 # Set full read, write, execute permissions for owner and just read and execute permissions for group and other
 echo "Setting file permissions..."
-/bin/chmod -R 755 $PAYLOAD || exit 1
+/bin/chmod -R 755 "$PAYLOAD" || exit 1
 
 # Remove any extended attributes (ACEs)
 echo "Removing extended attributes..."
-/usr/bin/xattr -rc $PAYLOAD || exit 1
+/usr/bin/xattr -rc "$PAYLOAD" || exit 1
 
 # Build installer package
 echo "Building installer package..."

--- a/src/osx/Installer.Mac/scripts/postinstall
+++ b/src/osx/Installer.Mac/scripts/postinstall
@@ -8,7 +8,7 @@ function IsBrewPkgInstalled
     if [ $? -eq 0 ]
     then
         # Check if the package has been installed
-        brew ls --versions $1 > /dev/null
+        brew ls --versions "$1" > /dev/null
         if [ $? -eq 0 ]
         then
             return 0
@@ -27,7 +27,7 @@ fi
 /bin/ln -Fs /usr/local/share/gcm-core/git-credential-manager /usr/local/bin/git-credential-manager
 
 # Set system gitconfig for the current user
-USER_ID=`id -u "${USER}"`
+USER_ID="$(id -u "${USER}")"
 if [ "${COMMAND_LINE_INSTALL}" = "" ]
 then
     /bin/launchctl asuser "${USER_ID}" "${PWD}/configure-git.sh"

--- a/src/osx/Installer.Mac/uninstall.sh
+++ b/src/osx/Installer.Mac/uninstall.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Unconfigure GCM
-HELPER=`git config --system credential.helper`
-if [ $HELPER = "/usr/local/share/gcm-core/git-credential-manager" ]
+HELPER="$(git config --system credential.helper)"
+if [ "$HELPER" = "/usr/local/share/gcm-core/git-credential-manager" ]
 then
 	echo "Resetting credential helper to 'osxkeychain'..."
 	sudo git config --system credential.helper osxkeychain


### PR DESCRIPTION
When running `uninstall.sh` I ran into the issue that bash variables weren't properly quoted so the script produced error messages.  This should fix these problems.