### PR TITLE
New Install 4/6: Extend IGitConfiguration to allow manipulating multivars

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/IGit.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IGit.cs
@@ -14,12 +14,56 @@ namespace Microsoft.Git.CredentialManager
         void Enumerate(GitConfigurationEnumerationCallback cb);
 
         /// <summary>
+        /// Get a snapshot of the configuration filtered to the specified level.
+        /// </summary>
+        /// <param name="level">Configuration level filter.</param>
+        /// <returns>Git configuration snapshot.</returns>
+        IGitConfiguration GetFilteredConfiguration(GitConfigurationLevel level);
+
+        /// <summary>
         /// Try and get the value of a configuration entry as a string.
         /// </summary>
         /// <param name="name">Configuration entry name.</param>
         /// <param name="value">Configuration entry value.</param>
         /// <returns>True if the value was found, false otherwise.</returns>
         bool TryGetValue(string name, out string value);
+
+        /// <summary>
+        /// Set the value of a configuration entry.
+        /// </summary>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="value">Configuration entry value.</param>
+        void SetValue(string name, string value);
+
+        /// <summary>
+        /// Deletes a configuration entry from the highest level.
+        /// </summary>
+        /// <param name="name">Configuration entry name.</param>
+        void DeleteEntry(string name);
+
+        /// <summary>
+        /// Get all values of a multivar configuration entry.
+        /// </summary>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="regexp">Regular expression to filter which variables we're interested in. Use null to indicate all.</param>
+        /// <returns>All values of the multivar configuration entry.</returns>
+        IEnumerable<string> GetMultivarValue(string name, string regexp);
+
+        /// <summary>
+        /// Set a multivar configuration entry value.
+        /// </summary>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="regexp">Regular expression to indicate which values to replace.</param>
+        /// <param name="value">Configuration entry value.</param>
+        /// <remarks>If the regular expression does not match any existing entry, a new entry is created.</remarks>
+        void SetMultivarValue(string name, string regexp, string value);
+
+        /// <summary>
+        /// Deletes one or several entries from a multivar.
+        /// </summary>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="regexp">Regular expression to indicate which values to delete.</param>
+        void DeleteMultivarEntry(string name, string regexp);
     }
 
     /// <summary>
@@ -45,6 +89,15 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="path">Path to resolve.</param>
         /// <returns>Git repository root path, or null if <paramref name="path"/> is not inside of a Git repository.</returns>
         string GetRepositoryPath(string path);
+    }
+
+    public enum GitConfigurationLevel
+    {
+        ProgramData,
+        System,
+        Xdg,
+        Global,
+        Local,
     }
 
     public static class GitExtensions

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.Error.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.Error.cs
@@ -164,15 +164,20 @@ namespace Microsoft.Git.CredentialManager.Interop.Native
             {
                 unsafe
                 {
-                    git_error error = git_error_last();
-
-                    string errorMessage = U8StringConverter.ToManaged(error.message);
-
                     string mainMessage = functionName is null
                         ? $"libgit2 '{functionName}' returned non-zero value"
                         : "libgit2 returned non-zero value";
 
-                    throw new InteropException(mainMessage, result, new Exception(errorMessage));
+                    git_error* error = git_error_last();
+
+                    if (error != null && error->message != null)
+                    {
+                        string errorMessage = U8StringConverter.ToManaged(error->message);
+
+                        throw new InteropException(mainMessage, result, new Exception(errorMessage));
+                    }
+
+                    throw new InteropException(mainMessage, result);
                 }
             }
         }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Native
         public static extern int git_libgit2_shutdown();
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern git_error git_error_last();
+        public static extern unsafe git_error* git_error_last();
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void git_buf_dispose(git_buf buf);
@@ -76,7 +76,53 @@ namespace Microsoft.Git.CredentialManager.Interop.Native
         public static extern unsafe int git_config_foreach(git_config* cfg, git_config_foreach_cb callback, void* payload);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_config_set_string(
+            git_config* cfg,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string name,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string value);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_config_delete_entry(
+            git_config* cfg,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string name);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_config_get_multivar_foreach(
+            git_config* cfg,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string name,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string regexp,
+            git_config_foreach_cb callback,
+            void *payload);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_config_set_multivar(
+            git_config* cfg,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string name,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string regexp,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string value);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_config_delete_multivar(
+            git_config* cfg,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string name,
+            [MarshalAs(CustomMarshaler, MarshalCookie = NativeCookie, MarshalTypeRef = typeof(U8StringMarshaler))]
+            string regexp);
+
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe int git_config_open_default(git_config** @out);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_config_open_level(git_config** @out, git_config* parent, git_config_level_t level);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe int git_config_snapshot(git_config** @out, git_config* config);
@@ -86,9 +132,9 @@ namespace Microsoft.Git.CredentialManager.Interop.Native
     public delegate void git_config_entry_free_callback(git_config_entry entry);
 
     [StructLayout(LayoutKind.Sequential)]
