### PR TITLE
New Install 1/6: Optimise the use of Git configuration from the Settings component

### DIFF
--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Git.CredentialManager
     {
         public static void Main(string[] args)
         {
-            var context = new CommandContext();
+            using (var context = new CommandContext())
             using (var app = new Application(context))
             {
                 // Register all supported host providers

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -64,6 +64,8 @@ namespace GitHub
 
         public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
+            ThrowIfDisposed();
+
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))
             {
@@ -105,14 +107,10 @@ namespace GitHub
             throw new Exception($"Interactive logon for '{targetUri}' failed.");
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void ReleaseManagedResources()
         {
-            if (disposing)
-            {
-                _gitHubApi.Dispose();
-            }
-
-            base.Dispose(disposing);
+            _gitHubApi.Dispose();
+            base.ReleaseManagedResources();
         }
 
         #region Private Methods

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -54,6 +54,8 @@ namespace Microsoft.AzureRepos
 
         public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
+            ThrowIfDisposed();
+
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))
             {
@@ -94,14 +96,10 @@ namespace Microsoft.AzureRepos
             return new GitCredential(Constants.PersonalAccessTokenUserName, pat);
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void ReleaseManagedResources()
         {
-            if (disposing)
-            {
-                _azDevOps.Dispose();
-            }
-
-            base.Dispose(disposing);
+            _azDevOps.Dispose();
+            base.ReleaseManagedResources();
         }
 
         #endregion

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -201,10 +201,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             var envars = new EnvironmentVariables(new Dictionary<string, string>());
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri value = settings.GetProxyConfiguration(out _);
 
@@ -228,10 +227,9 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue.ToString()
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
 
@@ -256,10 +254,9 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue.ToString()
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
 
@@ -284,10 +281,9 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue.ToString()
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
 
@@ -310,10 +306,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
 
@@ -336,10 +331,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
 
@@ -362,10 +356,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
 
@@ -388,10 +381,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RemoteUri = remoteUri,
-                RepositoryPath = repositoryPath
+                RemoteUri = remoteUri
             };
             Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
 
@@ -428,10 +420,9 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             void RunTest(Uri expectedValue)
             {
-                var settings = new Settings(new EnvironmentVariables(envarDict), new TestGit(configDict))
+                var settings = new Settings(new EnvironmentVariables(envarDict), new TestGit(configDict), repositoryPath)
                 {
-                    RemoteUri = remoteUri,
-                    RepositoryPath = repositoryPath
+                    RemoteUri = remoteUri
                 };
                 Uri actualValue = settings.GetProxyConfiguration(out bool actualIsDeprecated);
                 Assert.Equal(expectedValue, actualValue);
@@ -461,9 +452,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             var envars = new EnvironmentVariables(new Dictionary<string, string>());
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             string value = settings.ProviderOverride;
@@ -486,9 +476,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             string actualValue = settings.ProviderOverride;
@@ -513,9 +502,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             string actualValue = settings.ProviderOverride;
@@ -544,9 +532,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = otherValue
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             string actualValue = settings.ProviderOverride;
@@ -564,9 +551,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             var envars = new EnvironmentVariables(new Dictionary<string, string>());
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             string value = settings.LegacyAuthorityOverride;
@@ -589,9 +575,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             string actualValue = settings.LegacyAuthorityOverride;
@@ -616,9 +601,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var actualValue = settings.LegacyAuthorityOverride;
@@ -647,9 +631,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = otherValue
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var actualValue = settings.LegacyAuthorityOverride;
@@ -675,9 +658,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             });
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
@@ -699,9 +681,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             var envars = new EnvironmentVariables(new Dictionary<string, string>());
             var git = new TestGit();
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
@@ -728,9 +709,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var result = settings.TryGetSetting( envarName, section, property, out string actualValue);
@@ -758,9 +738,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = expectedValue
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
@@ -792,9 +771,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{scope2}.{property}"] = expectedValue,
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
@@ -826,9 +804,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"] = otherValue
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             var result = settings.TryGetSetting(envarName, section, property, out string actualValue);
@@ -868,9 +845,8 @@ namespace Microsoft.Git.CredentialManager.Tests
                 [$"{section}.{property}"]          = value4
             });
 
