### PR TITLE
Add local cache of Azure Repos organisation authorities

### DIFF
--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposAuthorityCacheTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposAuthorityCacheTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Microsoft.AzureRepos.Tests
+{
+    public class AzureReposAuthorityCacheTests
+    {
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_Null_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(dict);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.GetAuthority(null));
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_NoCachedAuthority_ReturnsNull()
+        {
+            const string key = "org.contoso.authority";
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            string authority = cache.GetAuthority(key);
+
+            Assert.Null(authority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_CachedAuthority_ReturnsAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = expectedAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(dict);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            string actualAuthority = cache.GetAuthority(orgName);
+
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_CachedAuthority_PersistedStoreChanged_ReturnsPersistedAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string oldAuthority = "https://old-login.contoso.com";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = oldAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(dict);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            // Update persisted store after creation of the authority cache
+            store.PersistedStore[key] = expectedAuthority;
+            // The in-memory value should be stale
+            Assert.Equal(oldAuthority, store.MemoryStore[key]);
+
+            string actualAuthority = cache.GetAuthority(orgName);
+
+            // Should have reloaded from the persisted store
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_UpdateAuthority_NoCachedAuthority_SetsAuthorityInPersistedStore()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            cache.UpdateAuthority(orgName, expectedAuthority);
+
+            Assert.True(store.PersistedStore.TryGetValue(key, out string actualAuthority));
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_UpdateAuthority_CachedAuthority_UpdatesAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string oldAuthority = "https://old-login.contoso.com";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = oldAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(dict);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            cache.UpdateAuthority(orgName, expectedAuthority);
+
+            Assert.True(store.PersistedStore.TryGetValue(key, out string actualAuthority));
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_UpdateAuthority_CachedAuthority_PersistedStoreChanged_OverwritesPersistedAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string otherAuthority = "https://alt-login.contoso.com";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            // Persisted store is updated after the authority cache is created
+            store.PersistedStore[key] = otherAuthority;
+
+            cache.UpdateAuthority(orgName, expectedAuthority);
+
+            Assert.True(store.PersistedStore.TryGetValue(key, out string actualAuthority));
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_EraseAuthority_NoCachedAuthority_DoesNothing()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string otherKey = "org.fabrikam.authority";
+            const string otherAuthority = "https://fabrikam.com/login";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [otherKey] = otherAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(dict);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            cache.EraseAuthority(orgName);
+
+            // Other entries should remain in the persisted store
+            Assert.False(store.PersistedStore.ContainsKey(key));
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(otherKey, out string actualOtherAuthority));
+            Assert.Equal(otherAuthority, actualOtherAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_EraseAuthority_CachedAuthority_RemovesAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string authority = "https://login.contoso.com";
+            const string otherKey = "org.fabrikam.authority";
+            const string otherAuthority = "https://fabrikam.com/login";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = authority,
+                [otherKey] = otherAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryValueStore<string, string>(dict);
+            var cache = new AzureReposAuthorityCache(trace, store);
+
+            cache.EraseAuthority(orgName);
+
+            // Only the other entries should remain in the persisted store
+            Assert.False(store.PersistedStore.ContainsKey(key));
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(otherKey, out string actualOtherAuthority));
+            Assert.Equal(otherAuthority, actualOtherAuthority);
+        }
+    }
+}

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AzureRepos.Tests
     public class AzureReposHostProviderTests
     {
         [Fact]
-        public void AzureReposProvider_IsSupported_AzureHost_UnencryptedHttp_ReturnsTrue()
+        public void AzureReposHostProvider_IsSupported_AzureHost_UnencryptedHttp_ReturnsTrue()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -31,7 +31,7 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public void AzureReposProvider_IsSupported_VisualStudioHost_UnencryptedHttp_ReturnsTrue()
+        public void AzureReposHostProvider_IsSupported_VisualStudioHost_UnencryptedHttp_ReturnsTrue()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -47,7 +47,7 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public void AzureReposProvider_IsSupported_AzureHost_WithPath_ReturnsTrue()
+        public void AzureReposHostProvider_IsSupported_AzureHost_WithPath_ReturnsTrue()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -61,7 +61,7 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public void AzureReposProvider_IsSupported_AzureHost_MissingPath_ReturnsTrue()
+        public void AzureReposHostProvider_IsSupported_AzureHost_MissingPath_ReturnsTrue()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -74,7 +74,7 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public void AzureReposProvider_IsSupported_VisualStudioHost_ReturnsTrue()
+        public void AzureReposHostProvider_IsSupported_VisualStudioHost_ReturnsTrue()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -87,7 +87,7 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public void AzureReposProvider_IsSupported_VisualStudioHost_MissingOrgInHost_ReturnsFalse()
+        public void AzureReposHostProvider_IsSupported_VisualStudioHost_MissingOrgInHost_ReturnsFalse()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -100,7 +100,7 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public void AzureReposProvider_IsSupported_NonAzureRepos_ReturnsFalse()
+        public void AzureReposHostProvider_IsSupported_NonAzureRepos_ReturnsFalse()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -114,7 +114,7 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public async Task AzureReposProvider_GetCredentialAsync_UnencryptedHttp_ThrowsException()
+        public async Task AzureReposHostProvider_GetCredentialAsync_UnencryptedHttp_ThrowsException()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -126,14 +126,15 @@ namespace Microsoft.AzureRepos.Tests
             var context = new TestCommandContext();
             var azDevOps = Mock.Of<IAzureDevOpsRestApi>();
             var msAuth = Mock.Of<IMicrosoftAuthentication>();
+            var authorityCache = Mock.Of<IAzureReposAuthorityCache>();
 
-            var provider = new AzureReposHostProvider(context, azDevOps, msAuth);
+            var provider = new AzureReposHostProvider(context, azDevOps, msAuth, authorityCache);
 
             await Assert.ThrowsAsync<Exception>(() => provider.GetCredentialAsync(input));
         }
 
         [Fact]