-    public class git_error
+    public unsafe struct git_error
     {
-        public unsafe byte* message;
+        public byte* message;
         public int klass;
     }
 

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -8,25 +8,21 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestGit : IGit
     {
-        public TestGit(IDictionary<string, string> globalConfig = null)
+        public TestGitConfiguration GlobalConfiguration { get; } = new TestGitConfiguration();
+
+        public IDictionary<string, TestGitRepository> Repositories { get; } = new Dictionary<string, TestGitRepository>();
+
+        public TestGitRepository AddRepository(TestGitRepository repo)
         {
-            GlobalConfiguration = new TestGitConfiguration(globalConfig);
-        }
-
-        public TestGitConfiguration GlobalConfiguration { get; }
-
-        public IDictionary<string, TestGitRepository> Repositories { get; } =
-            new Dictionary<string, TestGitRepository>();
-
-        public TestGitRepository AddRepository(string repoPath, IDictionary<string, string> config = null)
-        {
-            var repoConfig = new TestGitConfiguration(config);
-            var repo = new TestGitRepository(repoPath, repoConfig);
-
-            Repositories.Add(repoPath, repo);
-
+            Repositories.Add(repo.Path, repo);
             return repo;
         }
+
+        public TestGitRepository AddRepository(string repoPath, TestGitConfiguration repoConfig) =>
+            AddRepository(new TestGitRepository(repoPath, repoConfig));
+
+        public TestGitRepository AddRepository(string repoPath) =>
+            AddRepository(repoPath, new TestGitConfiguration());
 
         #region IGit
 
@@ -39,21 +35,20 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
                 return GlobalConfiguration;
             }
 
-            IDictionary<string, string> mergedConfigDict = MergeDictionaries(GlobalConfiguration.Dictionary, repo.Configuration.Dictionary);
+            IDictionary<string, IList<string>> mergedConfigDict = MergeDictionaries(GlobalConfiguration.Dictionary, repo.Configuration.Dictionary);
 
             return new TestGitConfiguration(mergedConfigDict);
         }
 
-        string IGit.GetRepositoryPath(string path) =>
-            Repositories.Keys.FirstOrDefault(path.StartsWith);
+        string IGit.GetRepositoryPath(string path) => Repositories.Keys.FirstOrDefault(path.StartsWith);
 
         #endregion
 