-            var settings = new Settings(envars, git)
+            var settings = new Settings(envars, git, repositoryPath)
             {
-                RepositoryPath = repositoryPath,
                 RemoteUri = remoteUri
             };
             string[] actualValues = settings.GetSettingValues(envarName, section, property).ToArray();

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
@@ -138,6 +138,25 @@ namespace Microsoft.Git.CredentialManager.Tests
         [InlineData("foo", '/', "foo")]
         [InlineData("foo/", '/', "foo")]
         [InlineData("foo/bar", '/', "foo")]
+        [InlineData("foo/bar/", '/', "foo")]
+        public void StringExtensions_TruncateLastIndexOf(string input, char c, string expected)
+        {
+            string actual = StringExtensions.TruncateFromIndexOf(input, c);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void StringExtensions_TruncateLastIndexOf_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => StringExtensions.TruncateFromIndexOf(null, '/'));
+        }
+
+        [Theory]
+        [InlineData("", '/', "")]
+        [InlineData("/", '/', "")]
+        [InlineData("foo", '/', "foo")]
+        [InlineData("foo/", '/', "foo")]
+        [InlineData("foo/bar", '/', "foo")]
         [InlineData("foo/bar/", '/', "foo/bar")]
         public void StringExtensions_TruncateFromLastIndexOf(string input, char c, string expected)
         {
@@ -200,6 +219,57 @@ namespace Microsoft.Git.CredentialManager.Tests
         public void StringExtensions_TrimUntilIndexOf_String_Null_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => StringExtensions.TrimUntilIndexOf(null, "://"));
+        }
+
+        [Theory]
+        [InlineData("", '/', "")]
+        [InlineData("/", '/', "")]
+        [InlineData("foo", '/', "foo")]
+        [InlineData("foo/", '/', "")]
+        [InlineData("foo/bar", '/', "bar")]
+        [InlineData("foo/bar/", '/', "")]
+        public void StringExtensions_TrimUntilLastIndexOf_Character(string input, char c, string expected)
+        {
+            string actual = StringExtensions.TrimUntilLastIndexOf(input, c);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void StringExtensions_TrimUntilLastIndexOf_Character_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => StringExtensions.TrimUntilLastIndexOf(null, '/'));
+        }
+
+        [Theory]
+        [InlineData("", "://", "")]
+        [InlineData("://", "://", "")]
+        [InlineData("foo", "://", "foo")]
+        [InlineData("foo://", "://", "")]
+        [InlineData("foo://bar", "://", "bar")]
+        [InlineData("foo://bar/", "://", "bar/")]
+        public void StringExtensions_TrimUntilLastIndexOf_String(string input, string trim, string expected)
+        {
+            string actual = StringExtensions.TrimUntilLastIndexOf(input, trim);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("fooTRIMbar", "TRIM", StringComparison.Ordinal, "bar")]
+        [InlineData("fooTRIMbar", "trim", StringComparison.Ordinal, "fooTRIMbar")]
+        [InlineData("fooTRIMbar", "tRiM", StringComparison.Ordinal, "fooTRIMbar")]
+        [InlineData("fooTRIMbar", "TRIM", StringComparison.OrdinalIgnoreCase, "bar")]
+        [InlineData("fooTRIMbar", "trim", StringComparison.OrdinalIgnoreCase, "bar")]
+        [InlineData("fooTRIMbar", "tRiM", StringComparison.OrdinalIgnoreCase, "bar")]
+        public void StringExtensions_TrimUntilLastIndexOf_String_ComparisonType(string input, string trim, StringComparison comparisonType, string expected)
+        {
+            string actual = StringExtensions.TrimUntilLastIndexOf(input, trim, comparisonType);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void StringExtensions_TrimUntilLastIndexOf_String_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => StringExtensions.TrimUntilLastIndexOf(null, "://"));
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Git.CredentialManager
     /// <summary>
     /// Real command execution environment using the actual <see cref="Console"/>, file system calls and environment.
     /// </summary>
