### PR TITLE
New Install 2/6: Rename main executable to GCM Core to make SxS easier

### DIFF
--- a/.github/ISSUE_TEMPLATE/auth-problem.md
+++ b/.github/ISSUE_TEMPLATE/auth-problem.md
@@ -8,7 +8,7 @@ assignees: ''
 
 **Which version of GCM Core are you using?**
 
-From a terminal, run `git-credential-manager version` and paste the output.
+From a terminal, run `git-credential-manager-core version` and paste the output.
 
 <!-- Ex:
 Git Credential Manager version 2.0.8-beta+e1f8492d04 (macOS, .NET Core 4.6.27129.04)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/out/shared/Git-Credential-Manager/bin/Debug/netcoreapp2.1/git-credential-manager.dll",
+            "program": "${workspaceFolder}/out/shared/Git-Credential-Manager/bin/Debug/netcoreapp2.1/git-credential-manager-core.dll",
             "args": ["get"],
             "cwd": "${workspaceFolder}/out/shared/Git-Credential-Manager",
             "console": "integratedTerminal",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use GCM Core, you can download the [latest installer](https://github.com/Micr
 
 ### Git Credential Manager for Mac and Linux (Java-based GCM)
 
-If you have an existing installation of the 'Java GCM' on macOS and you have installed this using Homebrew, this installation will be unlinked (`brew unlink git-credential-manager`) when GCM Core is installed. Additionally any symlinks or files previously located at `/usr/local/bin/git-credential-manager` will be replaced with a GCM Core symlink.
+If you have an existing installation of the 'Java GCM' on macOS and you have installed this using Homebrew, this installation will be unlinked (`brew unlink git-credential-manager`) when GCM Core is installed.
 
 ## How to use
 

--- a/src/osx/Installer.Mac/scripts/configure-git.sh
+++ b/src/osx/Installer.Mac/scripts/configure-git.sh
@@ -8,7 +8,7 @@ set -e
 PATH=""
 eval $(/usr/libexec/path_helper -s)
 
-git config --system credential.helper /usr/local/share/gcm-core/git-credential-manager
+git config --system credential.helper /usr/local/share/gcm-core/git-credential-manager-core
 git config --system credential.https://dev.azure.com.useHttpPath true
 
 exit 0

--- a/src/osx/Installer.Mac/scripts/postinstall
+++ b/src/osx/Installer.Mac/scripts/postinstall
@@ -24,7 +24,7 @@ then
 fi
 
 # Create symlink to GCM in /usr/local/bin
-/bin/ln -Fs /usr/local/share/gcm-core/git-credential-manager /usr/local/bin/git-credential-manager
+/bin/ln -Fs /usr/local/share/gcm-core/git-credential-manager-core /usr/local/bin/git-credential-manager-core
 
 # Set system gitconfig for the current user
 USER_ID="$(id -u "${USER}")"

--- a/src/osx/Installer.Mac/uninstall.sh
+++ b/src/osx/Installer.Mac/uninstall.sh
@@ -2,7 +2,7 @@
 
 # Unconfigure GCM
 HELPER="$(git config --system credential.helper)"
-if [ "$HELPER" = "/usr/local/share/gcm-core/git-credential-manager" ]
+if [ "$HELPER" = "/usr/local/share/gcm-core/git-credential-manager-core" ]
 then
 	echo "Resetting credential helper to 'osxkeychain'..."
 	sudo git config --system credential.helper osxkeychain
@@ -11,10 +11,10 @@ else
 fi
 
 # Remove GCM symlink
-if [ -L /usr/local/bin/git-credential-manager ]
+if [ -L /usr/local/bin/git-credential-manager-core ]
 then
 	echo "Deleting GCM symlink..."
-	rm /usr/local/bin/git-credential-manager
+	rm /usr/local/bin/git-credential-manager-core
 else
 	echo "No GCM symlink found."
 fi

--- a/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
+++ b/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <FilesToSign Include="
-      $(OutDir)\git-credential-manager.dll;
+      $(OutDir)\git-credential-manager-core.dll;
       $(OutDir)\GitHub.dll;
       $(OutDir)\Microsoft.AzureRepos.dll;
       $(OutDir)\Microsoft.Git.CredentialManager.dll;">
@@ -28,7 +28,7 @@
       <InProject>false</InProject>
     </FilesToSign>
     <MacFilesToSign Include="
-      $(OutDir)\git-credential-manager;
+      $(OutDir)\git-credential-manager-core;
       $(OutDir)\Microsoft.Authentication.Helper;">
       <InProject>false</InProject>
     </MacFilesToSign>

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -5,11 +5,12 @@
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netcoreapp2.1;net461</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
-    <AssemblyName>git-credential-manager</AssemblyName>
+    <AssemblyName>git-credential-manager-core</AssemblyName>
     <RootNamespace>Microsoft.Git.CredentialManager</RootNamespace>
     <ApplicationIcon>$(RepoAssetsPath)gcmicon.ico</ApplicationIcon>
     <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -11,12 +11,12 @@
   #error Payload directory path property 'PayloadDir' must be specified
 #endif
 
-#ifnexist PayloadDir + "\git-credential-manager.exe"
+#ifnexist PayloadDir + "\git-credential-manager-core.exe"
   #error Payload files are missing
 #endif
 
 ; Define core properties
-#define GcmName "Git Credential Manager"
+#define GcmName "Git Credential Manager Core"
 #define GcmPublisher "Microsoft Corporation"
 #define GcmPublisherUrl "https://www.microsoft.com"
 #define GcmCopyright "Copyright (c) Microsoft 2019"
@@ -30,7 +30,7 @@
 #define VerMinor
 #define VerBuild
 #define VerRevision
-#expr ParseVersion(PayloadDir + "\git-credential-manager.exe", VerMajor, VerMinor, VerBuild, VerRevision)
+#expr ParseVersion(PayloadDir + "\git-credential-manager-core.exe", VerMajor, VerMinor, VerBuild, VerRevision)
 #define GcmVersion str(VerMajor) + "." + str(VerMinor) + "." + str(VerBuild) + "." + str(VerRevision)
 
 [Setup]
@@ -49,37 +49,38 @@ VersionInfoVersion={#GcmVersion}
 LicenseFile={#GcmRepoRoot}\LICENSE
 OutputBaseFilename=gcmcore-windows-{#GcmVersion}
 DefaultDirName={pf}\{#GcmName}
-DisableReadyPage=yes
 Compression=lzma2
 SolidCompression=yes
 MinVersion=6.1.7600
 DisableDirPage=yes
 ArchitecturesInstallIn64BitMode=x64
-UninstallDisplayIcon={app}\git-credential-manager.exe
+UninstallDisplayIcon={app}\git-credential-manager-core.exe
 SetupIconFile={#GcmAssets}\gcmicon.ico
 WizardImageFile={#GcmAssets}\gcmicon128.bmp
 WizardSmallImageFile={#GcmAssets}\gcmicon64.bmp
+WizardStyle=modern
 WizardImageStretch=no
 WindowResizable=no
+ChangesEnvironment=yes
 
 [Languages]
-Name: "english"; MessagesFile: "compiler:Default.isl";
+Name: english; MessagesFile: "compiler:Default.isl";
 
 [Types]
-Name: "full"; Description: "Full installation"; Flags: iscustom;
+Name: full; Description: "Full installation"; Flags: iscustom;
 
 [Components]
 ; TODO
 
 [Files]
-Source: "{#PayloadDir}\git-credential-manager.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\GitHub.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\GitHub.UI.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\GitHub.Authentication.Helper.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\git2-572e4d8.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Authentication.Helper.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Authentication.Helper.exe.config"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.AzureRepos.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Git.CredentialManager.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Identity.Client.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\git-credential-manager-core.exe";               DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\GitHub.dll";                                    DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\GitHub.UI.dll";                                 DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\GitHub.Authentication.Helper.exe";              DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\git2-572e4d8.dll";                              DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Authentication.Helper.exe";           DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Authentication.Helper.exe.config";    DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.AzureRepos.dll";                      DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Git.CredentialManager.dll";           DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Identity.Client.dll";                 DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Identity.Client.Extensions.Msal.dll"; DestDir: "{app}"; Flags: ignoreversion

--- a/src/windows/Payload.Windows/Payload.Windows.csproj
+++ b/src/windows/Payload.Windows/Payload.Windows.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\GitHub.Authentication.Helper.Windows\GitHub.Authentication.Helper.Windows.csproj" />
     <ProjectReference Include="..\Microsoft.Authentication.Helper.Windows\Microsoft.Authentication.Helper.Windows.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0">
       <PrivateAssets>all</PrivateAssets>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <FilesToSign Include="
-      $(OutDir)git-credential-manager.exe;
+      $(OutDir)git-credential-manager-core.exe;
       $(OutDir)GitHub.dll;
       $(OutDir)GitHub.UI.dll;
       $(OutDir)GitHub.Authentication.Helper.exe;
@@ -51,7 +51,7 @@
 
   <!-- We don't want to produce a binary with this project -->
   <Target Name="CoreCompile" />
-  
+
   <!-- We only want to copy the dependent projects' outputs; no binary is produced for this project -->
   <Target Name="CopyFilesToOutputDirectory"
           DependsOnTargets="


### PR DESCRIPTION
Rename the main executable to include "-core" to make side-by-side installs of GCM Core and Windows-only GCM easier.

We can just change the configuration between "manager" and "manager-core".

~**Note for reviewers:** please wait until #69 is complete for an easier time reviewing, or just view the latest commit in this PR as this branch is based on changes from #69.~