### PR TITLE
Install: fix postinstall script on osx

### DIFF
--- a/src/osx/Installer.Mac/scripts/postinstall
+++ b/src/osx/Installer.Mac/scripts/postinstall
@@ -18,7 +18,7 @@ function IsBrewPkgInstalled
 }
 
 # Check if Java GCM is present on this system and unlink it should it exist
-if [ -L /usr/local/bin/git-credential-manager && IsBrewPkgInstalled "git-credential-manager" ]
+if [ -L /usr/local/bin/git-credential-manager ] && IsBrewPkgInstalled "git-credential-manager";
 then
     brew unlink git-credential-manager
 fi


### PR DESCRIPTION
The macOS install encounteres the following error when running the postinstall script:

    ./postinstall: /tmp/PKInstallSandbox.qGkbqk/Scripts/com.microsoft.GitCredentialManager.kjGWk5/postinstall: line 21: [: missing `]'

This resulted in the credential helper not being correctly configured.

The problem is with the test on the indicated line - the '[ ]' test does not
support '&&' statements inside the test expression, as it splits the expression into separate
commands.

Running the post install script with more diagnostic output we see:

```
# Check if Java GCM is present on this system and unlink it should it exist
if [ -L /usr/local/bin/git-credential-manager && IsBrewPkgInstalled "git-credential-manager" ]
then
    brew unlink git-credential-manager
fi
+ '[' -L /usr/local/bin/git-credential-manager
./postinstall: line 23: [: missing `]'
```