-        public async Task AzureReposProvider_GetCredentialAsync_ReturnsCredential()
+        public async Task AzureReposHostProvider_GetCredentialAsync_ReturnsCredential()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -163,13 +164,102 @@ namespace Microsoft.AzureRepos.Tests
             msAuthMock.Setup(x => x.GetAccessTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedResource, remoteUri))
                       .ReturnsAsync(accessToken);
 
-            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object);
+            var authorityCache = Mock.Of<IAzureReposAuthorityCache>();
+
+            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCache);
 
             ICredential credential = await provider.GetCredentialAsync(input);
 
             Assert.NotNull(credential);
             Assert.Equal(personalAccessToken, credential.Password);
             // We don't care about the username value
+        }
+
+        [Fact]
+        public async Task AzureReposHostProvider_GetCredentialAsync_UsesAuthorityCache()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "dev.azure.com",
+                ["path"] = "org/proj/_git/repo"
+            });
+
+            var expectedAuthority = "https://login.microsoftonline.com/common";
+
+            var context = new TestCommandContext();
+
+            var azDevOpsMock = new Mock<IAzureDevOpsRestApi>();
+            var msAuthMock = new Mock<IMicrosoftAuthentication>();
+
+            var authorityCacheMock = new Mock<IAzureReposAuthorityCache>();
+            authorityCacheMock.Setup(x => x.GetAuthority(It.IsAny<string>()))
+                              .Returns(expectedAuthority);
+
+            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object);
+
+            await provider.GetCredentialAsync(input);
+
+            authorityCacheMock.Verify(x => x.GetAuthority("org"), Times.Once);
+            authorityCacheMock.VerifyNoOtherCalls();
+            azDevOpsMock.Verify(x => x.GetAuthorityAsync(It.IsAny<Uri>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AzureReposHostProvider_GetCredentialAsync_UpdatesAuthorityCache()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "dev.azure.com",
+                ["path"] = "org/proj/_git/repo"
+            });
+
+            var orgUri = new Uri("https://dev.azure.com/org");
+            var expectedAuthority = "https://login.microsoftonline.com/common";
+
+            var context = new TestCommandContext();
+
+            var azDevOpsMock = new Mock<IAzureDevOpsRestApi>();
+            azDevOpsMock.Setup(x => x.GetAuthorityAsync(orgUri))
+                        .ReturnsAsync(expectedAuthority);
+
+            var msAuthMock = new Mock<IMicrosoftAuthentication>();
+
+            var authorityCacheMock = new Mock<IAzureReposAuthorityCache>();
+            authorityCacheMock.Setup(x => x.GetAuthority(It.IsAny<string>()))
+                              .Returns((string) null);
+            authorityCacheMock.Setup(x => x.UpdateAuthority("org", expectedAuthority))
+                              .Verifiable();
+
+            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object);
+
+            await provider.GetCredentialAsync(input);
+
+            authorityCacheMock.Verify(x => x.UpdateAuthority("org", expectedAuthority), Times.Once);
+        }
+
+        [Fact]
+        public async Task AzureReposHostProvider_EraseCredentialAsync_ErasesAuthorityCache()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "dev.azure.com",
+                ["path"] = "org/proj/_git/repo"
+            });
+
+            var context = new TestCommandContext();
+
+            var azDevOpsMock = new Mock<IAzureDevOpsRestApi>();
+            var msAuthMock = new Mock<IMicrosoftAuthentication>();
+            var authorityCacheMock = new Mock<IAzureReposAuthorityCache>();
+
+            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object);
+
+            await provider.EraseCredentialAsync(input);
+
+            authorityCacheMock.Verify(x => x.EraseAuthority("org"), Times.Once);
         }
     }
 }

--- a/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
-using System.Collections.Generic;
-using Microsoft.Git.CredentialManager;
 using Xunit;
 
 namespace Microsoft.AzureRepos.Tests
@@ -40,129 +38,83 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public void UriHelpers_CreateOrganizationUri_Null_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => UriHelpers.CreateOrganizationUri(null));
+            Assert.Throws<ArgumentNullException>(() => UriHelpers.CreateOrganizationUri(null, out _));
         }
 
         [Fact]
-        public void UriHelpers_CreateOrganizationUri_InputArgsMissingProtocol_ThrowsException()
+        public void UriHelpers_CreateOrganizationUri_AzureHost_ReturnsCorrectUriAndOrgName()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["host"] = "dev.azure.com"
-            });
+            const string expectedOrgName = "myorg";
+            var expectedOrgUri = new Uri("https://dev.azure.com/myorg");
+            var remoteUri = new Uri("https://dev.azure.com/myorg/myproject/_git/myrepo");
 
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
-        }
+            Uri actualOrgUri = UriHelpers.CreateOrganizationUri(remoteUri, out string actualOrgName);
 
-        [Fact]
-        public void UriHelpers_CreateOrganizationUri_InputArgsMissingHost_ThrowsException()
-        {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https"
-            });
-
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
-        }
-
-        [Fact]
-        public void UriHelpers_CreateOrganizationUri_AzureHost_ReturnsCorrectUri()
-        {
-            var expected = new Uri("https://dev.azure.com/myorg");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com",
-                ["path"]     = "myorg/myproject/_git/myrepo"
-            });
-
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
-
-            Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrgUri, actualOrgUri);
+            Assert.Equal(expectedOrgName, actualOrgName);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_OrgAlsoInUser_PrefersPathOrg()
         {
-            var expected = new Uri("https://dev.azure.com/myorg-path");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com",
-                ["path"]     = "myorg-path",
-                ["username"] = "myorg-user"
-            });
+            const string expectedOrgName = "myorg-path";
+            var expectedOrgUri = new Uri("https://dev.azure.com/myorg-path");
+            var remoteUri = new Uri("https://myorg-user@dev.azure.com/myorg-path");
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actualOrgUri = UriHelpers.CreateOrganizationUri(remoteUri, out string actualOrgName);
 
