### PR TITLE
Replace old SHA1 signing certificates with SHA256 ones

### DIFF
--- a/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
+++ b/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
@@ -24,7 +24,7 @@
       $(OutDir)\GitHub.dll;
       $(OutDir)\Microsoft.AzureRepos.dll;
       $(OutDir)\Microsoft.Git.CredentialManager.dll;">
-      <Authenticode>Microsoft</Authenticode>
+      <Authenticode>Microsoft400</Authenticode>
       <InProject>false</InProject>
     </FilesToSign>
     <MacFilesToSign Include="

--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -30,7 +30,7 @@
   <Target Name="CreateFilesToSignItems" DependsOnTargets="GetBuildVersion" BeforeTargets="PrepareForRun">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)gcmcore-windows-$(BuildVersion).exe">
-        <Authenticode>Microsoft</Authenticode>
+        <Authenticode>Microsoft400</Authenticode>
         <InProject>false</InProject>
       </FilesToSign>
     </ItemGroup>

--- a/src/windows/Payload.Windows/Payload.Windows.csproj
+++ b/src/windows/Payload.Windows/Payload.Windows.csproj
@@ -29,7 +29,7 @@
       $(OutDir)Microsoft.AzureRepos.dll;
       $(OutDir)Microsoft.Git.CredentialManager.dll;
       $(OutDir)Microsoft.Authentication.Helper.exe;">
-      <Authenticode>Microsoft</Authenticode>
+      <Authenticode>Microsoft400</Authenticode>
       <InProject>false</InProject>
     </FilesToSign>
   </ItemGroup>


### PR DESCRIPTION
Per policy we should stop using SHA1 certificates for signing binaries and installers. The replacement for the 'Microsoft' Authenticode certificate is 'Microsoft400'.

Fixes #76.