### PR TITLE
Add GCM_INTERACTIVE/credential.interactive setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,37 @@ For the complete list of settings GCM Core understands, see the list below.
 
 ## Available settings
 
+### credential.interactive
+
+Permit or disable GCM Core from interacting with the user (showing GUI or TTY prompts). If interaction is required but has been disabled, an error is returned.
+
+This can be helpful when using GCM Core in headless and unattended environments, such as build servers, where it would be preferable to fail than to hang indefinately waiting for a non-existent user.
+
+To disable interactivity set this to `false` or `0`.
+
+#### Compatibility
+
+In previous versions of GCM this setting had a different behavior and accepted other values.
+The following table summarizes the change in behavior and the mapping of older values such as `never`:
+
+Value(s)|Old meaning|New meaning
+-|-|-
+`auto`|Prompt if required – use cached credentials if possible|_(unchanged)_
+`never`,<br/>`false`| Never prompt – fail if interaction is required|_(unchanged)_
+`always`,<br/>`force`,<br/>`true`|Always prompt – don't use cached credentials|Prompt if required (same as the old `auto` value)
+
+#### Example
+
+```shell
+git config --global credential.interactive false
+```
+
+Defaults to enabled.
+
+**Also see: [GCM_INTERACTIVE](environment.md#GCM_INTERACTIVE)**
+
+---
+
 ### credential.provider
 
 Define the host provider to use when authenticating.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -121,6 +121,45 @@ _No configuration equivalent._
 
 ---
 
+### GCM_INTERACTIVE
+
+Permit or disable GCM Core from interacting with the user (showing GUI or TTY prompts). If interaction is required but has been disabled, an error is returned.
+
+This can be helpful when using GCM Core in headless and unattended environments, such as build servers, where it would be preferable to fail than to hang indefinately waiting for a non-existent user.
+
+To disable interactivity set this to `false` or `0`.
+
+#### Compatibility
+
+In previous versions of GCM this setting had a different behavior and accepted other values.
+The following table summarizes the change in behavior and the mapping of older values such as `never`:
+
+Value(s)|Old meaning|New meaning
+-|-|-
+`auto`|Prompt if required – use cached credentials if possible|_(unchanged)_
+`never`,<br/>`false`| Never prompt – fail if interaction is required|_(unchanged)_
+`always`,<br/>`force`,<br/>`true`|Always prompt – don't use cached credentials|Prompt if required (same as the old `auto` value)
+
+#### Example
+
+##### Windows
+
+```batch
+SET GCM_INTERACTIVE=0
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_INTERACTIVE=0
+```
+
+Defaults to enabled.
+
+**Also see: [credential.interactive](configuration.md#credentialinteractive)**
+
+---
+
 ### GCM_PROVIDER
 
 Define the host provider to use when authenticating.

--- a/src/osx/Microsoft.Authentication.Helper.Mac/Source/main.m
+++ b/src/osx/Microsoft.Authentication.Helper.Mac/Source/main.m
@@ -28,7 +28,8 @@ int main(int argc, const char * argv[]) {
 
     @autoreleasepool {
         int exitCode;
-        NSError* error;
+        NSError *error;
+        NSString *output;
 
         AHLogger *logger = [[AHLogger alloc] init];
 
@@ -97,24 +98,32 @@ int main(int argc, const char * argv[]) {
         NSString* clientId    = [configs objectForKey:@"clientId"];
         NSString* resource    = [configs objectForKey:@"resource"];
         NSString* redirectUri = [configs objectForKey:@"redirectUri"];
+        NSString* interactive = [configs objectForKey:@"interactive"];
 
-        NSString *accessToken = [AHGenerateAccessToken generateAccessTokenWithAuthority:authority
-                                                                               clientId:clientId
-                                                                               resource:resource
-                                                                            redirectUri:redirectUri
-                                                                                  error:&error
-                                                                                 logger:logger];
-
-        NSString* output;
-
-        if (error == nil && accessToken != nil)
+        // We only perform interactive flows
+        if (isTruthy(interactive))
         {
-            output = [NSString stringWithFormat:@"accessToken=%@\n", accessToken];
-            exitCode = 0;
+            NSString *accessToken = [AHGenerateAccessToken generateAccessTokenWithAuthority:authority
+                                                                                   clientId:clientId
+                                                                                   resource:resource
+                                                                                redirectUri:redirectUri
+                                                                                      error:&error
+                                                                                     logger:logger];
+
+            if (error == nil && accessToken != nil)
+            {
+                output = [NSString stringWithFormat:@"accessToken=%@\n", accessToken];
+                exitCode = 0;
+            }
+            else
+            {
+                output = [NSString stringWithFormat:@"error=%@\n", [error description]];
+                exitCode = -1;
+            }
         }
         else
         {
-            output = [NSString stringWithFormat:@"error=%@\n", [error description]];
+            output = @"error=Interactivity is required but has been disabled.\n";
             exitCode = -1;
         }
 

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -31,6 +31,8 @@ namespace GitHub
         {
             string userName, password;
 
+            ThrowIfUserInteractionDisabled();
+
             if (TryFindHelperExecutablePath(out string helperPath))
             {
                 IDictionary<string, string> resultDict = await InvokeHelperAsync(helperPath, "--prompt userpass", null);
@@ -47,7 +49,7 @@ namespace GitHub
             }
             else
             {
-                EnsureTerminalPromptsEnabled();
+                ThrowIfTerminalPromptsDisabled();
 
                 Context.Terminal.WriteLine("Enter GitHub credentials for '{0}'...", targetUri);
 
@@ -57,8 +59,11 @@ namespace GitHub
 
             return new GitCredential(userName, password);
         }
+
         public async Task<string> GetAuthenticationCodeAsync(Uri targetUri, bool isSms)
         {
+            ThrowIfUserInteractionDisabled();
+
             if (TryFindHelperExecutablePath(out string helperPath))
             {
                 IDictionary<string, string> resultDict = await InvokeHelperAsync(helperPath, "--prompt authcode", null);
@@ -72,7 +77,7 @@ namespace GitHub
             }
             else
             {
-                EnsureTerminalPromptsEnabled();
+                ThrowIfTerminalPromptsDisabled();
 
                 Context.Terminal.WriteLine("Two-factor authentication is enabled and an authentication code is required.");
 

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
@@ -56,6 +56,21 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
         }
 
         [Fact]
+        public void BasicAuthentication_GetCredentials_NoInteraction_ThrowsException()
+        {
+            const string testResource = "https://example.com";
+
+            var context = new TestCommandContext
+            {
+                Settings = {IsInteractionAllowed = false},
+            };
+
+            var basicAuth = new BasicAuthentication(context);
+
+            Assert.Throws<InvalidOperationException>(() => basicAuth.GetCredentials(testResource));
+        }
+
+        [Fact]
         public void BasicAuthentication_GetCredentials_NoTerminalPrompts_ThrowsException()
         {
             const string testResource = "https://example.com";

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/MicrosoftAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/MicrosoftAuthenticationTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using Microsoft.Git.CredentialManager.Authentication;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests.Authentication
+{
+    public class MicrosoftAuthenticationTests
+    {
+        [Fact]
+        public async System.Threading.Tasks.Task MicrosoftAuthentication_GetAccessTokenAsync_NoInteraction_ThrowsException()
+        {
+            const string authority = "https://login.microsoftonline.com/common";
+            const string clientId = "C9E8FDA6-1D46-484C-917C-3DBD518F27C3";
+            Uri redirectUri = new Uri("https://localhost");
+            const string resource = "https://graph.microsoft.com";
+            Uri remoteUri = new Uri("https://example.com");
+            const string userName = null; // No user to ensure we do not use an existing token
+
+            var context = new TestCommandContext
+            {
+                Settings = {IsInteractionAllowed = false},
+            };
+
+            var msAuth = new MicrosoftAuthentication(context);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => msAuth.GetAccessTokenAsync(authority, clientId, redirectUri, resource, remoteUri, userName));
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -88,6 +88,135 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public void Settings_IsInteractionAllowed_EnvarUnset_ReturnsTrue()
+        {
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_EnvarTruthy_ReturnsTrue()
+        {
+            var envars = new TestEnvironment
+            {
+                Variables = {[Constants.EnvironmentVariables.GcmInteractive] = "1"}
+            };
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_EnvarFalsey_ReturnsFalse()
+        {
+            var envars = new TestEnvironment
+            {
+                Variables = {[Constants.EnvironmentVariables.GcmInteractive] = "0"},
+            };
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_ConfigAuto_ReturnsTrue()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Interactive;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = "auto";
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_ConfigAlways_ReturnsTrue()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Interactive;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = "always";
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_ConfigNever_ReturnsFalse()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Interactive;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = "never";
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_ConfigTruthy_ReturnsTrue()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Interactive;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = "1";
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_ConfigFalsey_ReturnsFalse()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Interactive;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = "0";
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
+        public void Settings_IsInteractionAllowed_ConfigNonBooleanyValue_ReturnsTrue()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.Interactive;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = Guid.NewGuid().ToString();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsInteractionAllowed);
+        }
+
+        [Fact]
         public void Settings_IsTracingEnabled_EnvarUnset_ReturnsFalse()
         {
             var envars = new TestEnvironment();

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
@@ -62,13 +62,28 @@ namespace Microsoft.Git.CredentialManager.Authentication
             return resultDict;
         }
 
-        protected void EnsureTerminalPromptsEnabled()
+        protected void ThrowIfUserInteractionDisabled()
+        {
+            if (!Context.Settings.IsInteractionAllowed)
+            {
+                string envName = Constants.EnvironmentVariables.GcmInteractive;
+                string cfgName = string.Format("{0}.{1}",
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.Interactive);
+
+                Context.Trace.WriteLine($"{envName} / {cfgName} is false/never; user interactivity has been disabled.");
+
+                throw new InvalidOperationException("Cannot prompt because user interactivity has been disabled.");
+            }
+        }
+
+        protected void ThrowIfTerminalPromptsDisabled()
         {
             if (!Context.Settings.IsTerminalPromptsEnabled)
             {
                 Context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; terminal prompts have been disabled.");
 
-                throw new InvalidOperationException("Cannot show credential prompt because terminal prompts have been disabled.");
+                throw new InvalidOperationException("Cannot prompt because terminal prompts have been disabled.");
             }
         }
     }

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Git.CredentialManager.Authentication
         {
             EnsureArgument.NotNullOrWhiteSpace(resource, nameof(resource));
 
-            EnsureTerminalPromptsEnabled();
+            ThrowIfUserInteractionDisabled();
+            ThrowIfTerminalPromptsDisabled();
 
             Context.Terminal.WriteLine("Enter basic credentials for '{0}':", resource);
 

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Git.CredentialManager
             public const string CurlHttpsProxy     = "HTTPS_PROXY";
             public const string GcmHttpProxy       = "GCM_HTTP_PROXY";
             public const string GitSslNoVerify     = "GIT_SSL_NO_VERIFY";
+            public const string GcmInteractive     = "GCM_INTERACTIVE";
         }
 
         public static class Http
@@ -70,6 +71,7 @@ namespace Microsoft.Git.CredentialManager
                 public const string HttpProxy   = "httpProxy";
                 public const string HttpsProxy  = "httpsProxy";
                 public const string UseHttpPath = "useHttpPath";
+                public const string Interactive = "interactive";
             }
 
             public static class Http

--- a/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Git.CredentialManager
     public static class PlatformUtils
     {
         /// <summary>
-        /// Determine if the current session is interactive (can display UI).
+        /// Determine if the current session has access to a desktop/can display UI.
         /// </summary>
-        /// <returns>True if the session is interactive, false otherwise.</returns>
-        public static bool IsInteractiveSession()
+        /// <returns>True if the session can display UI, false otherwise.</returns>
+        public static bool IsDesktopSession()
         {
             return Environment.UserInteractive;
         }

--- a/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
+++ b/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestFileSystem : IFileSystem
     {
-        public IDictionary<string, Stream> Files { get; set; }
-        public ISet<string> Directories { get; set; }
+        public IDictionary<string, Stream> Files { get; set; } = new Dictionary<string, Stream>();
+        public ISet<string> Directories { get; set; } = new HashSet<string>();
         public string CurrentDirectory { get; set; } = Path.GetTempPath();
         public IEqualityComparer<string> PathComparer { get; set; }= StringComparer.OrdinalIgnoreCase;
 

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public bool IsTerminalPromptsEnabled { get; set; } = true;
 
+        public bool IsInteractionAllowed { get; set; } = true;
+
         public string Trace { get; set; }
 
         public bool IsSecretTracingEnabled { get; set; }
@@ -37,6 +39,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         bool ISettings.IsDebuggingEnabled => IsDebuggingEnabled;
 
         bool ISettings.IsTerminalPromptsEnabled => IsTerminalPromptsEnabled;
+
+        bool ISettings.IsInteractionAllowed => IsInteractionAllowed;
 
         bool ISettings.GetTracingEnabled(out string value)
         {


### PR DESCRIPTION
Add a setting to disable all user interaction. By setting `GCM_INTERACTIVE` or `credential.interactive` to a 'falsey' value, GCM Core will now fail and return an error if user interaction is required.

This is useful in headless and unattended environments, such as build servers, where is is preferable to fail than it is to hang waiting for input from a non-existent user.

The setting also existed in the previous GCM for Windows, but its behaviour has been slightly modified to treat 'always' values as 'auto'. See more in the documentation and the code.

The default value is `true` / permit interaction.

Closed #90.