-            Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrgUri, actualOrgUri);
+            Assert.Equal(expectedOrgName, actualOrgName);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_InputArgsMissingPath_HasUser_UsesUserOrg()
         {
-            var expected = new Uri("https://dev.azure.com/myorg-user");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com",
-                ["username"] = "myorg-user"
-            });
+            const string expectedOrgName = "myorg-user";
+            var expectedOrgUri = new Uri("https://dev.azure.com/myorg-user");
+            var remoteUri = new Uri("https://myorg-user@dev.azure.com");
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actualOrgUri = UriHelpers.CreateOrganizationUri(remoteUri, out string actualOrgName);
 
-            Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrgUri, actualOrgUri);
+            Assert.Equal(expectedOrgName, actualOrgName);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_InputArgsMissingPathAndUser_ThrowsException()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com"
-            });
+            var remoteUri = new Uri("https://dev.azure.com");
 
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(remoteUri, out _));
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_VisualStudioHost_ReturnsCorrectUri()
         {
-            var expected = new Uri("https://myorg.visualstudio.com/");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "myorg.visualstudio.com",
-            });
+            const string expectedOrgName = "myorg";
+            var expectedOrgUri = new Uri("https://myorg.visualstudio.com/");
+            var remoteUri = new Uri("https://myorg.visualstudio.com");
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actualOrgUri = UriHelpers.CreateOrganizationUri(remoteUri, out string actualOrgName);
 
-            Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrgUri, actualOrgUri);
+            Assert.Equal(expectedOrgName, actualOrgName);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_VisualStudioHost_MissingOrgInHost_ThrowsException()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "visualstudio.com",
-            });
+            var remoteUri = new Uri("https://visualstudio.com");
 
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(remoteUri, out _));
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_NonAzureDevOpsHost_ThrowsException()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "example.com",
-            });
+            var remoteUri = new Uri("https://example.com");
 
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(remoteUri, out _));
         }
     }
 }

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -1,11 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
+using System.IO;
+using Microsoft.Git.CredentialManager;
 
 namespace Microsoft.AzureRepos
 {
     internal static class AzureDevOpsConstants
     {
+        public const string AzReposDataDirectoryName = "azure-repos";
+        public const string AzReposDataStoreName = "store.ini";
+
         // Azure DevOps's resource ID
         public const string AadResourceId = "499b84ac-1321-427f-aa17-267ca6975798";
 
@@ -26,6 +31,18 @@ namespace Microsoft.AzureRepos
         {
             public const string ReposWrite = "vso.code_write";
             public const string ArtifactsRead = "vso.packaging";
+        }
+
+        public static IniFileValueStore CreateIniDataStore(IFileSystem fs)
+        {
+            EnsureArgument.NotNull(fs, nameof(fs));
+
+            string storePath = Path.Combine(
+                fs.UserDataDirectoryPath,
+                AzReposDataDirectoryName,
+                AzReposDataStoreName);
+
+            return new IniFileValueStore(fs, new IniSerializer(), storePath);
         }
     }
 }

