### PR TITLE
Fix real-sign Windows build to actually sign

### DIFF
--- a/.azure-pipelines/templates/windows/compile.yml
+++ b/.azure-pipelines/templates/windows/compile.yml
@@ -1,4 +1,10 @@
 steps:
+- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
+  displayName: Install signing plugin
+  condition: and(succeeded(), eq(variables['SignType'], 'real'))
+  inputs:
+    signType: '$(SignType)'
+
 - task: DotNetCoreInstaller@0
   displayName: Install .NET Core SDK 2.2.100
   inputs:


### PR DESCRIPTION
Ensure the Signing MicroBuild plugin has been installed when doing a real-signed Windows build.