-    public class CommandContext : ICommandContext
+    public class CommandContext : DisposableObject, ICommandContext
     {
         private readonly IGit _git;
 
@@ -111,10 +111,13 @@ namespace Microsoft.Git.CredentialManager
 
         #region IDisposable
 
-        public void Dispose()
+        protected override void ReleaseManagedResources()
         {
             Settings?.Dispose();
             _git?.Dispose();
+            Trace?.Dispose();
+
+            base.ReleaseManagedResources();
         }
 
         #endregion

--- a/src/shared/Microsoft.Git.CredentialManager/DisposableObject.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/DisposableObject.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// An object that implements the <see cref="IDisposable"/> interface and the disposable pattern.
+    /// </summary>
+    public abstract class DisposableObject : IDisposable
+    {
+        private bool _isDisposed;
+
+        /// <summary>
+        /// Throw an exception if the object has been disposed.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if the object has been disposed.</exception>
+        protected void ThrowIfDisposed()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+
+        /// <summary>
+        /// Called when unmanaged resources should be released and memory freed.
+        /// </summary>
+        protected virtual void ReleaseUnmanagedResources() { }
+
+        /// <summary>
+        /// Called when managed resources should be released.
+        /// </summary>
+        protected virtual void ReleaseManagedResources() { }
+
+        /// <summary>
+        /// Called when the application is being terminated. Clean up and release any resources.
+        /// </summary>
+        /// <param name="disposing">True if the instance is being disposed, false if being finalized.</param>
+        private void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            ReleaseUnmanagedResources();
+
+            if (disposing)
+            {
+                ReleaseManagedResources();
+            }
+
+            _isDisposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~DisposableObject()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Git.CredentialManager
 
         public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
+            ThrowIfDisposed();
+
             Uri uri = GetUriFromInput(input);
 
             // Determine the if the host supports Windows Integration Authentication (WIA)
@@ -115,10 +117,10 @@ namespace Microsoft.Git.CredentialManager
             }
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void ReleaseManagedResources()
         {
             _winAuth.Dispose();
-            base.Dispose(disposing);
+            base.ReleaseManagedResources();
         }
 
         #endregion

--- a/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Git.CredentialManager
     /// Represents a Git hosting provider where credentials can be stored and recalled in/from the Operating System's
     /// secure credential store.
     /// </summary>
-    public abstract class HostProvider : IHostProvider
+    public abstract class HostProvider : DisposableObject, IHostProvider
     {
         protected HostProvider(ICommandContext context)
         {
@@ -193,23 +193,6 @@ namespace Microsoft.Git.CredentialManager
             }
 
             return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Called when the application is being terminated. Clean up and release any resources.
-        /// </summary>
-        /// <param name="disposing">True if the instance is being disposed, false if being finalized.</param>
-        protected virtual void Dispose(bool disposing) { }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        ~HostProvider()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/IGit.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IGit.cs
@@ -8,9 +8,10 @@ namespace Microsoft.Git.CredentialManager
     public interface IGitConfiguration : IDisposable
     {
         /// <summary>
-        /// Path to repository if this configuration object is also scoped to a repository, otherwise null.
+        /// Enumerate all configuration entries invoking the specified callback for each entry.
         /// </summary>
-        string RepositoryPath { get; }
+        /// <param name="cb">Callback to invoke for each configuration entry.</param>
+        void Enumerate(GitConfigurationEnumerationCallback cb);
 
         /// <summary>
         /// Try and get the value of a configuration entry as a string.
@@ -20,6 +21,14 @@ namespace Microsoft.Git.CredentialManager
         /// <returns>True if the value was found, false otherwise.</returns>
         bool TryGetValue(string name, out string value);
     }
+
+    /// <summary>
+    /// Invoked for each Git configuration entry during an enumeration (<see cref="IGitConfiguration.Enumerate"/>).
+    /// </summary>
+    /// <param name="name">Name of the current configuration entry.</param>
+    /// <param name="value">Value of the current configuration entry.</param>
+    /// <returns>True to continue enumeration, false to stop enumeration.</returns>
+    public delegate bool GitConfigurationEnumerationCallback(string name, string value);
 
     public interface IGit : IDisposable
     {

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/LibGit2.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/LibGit2.cs
@@ -10,13 +10,22 @@ namespace Microsoft.Git.CredentialManager.Interop
 {
     public class LibGit2 : IGit
     {
-        public LibGit2()
+        private readonly ITrace _trace;
+
+        public LibGit2(ITrace trace)
         {
+            EnsureArgument.NotNull(trace, nameof(trace));
+
+            _trace = trace;
+
+            _trace.WriteLine("Initializing libgit2...");
             git_libgit2_init();
         }
 
         public unsafe IGitConfiguration GetConfiguration(string repositoryPath)
         {
+            _trace.WriteLine("Opening default Git configuration...");
+
             // Open the default, non-repository-scoped configuration (progdata, system, xdg, global)
             // Note that currently git_config_open_default(git_config** does not search /usr/local/etc for Git configuration
             // files (such as those used by Homebrew installations on macOS, or locally built Git instances).
@@ -31,6 +40,7 @@ namespace Microsoft.Git.CredentialManager.Interop
                 string repoConfigPath = Path.Combine(repositoryPath, ".git", "config");
 
                 // Add the repository configuration
+                _trace.WriteLine($"Adding local configuration from repository '{repositoryPath}'...");
                 int error = git_config_add_file_ondisk(config, repoConfigPath, GIT_CONFIG_LEVEL_LOCAL, null, 0);
                 switch (error)
                 {
@@ -44,11 +54,13 @@ namespace Microsoft.Git.CredentialManager.Interop
                 }
             }
 
-            return new LibGit2Configuration(config, repositoryPath);
+            return new LibGit2Configuration(_trace, config);
         }
 
         public string GetRepositoryPath(string path)
         {
+            _trace.WriteLine($"Discovering repository from path '{path}'...");
+
             var buf = new git_buf();
             int error = git_repository_discover(buf, path, true, null);
 
@@ -57,7 +69,9 @@ namespace Microsoft.Git.CredentialManager.Interop
                 switch (error)
                 {
                     case GIT_OK:
-                        return buf.ToString();
+                        string repoPath = buf.ToString();
+                        _trace.WriteLine($"Found repository at '{repoPath}'.");
+                        return repoPath;
                     case GIT_ENOTFOUND:
                         return null;
                     default:
@@ -90,31 +104,61 @@ namespace Microsoft.Git.CredentialManager.Interop
 
     internal class LibGit2Configuration : IGitConfiguration
     {
+        private readonly ITrace _trace;
         private readonly unsafe git_config* _config;
         private readonly unsafe git_config* _snapshot;
 
-        internal unsafe LibGit2Configuration(git_config* config, string repositoryPath)
+        internal unsafe LibGit2Configuration(ITrace trace, git_config* config)
         {
+            _trace = trace;
             _config = config;
-            RepositoryPath = repositoryPath;
 
             // Create snapshot for reading values
+            _trace.WriteLine("Creating Git configuration snapshot...");
             git_config* snapshot = null;
             ThrowIfError(git_config_snapshot(&snapshot, config), nameof(git_config_snapshot));
             _snapshot = snapshot;
         }
 
-        public string RepositoryPath { get; }
+        public unsafe void Enumerate(GitConfigurationEnumerationCallback cb)
+        {
+            int native_cb(git_config_entry entry, void* payload)
+            {
+                if (!cb(entry.GetName(), entry.GetValue()))
+                {
+                    return GIT_ITEROVER;
+                }
+
+                return GIT_OK;
+            }
+
+            _trace.WriteLine("Enumerating Git configuration entries...");
+            var result = git_config_foreach(_config, native_cb, (void*) IntPtr.Zero);
+
+            switch (result)
+            {
+                case GIT_OK:
+                case GIT_ITEROVER:
+                    _trace.WriteLine("Enumeration complete.");
+                    break;
+                default:
+                    ThrowIfError(result, nameof(git_config_foreach));
+                    break;
+            }
+        }
 
         public unsafe bool TryGetValue(string name, out string value)
         {
+            _trace.WriteLine($"Reading Git configuration entry '{name}'...");
             int result = git_config_get_string(out value, _snapshot, name);
 
             switch (result)
             {
                 case GIT_OK:
+                    _trace.WriteLine($"Successfully read value '{value}'.");
                     return true;
                 case GIT_ENOTFOUND:
+                    _trace.WriteLine("No entry found.");
                     value = null;
                     break;
                 default:
@@ -129,6 +173,7 @@ namespace Microsoft.Git.CredentialManager.Interop
         {
             unsafe
             {
+                _trace.WriteLine("Disposing Git configuration...");
                 git_config_free(_snapshot);
                 git_config_free(_config);
             }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.cs
@@ -73,11 +73,17 @@ namespace Microsoft.Git.CredentialManager.Interop.Native
             string name);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_config_foreach(git_config* cfg, git_config_foreach_cb callback, void* payload);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe int git_config_open_default(git_config** @out);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe int git_config_snapshot(git_config** @out, git_config* config);
     }
+
+    public unsafe delegate int git_config_foreach_cb(git_config_entry entry, void* payload);
+    public delegate void git_config_entry_free_callback(git_config_entry entry);
 
     [StructLayout(LayoutKind.Sequential)]
     public class git_error
@@ -96,6 +102,27 @@ namespace Microsoft.Git.CredentialManager.Interop.Native
         public override unsafe string ToString()
         {
             return U8StringConverter.ToManaged(ptr);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class git_config_entry
+    {
+        public unsafe byte* name;
+        public unsafe byte* value;
+        public uint include_depth;
+        public git_config_level_t level;
+        public git_config_entry_free_callback free;
+        public unsafe void* payload;
+
+        public unsafe string GetName()
+        {
+            return U8StringConverter.ToManaged(name);
+        }
+
+        public unsafe string GetValue()
+        {
+            return U8StringConverter.ToManaged(value);
         }
     }
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixFileDescriptor.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixFileDescriptor.cs
@@ -9,11 +9,9 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
     /// <summary>
     /// Represents a thin wrapper over a POSIX file descriptor.
     /// </summary>
-    public class PosixFileDescriptor : IDisposable
+    public class PosixFileDescriptor : DisposableObject
     {
         private readonly int _fd;
-
-        private bool _isDisposed;
 
         private PosixFileDescriptor()
         {
@@ -72,27 +70,14 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
             return Write(buf, buf.Length);
         }
 
-        private void Dispose(bool disposing)
+        protected override void ReleaseUnmanagedResources()
         {
-            if (_isDisposed)
-            {
-                return;
-            }
-
             if (!IsInvalid)
             {
                 Unistd.close(_fd);
             }
 
-            _isDisposed = true;
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(PosixFileDescriptor));
-            }
+            base.ReleaseUnmanagedResources();
         }
 
         private void ThrowIfInvalid()
@@ -101,17 +86,6 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
             {
                 throw new InvalidOperationException("File descriptor is invalid");
             }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        ~PosixFileDescriptor()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/StringExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/StringExtensions.cs
@@ -92,6 +92,25 @@ namespace Microsoft.Git.CredentialManager
         }
 
         /// <summary>
+        /// Truncate the string from the first index of the given character, also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to truncate.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Truncated string.</returns>
+        public static string TruncateFromIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int last = str.IndexOf(c);
+            if (last > -1)
+            {
+                return str.Substring(0, last);
+            }
+
+            return str;
+        }
+
+        /// <summary>
         /// Truncate the string from the last index of the given character, also removing the indexed character.
         /// </summary>
         /// <param name="str">String to truncate.</param>
@@ -143,6 +162,47 @@ namespace Microsoft.Git.CredentialManager
             EnsureArgument.NotNull(str, nameof(str));
 
             int first = str.IndexOf(value, comparisonType);
+            if (first > -1)
+            {
+                return str.Substring(first + value.Length, str.Length - first - value.Length);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the last index of the given character,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilLastIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.LastIndexOf(c);
+            if (first > -1)
+            {
+                return str.Substring(first + 1, str.Length - first - 1);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the last index of the given string,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="value">String to locate the index of.</param>
+        /// <param name="comparisonType">Comparison rule for locating the string.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilLastIndexOf(this string str, string value, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.LastIndexOf(value, comparisonType);
             if (first > -1)
             {
                 return str.Substring(first + value.Length, str.Length - first - value.Length);

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -42,5 +42,11 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             string format, object[] secrets, string filePath, int lineNumber, string memberName) { }
 
         #endregion
+
+        #region IDisposable
+
+        void IDisposable.Dispose() { }
+
+        #endregion
     }
 }

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
@@ -28,6 +29,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         ICredentialStore ICommandContext.CredentialStore => CredentialStore;
 
         IHttpClientFactory ICommandContext.HttpClientFactory => HttpClientFactory;
+
+        #endregion
+
+        #region IDisposable
+
+        void IDisposable.Dispose() { }
 
         #endregion
     }

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public TestGitRepository AddRepository(string repoPath, IDictionary<string, string> config = null)
         {
-            var repoConfig = new TestGitConfiguration(repoPath, config);
+            var repoConfig = new TestGitConfiguration(config);
             var repo = new TestGitRepository(repoPath, repoConfig);
 
             Repositories.Add(repoPath, repo);
@@ -41,7 +41,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
             IDictionary<string, string> mergedConfigDict = MergeDictionaries(GlobalConfiguration.Dictionary, repo.Configuration.Dictionary);
 
-            return new TestGitConfiguration(repositoryPath, mergedConfigDict);
+            return new TestGitConfiguration(mergedConfigDict);
         }
 
         string IGit.GetRepositoryPath(string path) =>

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -7,15 +7,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestGitConfiguration : IGitConfiguration
     {
-        public TestGitConfiguration() : this(null, null) { }
-
-        public TestGitConfiguration(string repositoryPath) : this(repositoryPath, null) { }
-
-        public TestGitConfiguration(IDictionary<string,string> config) : this(null, config) { }
-
-        public TestGitConfiguration(string repositoryPath, IDictionary<string,string> config)
+        public TestGitConfiguration(IDictionary<string,string> config = null)
         {
-            RepositoryPath = repositoryPath;
             Dictionary = config ?? new Dictionary<string, string>();
         }
 
@@ -32,7 +25,16 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         #region IGitConfiguration
 
-        public string RepositoryPath { get; set; }
+        public void Enumerate(GitConfigurationEnumerationCallback cb)
+        {
+            foreach (var kvp in Dictionary)
+            {
+                if (!cb(kvp.Key, kvp.Value))
+                {
+                    break;
+                }
+            }
+        }
 
         public bool TryGetValue(string name, out string value) => Dictionary.TryGetValue(name, out value);
 

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -63,5 +63,11 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         }
 
         #endregion
+
+        #region IDisposable
+
+        void IDisposable.Dispose() { }
+
+        #endregion
     }
 }

--- a/src/windows/Microsoft.Authentication.Helper.Windows/Program.cs
+++ b/src/windows/Microsoft.Authentication.Helper.Windows/Program.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Authentication.Helper
     {
         public static void Main(string[] args)
         {
-            var context = new CommandContext();
+            using (var context = new CommandContext())
             using (var app = new Application(context))
             {
                 int exitCode = app.RunAsync(args)


### PR DESCRIPTION
Keep hold of a single `IGitConfiguration` object when creating an instance of the `Settings` component.

When querying for scoped settings now we enumerate all configuration entries and store all those that have the same section and property name locally up-front. This prevents us from calling `TryGetValue` on the configuration object multiple times.

Add tracing to the libgit2 calls.