--- a/src/shared/Microsoft.AzureRepos/AzureReposAuthorityCache.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposAuthorityCache.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.Git.CredentialManager;
+
+namespace Microsoft.AzureRepos
+{
+    public interface IAzureReposAuthorityCache
+    {
+        /// <summary>
+        /// Lookup the cached authority for the specified Azure DevOps organization.
+        /// </summary>
+        /// <param name="orgName">Azure DevOps organization name.</param>
+        /// <returns>Authority for the organization, or null if not found.</returns>
+        string GetAuthority(string orgName);
+
+        /// <summary>
+        /// Updates the cached authority for the specified Azure DevOps organization.
+        /// </summary>
+        /// <param name="orgName">Azure DevOps organization name.</param>
+        /// <param name="authority">New authority value.</param>
+        void UpdateAuthority(string orgName, string authority);
+
+        /// <summary>
+        /// Erase the cached authority for the specified Azure DevOps organization.
+        /// </summary>
+        /// <param name="orgName">Azure DevOps organization name.</param>
+        void EraseAuthority(string orgName);
+    }
+
+    public class AzureReposAuthorityCache : IAzureReposAuthorityCache
+    {
+        private readonly ITrace _trace;
+        private readonly ITransactionalValueStore<string, string> _store;
+
+        public AzureReposAuthorityCache(ITrace trace, ITransactionalValueStore<string, string> store)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(store, nameof(store));
+
+            _trace = trace;
+            _store = store;
+        }
+
+        public string GetAuthority(string orgName)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+            _trace.WriteLine($"Looking up cached authority for organization '{orgName}'...");
+
+            _store.Reload();
+            if (_store.TryGetValue(GetAuthorityKey(orgName), out string authority))
+            {
+                return authority;
+            }
+
+            return null;
+        }
+
+        public void UpdateAuthority(string orgName, string authority)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+            _trace.WriteLine($"Updating cached authority for '{orgName}' to '{authority}'...");
+
+            _store.Reload();
+            _store.SetValue(GetAuthorityKey(orgName), authority);
+            _store.Commit();
+        }
+
+        public void EraseAuthority(string orgName)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+            _trace.WriteLine($"Removing cached authority for '{orgName}'...");
+            _store.Reload();
+            _store.Remove(GetAuthorityKey(orgName));
+            _store.Commit();
+        }
+
+        private static string GetAuthorityKey(string orgName)
+        {
+            return $"org.{orgName}.authority";
+        }
+    }
+}

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication;
@@ -12,21 +13,38 @@ namespace Microsoft.AzureRepos
     {
         private readonly IAzureDevOpsRestApi _azDevOps;
         private readonly IMicrosoftAuthentication _msAuth;
+        private readonly IAzureReposAuthorityCache _authorityCache;
 
         public AzureReposHostProvider(ICommandContext context)
-            : this(context, new AzureDevOpsRestApi(context), new MicrosoftAuthentication(context))
-        {
-        }
+            : this(context,
+                new AzureDevOpsRestApi(context),
+                new MicrosoftAuthentication(context),
+                AzureDevOpsConstants.CreateIniDataStore(context?.FileSystem))
+        { }
 
-        public AzureReposHostProvider(ICommandContext context, IAzureDevOpsRestApi azDevOps,
-            IMicrosoftAuthentication msAuth)
+        public AzureReposHostProvider(
+            ICommandContext context,
+            IAzureDevOpsRestApi azDevOps,
+            IMicrosoftAuthentication msAuth,
+            ITransactionalValueStore<string, string> dataStore)
+            : this(context, azDevOps, msAuth,
+                new AzureReposAuthorityCache(context?.Trace, dataStore))
+        { }
+
+        public AzureReposHostProvider(
+            ICommandContext context,
+            IAzureDevOpsRestApi azDevOps,
+            IMicrosoftAuthentication msAuth,
+            IAzureReposAuthorityCache authorityCache)
             : base(context)
         {
             EnsureArgument.NotNull(azDevOps, nameof(azDevOps));
             EnsureArgument.NotNull(msAuth, nameof(msAuth));
+            EnsureArgument.NotNull(authorityCache, nameof(authorityCache));
 
             _azDevOps = azDevOps;
             _msAuth = msAuth;
+            _authorityCache = authorityCache;
         }
 
         #region HostProvider
@@ -49,7 +67,9 @@ namespace Microsoft.AzureRepos
 
         public override string GetCredentialKey(InputArguments input)
         {
-            return $"git:{UriHelpers.CreateOrganizationUri(input).AbsoluteUri}";
+            Uri remoteUri = input.GetRemoteUri();
+            Uri orgUri = UriHelpers.CreateOrganizationUri(remoteUri);
+            return $"git:{orgUri.AbsoluteUri}";
         }
 
         public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
@@ -60,18 +80,25 @@ namespace Microsoft.AzureRepos
                 throw new Exception("Unencrypted HTTP is not supported for Azure Repos. Ensure the repository remote URL is using HTTPS.");
             }
 
-            Uri orgUri = UriHelpers.CreateOrganizationUri(input);
             Uri remoteUri = input.GetRemoteUri();
+            Uri orgUri = UriHelpers.CreateOrganizationUri(remoteUri, out string orgName);
 
             // Determine the MS authentication authority for this organization
