### PR TITLE
Fix up release build problems

### DIFF
--- a/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
@@ -24,5 +24,5 @@ steps:
   - task: PublishPipelineArtifact@0
     displayName: Upload unsigned package
     inputs:
-      artifactName: 'tmp.macpkg_unsigned'
+      artifactName: 'tmp.macinstaller_unsigned'
       targetPath: '$(Build.StagingDirectory)/pkg/gcmcore-osx-$(GitBuildVersion).pkg'

--- a/.azure-pipelines/templates/osx/pack.signed/step4-signpack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step4-signpack.yml
@@ -8,7 +8,7 @@ steps:
     displayName: Download unsigned package
     inputs:
       buildType: 'current'
-      artifactName: 'tmp.macpkg_unsigned'
+      artifactName: 'tmp.macinstaller_unsigned'
       downloadPath: '$(Build.StagingDirectory)\pkg'
 
   - powershell: |

--- a/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
@@ -4,29 +4,30 @@ steps:
     inputs:
       buildType: 'current'
       artifactName: 'tmp.macinstaller_signed'
-      downloadPath: '$(Build.StagingDirectory)\pkg'
+      downloadPath: '$(Build.StagingDirectory)/pkg'
 
   - task: DownloadPipelineArtifact@1
     displayName: Download signed payload
     inputs:
       buildType: 'current'
       artifactName: 'tmp.macpayload_signed'
-      downloadPath: '$(Build.StagingDirectory)\payload'
+      downloadPath: '$(Build.StagingDirectory)/payload'
 
   - task: DownloadPipelineArtifact@1
     displayName: Download symbols
     inputs:
       buildType: 'current'
       artifactName: 'tmp.macsymbols'
-      downloadPath: '$(Build.StagingDirectory)\symbols'
+      downloadPath: '$(Build.StagingDirectory)/symbols'
 
-  - script: src/osx/SignFiles.Mac/notarize-pkg.sh -id "$(AppleId)" -p "$(AppleIdPassword)" -pkg '$(Build.StagingDirectory)\pkg\*.pkg'
+  - script: src/osx/SignFiles.Mac/notarize-pkg.sh -id "$(AppleId)" -p "$(AppleIdPassword)" -pkg "$(Build.StagingDirectory)"/pkg/*.pkg
     displayName: Notarize and staple installer package
 
   - script: |
-      cp "$(Build.StagingDirectory)/pkg/*.pkg" "$(Build.StagingDirectory)/publish/"
-      cp "$(Build.StagingDirectory)/payload"   "$(Build.StagingDirectory)/publish/payload/"
-      cp "$(Build.StagingDirectory)/symbols"   "$(Build.StagingDirectory)/publish/payload.sym/"
+      mkdir -p "$(Build.StagingDirectory)/publish/payload" "$(Build.StagingDirectory)/publish/payload.sym"
+      cp -f  "$(Build.StagingDirectory)"/pkg/*.pkg "$(Build.StagingDirectory)/publish/"
+      cp -Rf "$(Build.StagingDirectory)/payload/"  "$(Build.StagingDirectory)/publish/payload/"
+      cp -Rf "$(Build.StagingDirectory)/symbols/"  "$(Build.StagingDirectory)/publish/payload.sym/"
     displayName: Prepare final build artifact
 
   - task: PublishPipelineArtifact@0

--- a/src/osx/SignFiles.Mac/notarize-pkg.sh
+++ b/src/osx/SignFiles.Mac/notarize-pkg.sh
@@ -75,7 +75,7 @@ if [[ -z $arg_Password ]]; then
     exit 1
 fi
 
-if [[ ! -f "$arg_PackagePath" ]]; then
+if [[ ! -f $arg_PackagePath ]]; then
     echo "[ERROR] Must supply valid / non-empty path to package!"
     exit 1
 fi


### PR DESCRIPTION
Use the correct path separator in the macOS build YAML for notarizing the installer pkg file and containing binaries. Also fix some quoting issues around scripts.

The [build here](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=11075149) of this branch is now green.