### PR TITLE
Add debug trace listener when debugger is attached

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Git.CredentialManager
                 Debugger.Break();
             }
 
+            // Add the debug tracer if the debugger is attached
+            if (Debugger.IsAttached)
+            {
+                Context.Trace.AddListener(new DebugTraceWriter());
+            }
+
             // Enable tracing
             if (Context.Settings.GetTracingEnabled(out string traceValue))
             {

--- a/src/shared/Microsoft.Git.CredentialManager/Trace.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Trace.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Microsoft.Git.CredentialManager
 {
@@ -330,5 +332,16 @@ namespace Microsoft.Git.CredentialManager
 
             return text;
         }
+    }
+
+    public class DebugTraceWriter : TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(char value) => Debug.Write(value);
+
+        public override void Write(string value) => Debug.Write(value);
+
+        public override void WriteLine(string value) => Debug.WriteLine(value);
     }
 }


### PR DESCRIPTION
When a debugger is attached, automatically add a listener that will output to the debug console.