-            Context.Trace.WriteLine("Determining Microsoft Authentication Authority...");
-            string authAuthority = await _azDevOps.GetAuthorityAsync(orgUri);
-            Context.Trace.WriteLine($"Authority is '{authAuthority}'.");
+            string authority = _authorityCache.GetAuthority(orgName);
+            if (authority is null)
+            {
+                Context.Trace.WriteLine("No authority found in cache; querying server...");
+                authority = await _azDevOps.GetAuthorityAsync(orgUri);
+
+                // Update our cache
+                _authorityCache.UpdateAuthority(orgName, authority);
+            }
+            Context.Trace.WriteLine($"Authority for '{orgName}' is '{authority}'.");
 
             // Get an AAD access token for the Azure DevOps SPS
             Context.Trace.WriteLine("Getting Azure AD access token...");
             string accessToken = await _msAuth.GetAccessTokenAsync(
-                authAuthority,
+                authority,
                 AzureDevOpsConstants.AadClientId,
                 AzureDevOpsConstants.AadRedirectUri,
                 AzureDevOpsConstants.AadResourceId,
@@ -92,6 +119,17 @@ namespace Microsoft.AzureRepos
             Context.Trace.WriteLineSecrets("PAT created. PAT='{0}'", new object[] {pat});
 
             return new GitCredential(Constants.PersonalAccessTokenUserName, pat);
+        }
+
+        public override Task EraseCredentialAsync(InputArguments input)
+        {
+            // We should clear out the cached authority for this organization in case the reason for
+            // the authentication failure was using old or incorrect data to generate the credentials.
+            Uri remoteUri = input.GetRemoteUri();
+            string orgName = UriHelpers.GetOrganizationName(remoteUri);
+            _authorityCache.EraseAuthority(orgName);
+
+            return base.EraseCredentialAsync(input);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/IniSerializerTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/IniSerializerTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class IniSerializerTests
+    {
+        [Fact]
+        public void IniSerializer_Deserialize()
+        {
+            const string iniText = "[foo \"this:\\ is-contoso/].com\"]\n" +
+                                   "\tuser = john.doe\n" +
+                                   "\n" +
+                                   "[bar]\n" +
+                                   "\tuser = jane.doe\n" +
+                                   "\n" +
+                                   "[misc]\n" +
+                                   "\tnull =\n" +
+                                   "\tempty =\n" +
+                                   "\tvalue = foo\n" +
+                                   "\n";
+
+            var serializer = new IniSerializer();
+            using (var reader = new StringReader(iniText))
+            {
+                IniFile iniFile = serializer.Deserialize(reader);
+
+                Assert.Equal(3, iniFile.Sections.Count);
+
+                Assert.Equal("foo", iniFile.Sections[0].Name);
+                Assert.Equal("this:\\ is-contoso/].com", iniFile.Sections[0].Scope);
+                Assert.Equal(1, iniFile.Sections[0].Properties.Count);
+                Assert.True(iniFile.Sections[0].Properties.ContainsKey("user"));
+                Assert.Equal("john.doe", iniFile.Sections[0].Properties["user"]);
+
+                Assert.Equal("bar", iniFile.Sections[1].Name);
+                Assert.Null(iniFile.Sections[1].Scope);
+                Assert.Equal(1, iniFile.Sections[1].Properties.Count);
+                Assert.True(iniFile.Sections[1].Properties.ContainsKey("user"));
+                Assert.Equal("jane.doe", iniFile.Sections[1].Properties["user"]);
+
+                Assert.Equal("misc", iniFile.Sections[2].Name);
+                Assert.Null(iniFile.Sections[2].Scope);
+                Assert.Equal(3, iniFile.Sections[2].Properties.Count);
+                Assert.True(iniFile.Sections[2].Properties.ContainsKey("null"));
+                Assert.True(iniFile.Sections[2].Properties.ContainsKey("empty"));
+                Assert.True(iniFile.Sections[2].Properties.ContainsKey("value"));
+                Assert.Null(iniFile.Sections[2].Properties["null"]);
+                Assert.Null(iniFile.Sections[2].Properties["empty"]);
+                Assert.Equal("foo", iniFile.Sections[2].Properties["value"]);
+            }
+        }
+
+        [Fact]
+        public void IniSerializer_Serialize()
+        {
+            const string expectedIniText = "[foo \"this:\\ is-contoso/].com\"]\n" +
+                                           "\tuser = john.doe\n" +
+                                           "\n" +
+                                           "[bar]\n" +
+                                           "\tuser = jane.doe\n" +
+                                           "\n" +
+                                           "[misc]\n" +
+                                           "\tnull =\n" +
+                                           "\tempty =\n" +
+                                           "\tvalue = foo\n" +
+                                           "\n";
+
+            var iniFile = new IniFile
+            {
+                Sections =
+                {
+                    new IniSection("foo", "this:\\ is-contoso/].com")
+                    {
+                        Properties = {["user"] = "john.doe"}
+                    },
+                    new IniSection("bar", null)
+                    {
+                        Properties = {["user"] = "jane.doe"}
+                    },
+                    new IniSection("misc", null)
+                    {
+                        Properties =
+                        {
+                            ["null"] = null,
+                            ["empty"] = "",
+                            ["value"] = "foo",
+                        },
+                    },
+                }
+            };
+
+            var serializer = new IniSerializer();
+
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb) {NewLine = "\n"})
+            {
+                serializer.Serialize(iniFile, writer);
+            }
+
+            string actualIniText = sb.ToString();
+
+            Assert.Equal(expectedIniText, actualIniText);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/FileSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/FileSystem.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
 using System.IO;
 
 namespace Microsoft.Git.CredentialManager
@@ -9,6 +10,16 @@ namespace Microsoft.Git.CredentialManager
     /// </summary>
     public interface IFileSystem
     {
+        /// <summary>
+        /// Get the path to the user's home profile directory ($HOME, %USERPROFILE%).
+        /// </summary>
+        string UserHomePath { get; }
+
+        /// <summary>
+        /// Get the path the the user's Git Credential Manager data directory.
+        /// </summary>
+        string UserDataDirectoryPath { get; }
+
         /// <summary>
         /// Check if a file exists at the specified path.
         /// </summary>
@@ -38,6 +49,33 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="fileShare">File share settings.</param>
         /// <returns></returns>
         Stream OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare);
+
+        /// <summary>
+        /// Opens a text file, reads all lines of the file, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to open for reading.</param>
+        /// <returns>A string containing all lines of the file.</returns>
+        string ReadAllText(string path);
+
+        /// <summary>
+        /// Creates a new file, writes the specified string to the file, and then closes the file.
+        /// If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="contents">The string to write to the file</param>
+        void WriteAllText(string path, string contents);
+
+        /// <summary>
+        /// Creates directories and subdirectories in the specified path unless they already exist.
+        /// </summary>
+        /// <param name="path">The directory to create.</param>
+        void CreateDirectory(string path);
+
+        /// <summary>
+        /// Deletes the specified file.
+        /// </summary>
+        /// <param name="path">The file to delete.</param>
+        void DeleteFile(string path);
     }
 
     /// <summary>
@@ -45,6 +83,10 @@ namespace Microsoft.Git.CredentialManager
     /// </summary>
     public class FileSystem : IFileSystem
     {
+        public string UserHomePath => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        public string UserDataDirectoryPath => Path.Combine(UserHomePath, ".gcm");
+
         public bool FileExists(string path) => File.Exists(path);
 
         public bool DirectoryExists(string path) => Directory.Exists(path);
@@ -53,5 +95,13 @@ namespace Microsoft.Git.CredentialManager
 
         public Stream OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare)
             => File.Open(path, fileMode, fileAccess, fileShare);