-        private static IDictionary<string, string> MergeDictionaries(params IDictionary<string, string>[] dictionaries)
+        private static IDictionary<string, IList<string>> MergeDictionaries(params IDictionary<string, IList<string>>[] dictionaries)
         {
-            var result = new Dictionary<string, string>();
+            var result = new Dictionary<string, IList<string>>();
 
-            foreach (var dict in dictionaries)
+            foreach (IDictionary<string, IList<string>> dict in dictionaries)
             {
                 foreach (var kvp in dict)
                 {

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -2,26 +2,32 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestGitConfiguration : IGitConfiguration
     {
-        public TestGitConfiguration(IDictionary<string,string> config = null)
+        public TestGitConfiguration(IDictionary<string, IList<string>> config = null)
         {
-            Dictionary = config ?? new Dictionary<string, string>();
+            Dictionary = config ?? new Dictionary<string, IList<string>>();
         }
 
         /// <summary>
         /// Backing dictionary for the test configuration entries.
         /// </summary>
-        public IDictionary<string, string> Dictionary { get; }
+        public IDictionary<string, IList<string>> Dictionary { get; }
 
         /// <summary>
         /// Convenience accessor for the backing <see cref="Dictionary"/> of configuration entries.
         /// </summary>
         /// <param name="key"></param>
-        public string this[string key] { get => Dictionary[key]; set => Dictionary[key] = value; }
+        public string this[string key]
+        {
+            get => TryGetValue(key, out string value) ? value : null;
+            set => SetValue(key, value);
+        }
 
         #region IGitConfiguration
 
@@ -29,14 +35,138 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         {
             foreach (var kvp in Dictionary)
             {
-                if (!cb(kvp.Key, kvp.Value))
+                foreach (var value in kvp.Value)
                 {
-                    break;
+                    if (!cb(kvp.Key, value))
+                    {
+                        break;
+                    }
                 }
             }
         }
 
-        public bool TryGetValue(string name, out string value) => Dictionary.TryGetValue(name, out value);
+        public IGitConfiguration GetFilteredConfiguration(GitConfigurationLevel level)
+        {
+            return this;
+        }
+
+        public bool TryGetValue(string name, out string value)
+        {
+            if (Dictionary.TryGetValue(name, out var values))
+            {
+                // Simulate libgit2
+                if (values.Count > 1)
+                {
+                    throw new Exception("Configuration entry is a multivar");
+                }
+
+                if (values.Count == 1)
+                {
+                    value = values[0];
+                    return true;
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        public void SetValue(string name, string value)
+        {
+            if (!Dictionary.TryGetValue(name, out IList<string> values))
+            {
+                values = new List<string>();
+                Dictionary[name] = values;
+            }
+
+            // Simulate libgit2
+            if (values.Count > 1)
+            {
+                throw new Exception("Configuration entry is a multivar");
+            }
+
+            if (values.Count == 1)
+            {
+                values[0] = value;
+            }
+            else if (values.Count == 0)
+            {
+                values.Add(value);
+            }
+        }
+
+        public void DeleteEntry(string name)
+        {
+            // Simulate libgit2
+            if (Dictionary.TryGetValue(name, out var values) && values.Count > 1)
+            {
+                throw new Exception("Configuration entry is a multivar");
+            }
+
+            Dictionary.Remove(name);
+        }
+
+        public IEnumerable<string> GetMultivarValue(string name, string regexp)
+        {
+            if (Dictionary.TryGetValue(name, out IList<string> values))
+            {
+                return values.Where(x => Regex.IsMatch(x, regexp));
+            }
+
+            return Enumerable.Empty<string>();
+        }
+
+        public void SetMultivarValue(string name, string regexp, string value)
+        {
+            if (!Dictionary.TryGetValue(name, out IList<string> values))
+            {
+                values = new List<string>();
+                Dictionary[name] = values;
+            }
+
+            bool updated = false;
+            for (int i = 0; i < values.Count; i++)
+            {
+                // Update matching values
+                if (Regex.IsMatch(values[i], regexp))
+                {
+                    values[i] = value;
+                    updated = true;
+                }
+            }
+
+            // If no existing value was found to update, add a new one
+            if (!updated)
+            {
+                values.Add(value);
+            }
+        }
+
+        public void DeleteMultivarEntry(string name, string regexp)
+        {
+            if (Dictionary.TryGetValue(name, out IList<string> values))
+            {
+                for (int i = 0; i < values.Count;)
+                {
+                    // Remove matching values
+                    if (Regex.IsMatch(values[i], regexp))
+                    {
+                        values.RemoveAt(i);
+                    }
+                    else
+                    {
+                        // Move to the next value
+                        i++;
+                    }
+                }
+
+                // If we've removed all values, remove the top-level list from the multivar dictionary
+                if (values.Count == 0)
+                {
+                    Dictionary.Remove(name);
+                }
+            }
+        }
 
         void IDisposable.Dispose() { }
 


### PR DESCRIPTION
Extend the IGitConfiguration to allow manipulation of Git configuration 'multivars' (config entries that can have multiple values). This will be used in future commits to set the credential.helper variable to have two values.

**Note for reviewers:** please wait until #71 is complete for an easier time reviewing, or just view the latest commit in this PR as this branch is based on changes from #71.