+
+        public string ReadAllText(string path) => File.ReadAllText(path);
+
+        public void WriteAllText(string path, string contents) => File.WriteAllText(path, contents);
+
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+
+        public void DeleteFile(string path) => File.Delete(path);
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/ITransactionalValueStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ITransactionalValueStore.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Represents a simple key/value store that can accumulate changes before 'committing' them to a persistent
+    /// storage location, or be reloaded from that storage at will.
+    /// </summary>
+    /// <typeparam name="TKey">Type of the key.</typeparam>
+    /// <typeparam name="TValue">Type of the value.</typeparam>
+    public interface ITransactionalValueStore<in TKey, TValue>
+    {
+        /// <summary>
+        /// Reload the store from persisted storage. Any uncommitted changes will be lost.
+        /// </summary>
+        void Reload();
+
+        /// <summary>
+        /// Commit changes to persisted storage. Any changes made outside of the application will be overwritten.
+        /// </summary>
+        void Commit();
+
+        /// <summary>
+        /// Try and get a value with the specified key from the store.
+        /// </summary>
+        /// <param name="key">Value key.</param>
+        /// <param name="value">Value.</param>
+        /// <returns>True if a value for the given key was found, false otherwise.</returns>
+        bool TryGetValue(TKey key, out TValue value);
+
+        /// <summary>
+        /// Add or update a value for the specified key in the store.
+        /// </summary>
+        /// <param name="key">Value key.</param>
+        /// <param name="value">New value.</param>
+        void SetValue(TKey key, TValue value);
+
+        /// <summary>
+        /// Remove the value with the specified key from the store.
+        /// </summary>
+        /// <param name="key"></param>
+        void Remove(TKey key);
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/IniFile.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IniFile.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Represents an INI based configuration file.
+    /// </summary>
+    public class IniFile
+    {
+        /// <summary>
+        /// All sections in this INI file.
+        /// </summary>
+        public IList<IniSection> Sections { get; } = new List<IniSection>();
+
+        /// <summary>
+        /// Attempt to find a section in this file with the given name and optional scope.
+        /// </summary>
+        /// <param name="name">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="section">Section with the specified name and scope.</param>
+        /// <returns>True if a section was found, false otherwise.</returns>
+        public bool TryGetSection(string name, string scope, out IniSection section)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(name, nameof(name));
+
+            foreach (IniSection s in Sections)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(name, s.Name) &&
+                    StringComparer.OrdinalIgnoreCase.Equals(scope, s.Scope))
+                {
+                    section = s;
+                    return true;
+                }
+            }
+
+            section = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get the value of a property in the INI file.
+        /// </summary>
+        /// <param name="section">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="property">Property name.</param>
+        /// <param name="value">Value of the property.</param>
+        /// <returns>True if the property was present and found, false otherwise.</returns>
+        /// <remarks>Null is a valid value.</remarks>
+        public bool TryGetValue(string section, string scope, string property, out string value)
+        {
+            value = null;
+            return TryGetSection(section, scope, out IniSection sectionObj) &&
+                   sectionObj.Properties.TryGetValue(property, out value);
+        }
+
+        /// <summary>
+        /// Set the value of a property in the INI file.
+        /// </summary>
+        /// <param name="section">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="property">Property name.</param>
+        /// <param name="value">Value of the property.</param>
+        /// <remarks>Null is a valid value. Use <see cref="UnsetValue"/> to remove the property.</remarks>
+        public void SetValue(string section, string scope, string property, string value)
+        {
+            if (!TryGetSection(section, scope, out IniSection sectionObj))
+            {
+                sectionObj = new IniSection(section, scope);
+                Sections.Add(sectionObj);
+            }
+
+            sectionObj.Properties[property] = value;
+        }
+
+        /// <summary>
+        /// Unset/remove a property from the INI file.
+        /// </summary>
+        /// <param name="section">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="property">Property name.</param>
+        public void UnsetValue(string section, string scope, string property)
+        {
+            if (TryGetSection(section, scope, out IniSection sectionObj))
+            {
+                sectionObj.Properties.Remove(property);
+            }
+        }
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class IniSection
+    {
+        public IniSection(string name, string scope)
+        {
+            Name = name;
+            Scope = scope;
+        }
+
+        /// <summary>
+        /// Name of the INI file section.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Optional scope of the INI file section.
+        /// </summary>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// All properties in this section.
+        /// </summary>
+        public IDictionary<string, string> Properties { get; } =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        private string DebuggerDisplay => Scope == null ? $"[{Name}]" : $"[{Name} \"{Scope}\"]";
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/IniFileValueStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IniFileValueStore.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.IO;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Value store that uses an INI file as the persistent storage.
+    /// </summary>
+    public class IniFileValueStore : ITransactionalValueStore<string, string>
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly IniSerializer _serializer;
+        private readonly string _filePath;
+        private readonly string _parentPath;
+        private readonly object _fileLock = new object();
+        private IniFile _iniFile;
+
+        public IniFileValueStore(IFileSystem fileSystem, IniSerializer serializer, string filePath)
+        {
+            _fileSystem = fileSystem;
+            _serializer = serializer;
+            _filePath = filePath;
+            _parentPath = Path.GetDirectoryName(_filePath);
+
+            Reload();
+        }
+
+        public void Reload()
+        {
+            lock (_fileLock)
+            {
+                if (_fileSystem.FileExists(_filePath))
+                {
+                    string text = _fileSystem.ReadAllText(_filePath);
+                    using (var reader = new StringReader(text))
+                    {
+                        _iniFile = _serializer.Deserialize(reader);
+                    }
+                }
+                else
+                {
+                    // Create a new empty INI file object
+                    _iniFile = new IniFile();
+                }
+            }
+        }
+
+        public void Commit()
+        {
+            lock (_fileLock)
+            {
+                // Sure parent directory exists
+                if (!_fileSystem.DirectoryExists(_parentPath))
+                {
+                    _fileSystem.CreateDirectory(_parentPath);
+                }
+
+                using (var writer = new StringWriter())
+                {
+                    _serializer.Serialize(_iniFile, writer);
+                    _fileSystem.WriteAllText(_filePath, writer.ToString());
+                }
+            }
+        }
+
+        public bool TryGetValue(string key, out string value)
+        {
+            lock (_fileLock)
+            {
+                value = null;
+
+                if (!TrySplitKey(key, out string section, out string scope, out string property))
+                {
+                    throw new ArgumentException($"Invalid key '{key}'.", nameof(key));
+                }
+
+                return _iniFile.TryGetValue(section, scope, property, out value);
+            }
+        }
+
+        public void SetValue(string key, string value)
+        {
+            lock (_fileLock)
+            {
+                if (!TrySplitKey(key, out string section, out string scope, out string property))
+                {
+                    throw new ArgumentException($"Invalid key '{key}'.", nameof(key));
+                }
+
+                _iniFile.SetValue(section, scope, property, value);
+            }
+        }
+
+        public void Remove(string key)
+        {
+            lock (_fileLock)
+            {
+                if (!TrySplitKey(key, out string section, out string scope, out string property))
+                {
+                    throw new ArgumentException($"Invalid key '{key}'.", nameof(key));
+                }
+
+                _iniFile.UnsetValue(section, scope, property);
+            }
+        }
+
+        private static bool TrySplitKey(string key, out string section, out string scope, out string property)
+        {
+            section = null;
+            scope = null;
+            property = null;
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            int first = key.IndexOf('.');
+            int last = key.LastIndexOf('.');
+
+            if (first < 0 || last < 0)
+            {
+                return false;
+            }
+
+            // section.property
+            if (first == last)
+            {
+                section = key.Substring(0, first);
+                property = key.Substring(last + 1);
+
+                return true;
+            }
+
+            // section.scope.maybe.with.periods.property
+            section = key.Substring(0, first);
+            scope = key.Substring(first + 1, last - first - 1);
+            property = key.Substring(last + 1);
+
+            return true;
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/IniSerializer.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IniSerializer.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Performs serialization and deserialization of INI files <seealso cref="IniFile"/>.
+    /// </summary>
+    public class IniSerializer
+    {
+        private static readonly Regex SectionRegex = new Regex(@"\[\s*(?<name>.+?)(?:\s+\""(?<scope>.+)\"")?\s*\]", RegexOptions.Compiled);
+        private static readonly Regex PropertyRegex = new Regex(@"(?<name>\S+?)\s*\=\s*(?<value>.+)?", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Serialize the given INI file to a <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="file">INI file to serialize.</param>
+        /// <param name="writer"><see cref="TextWriter"/> to serialize the INI file to.</param>
+        public void Serialize(IniFile file, TextWriter writer)
+        {
+            foreach (IniSection section in file.Sections)
+            {
+                if (section.Properties.Any())
+                {
+                    WriteSectionHeader(writer, section);
+                    writer.WriteLine();
+
+                    foreach (var property in section.Properties)
+                    {
+                        WriteProperty(writer, property);
+                        writer.WriteLine();
+                    }
+
+                    writer.WriteLine();
+                    writer.Flush();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deserialize an INI file from a <see cref="TextReader"/>.
+        /// </summary>
+        /// <param name="reader"><see cref="TextReader"/> to deserialize the INI file from.</param>
+        /// <returns>INI file.</returns>
+        public IniFile Deserialize(TextReader reader)
+        {
+            var file = new IniFile();
+
+            IniSection currentSection = null;
+
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                if (TryParseSection(line, out IniSection newSection))
+                {
+                    if (file.TryGetSection(newSection.Name, newSection.Scope, out IniSection existingSection))
+                    {
+                        currentSection = existingSection;
+                    }
+                    else
+                    {
+                        currentSection = newSection;
+                        file.Sections.Add(newSection);
+                    }
+                }
+                else if (TryParseProperty(line, out string propertyName, out string propertyValue))
+                {
+                    if (currentSection is null)
+                    {
+                        throw new Exception("Invalid INI file. Properties must exist in a section.");
+                    }
+
+                    currentSection.Properties[propertyName] = propertyValue;
+                }
+                else
+                {
+                    // Invalid line
+                }
+            }
+
+            return file;
+        }
+
+        #region Writer Helpers
+
+        private void WriteProperty(TextWriter writer, KeyValuePair<string, string> property)
+        {
+            writer.Write('\t');
+            writer.Write(property.Key);
+            writer.Write(" =");
+            if (!string.IsNullOrWhiteSpace(property.Value))
+            {
+                writer.Write(' ');
+                writer.Write(property.Value);
+            }
+        }
+
+        private void WriteSectionHeader(TextWriter writer, IniSection section)
+        {
+            writer.Write('[');
+            writer.Write(section.Name);
+            if (section.Scope != null)
+            {
+                writer.Write(" \"{0}\"", section.Scope);
+            }
+
+            writer.Write(']');
+        }
+
+        #endregion
+
+        #region Parsing Helpers
+
+        private bool TryParseSection(string line, out IniSection section)
+        {
+            var match = SectionRegex.Match(line);
+            if (match.Success)
+            {
+                string name = match.Groups["name"].Value;
+                string scope = match.Groups["scope"].Success ? match.Groups["scope"].Value : null;
+
+                section = new IniSection(name, scope);
+                return true;
+            }
+
+            section = null;
+            return false;
+        }
+
+        private bool TryParseProperty(string line, out string propertyName, out string propertyValue)
+        {
+            var match = PropertyRegex.Match(line);
+            if (match.Success)
+            {
+                propertyName = match.Groups["name"].Value;
+                propertyValue = match.Groups["value"].Success ? match.Groups["value"].Value : null;
+
+                return true;
+            }
+
+            propertyName = null;
+            propertyValue = null;
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/src/shared/TestInfrastructure/Objects/InMemoryValueStore.cs
+++ b/src/shared/TestInfrastructure/Objects/InMemoryValueStore.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.Collections.Generic;
+
+namespace Microsoft.Git.CredentialManager.Tests.Objects
+{
+    public class InMemoryValueStore<TKey, TValue> : ITransactionalValueStore<TKey, TValue>
+    {
+        private readonly object _txLock = new object();
+
+        public IDictionary<TKey, TValue> PersistedStore { get; }
+
+        public IDictionary<TKey, TValue> MemoryStore { get; }
+
+        public InMemoryValueStore() : this(EqualityComparer<TKey>.Default) { }
+
+        public InMemoryValueStore(IEqualityComparer<TKey> comparer)
+            : this(new Dictionary<TKey, TValue>(comparer)) { }
+
+        public InMemoryValueStore(Dictionary<TKey, TValue> persistedStore)
+        {
+            PersistedStore = persistedStore;
+            MemoryStore = new Dictionary<TKey, TValue>(persistedStore.Comparer);
+
+            Reload();
+        }
+
+        public void Reload()
+        {
+            // Copy state from persisted store -> memory store
+            lock (_txLock)
+            {
+                MemoryStore.Clear();
+                foreach (var kvp in PersistedStore)
+                {
+                    MemoryStore.Add(kvp);
+                }
+            }
+        }
+
+        public void Commit()
+        {
+            // Copy state from memory store -> persisted store
+            lock (_txLock)
+            {
+                PersistedStore.Clear();
+                foreach (var kvp in MemoryStore)
+                {
+                    PersistedStore.Add(kvp);
+                }
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return MemoryStore.TryGetValue(key, out value);
+        }
+
+        public void SetValue(TKey key, TValue value)
+        {
+            MemoryStore[key] = value;
+        }
+
+        public void Remove(TKey key)
+        {
+            MemoryStore.Remove(key);
+        }
+    }
+}

--- a/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
+++ b/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
@@ -1,15 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestFileSystem : IFileSystem
     {
-        public IDictionary<string, Stream> Files { get; set; }
-        public ISet<string> Directories { get; set; }
-        public string CurrentDirectory { get; set; } = Path.GetTempPath();
+        public IDictionary<string, MemoryStream> Files { get; set; } = new Dictionary<string, MemoryStream>();
+        public ISet<string> Directories { get; set; } = new HashSet<string>();
+        public string CurrentDirectory { get; set; }
+        public string UserHomePath { get; set; }
+        public string UserDataDirectoryPath { get; set; }
+
+        public TestFileSystem()
+        {
+            var gcmTestRoot = Path.Combine(Path.GetTempPath(), $"gcmtest-{Guid.NewGuid():N}");
+            UserHomePath = Path.Combine(gcmTestRoot, "HOME");
+            UserDataDirectoryPath = Path.Combine(UserHomePath, ".gcm");
+        }
 
         #region IFileSystem
 
@@ -30,7 +41,78 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         Stream IFileSystem.OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare)
         {
-            return Files[path];
+            MemoryStream stream;
+
+            bool writable = fileAccess == FileAccess.Write || fileAccess == FileAccess.ReadWrite;
+
+            // Simulate System.IO.FileStream
+            switch (fileMode)
+            {
+                case FileMode.Append:
+                    if (!writable) throw new IOException();
+                    stream = Files[path];
+                    stream.Seek(0, SeekOrigin.End);
+                    break;
+
+                case FileMode.Create:
+                    Files[path] = new MemoryStream();
+                    stream = Files[path];
+                    break;
+
+                case FileMode.CreateNew:
+                    if (Files.ContainsKey(path)) throw new IOException();
+                    Files[path] = new MemoryStream();
+                    stream = Files[path];
+                    break;
+
+                case FileMode.Open:
+                    if (!Files.ContainsKey(path)) throw new FileNotFoundException();
+                    stream = Files[path];
+                    stream.Seek(0, SeekOrigin.Begin);
+                    break;
+
+                case FileMode.OpenOrCreate:
+                    if (!Files.TryGetValue(path, out stream))
+                    {
+                        Files[path] = new MemoryStream();
+                        stream = Files[path];
+                    }
+                    stream.Seek(0, SeekOrigin.Begin);
+                    break;
+
+                case FileMode.Truncate:
+                    Files[path] = new MemoryStream();
+                    stream = Files[path];
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(fileMode), fileMode, "Unknown FileMode");
+            }
+
+            return stream;
+        }
+
+        public string ReadAllText(string path)
+        {
+            var bytes = Files[path].ToArray();
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        public void WriteAllText(string path, string contents)
+        {
+            var bytes = Encoding.UTF8.GetBytes(contents);
+            Files[path] = new MemoryStream();
+            Files[path].Write(bytes, 0, bytes.Length);
+        }
+
+        void IFileSystem.CreateDirectory(string path)
+        {
+            Directories.Add(path);
+        }
+
+        void IFileSystem.DeleteFile(string path)
+        {
+            Files.Remove(path);
         }
 
         #endregion


### PR DESCRIPTION
To avoid making a web call each time we want to create a new credential (to get the authentication authority for the Azure DevOps organisation), we cache the value against the org name in an INI file that is stored in `~/.gcm/azure-repos/store.ini`.

This is an important web call to avoid in an upcoming PR that will introduce an AAD AT-only mode where we need the authority for each GCM 'get' request, and not just ones when the PAT was not found (see #42).

Should an authentication fail, we clear the organisation cache entry for that failing remote. This will allow us to auto-clear stale authority values when, for example, an Azure DevOps organisation moves from being MSA- to AAD-backed.

This INI-based store will also be utilised in future PRs for storing user state for the AAD AT-only mode (see #42). A simple file/directory-based format was considered, but there are problems with escaping special characters. A JSON-based format could also be used. The INI based format was chosen to be consistent with Git's own configuration/storage format that is INI-like.