### PR TITLE
Correctly check for GUI on Win/Mac/POSIX

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,6 +4,7 @@ Do Not Translate or Localize
 This repository for Git Credential Manager Core includes material from the
 projects listed below.
 
+--------------------------------------------------------------------------------
 1. GitHub/VisualStudio (https://github.com/github/VisualStudio)
 
 Copyright (c) GitHub Inc.
@@ -24,3 +25,30 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+2. dotnet/runtime (https://github.com/dotnet/runtime)
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -45,7 +45,7 @@ namespace Atlassian.Bitbucket
             string password;
 
             // Shell out to the UI helper and show the Bitbucket u/p prompt
-            if (Context.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
+            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
             {
                 var cmdArgs = new StringBuilder("--prompt userpass");
                 if (!string.IsNullOrWhiteSpace(userName))
@@ -96,7 +96,7 @@ namespace Atlassian.Bitbucket
             ThrowIfUserInteractionDisabled();
 
             // Shell out to the UI helper and show the Bitbucket prompt
-            if (Context.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
+            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
             {
                 IDictionary<string, string> output = await InvokeHelperAsync(helperPath, "--prompt oauth");
 

--- a/src/shared/Git-Credential-Manager/NOTICE
+++ b/src/shared/Git-Credential-Manager/NOTICE
@@ -16,6 +16,7 @@ Notwithstanding any other terms, you may reverse engineer this software to the
 extent required to debug changes to any libraries licensed under the GNU Lesser
 General Public License.
 
+--------------------------------------------------------------------------------
 1. GitHub/VisualStudio (https://github.com/github/VisualStudio)
 
 Copyright (c) GitHub Inc.
@@ -36,3 +37,30 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+2. dotnet/runtime (https://github.com/dotnet/runtime)
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -63,7 +63,9 @@ namespace GitHub
 
             // If the GitHub auth stack doesn't support flows such as RFC 8628 and we do not have
             // an interactive desktop session, we cannot offer OAuth authentication.
-            if ((modes & AuthenticationModes.OAuth) != 0 && !Context.IsDesktopSession && !GitHubConstants.IsOAuthDeviceAuthSupported)
+            if ((modes & AuthenticationModes.OAuth) != 0
+                && !Context.SessionManager.IsDesktopSession
+                && !GitHubConstants.IsOAuthDeviceAuthSupported)
             {
                 Context.Trace.WriteLine("Ignoring OAuth authentication mode because we are not in an interactive desktop session. GitHub does not support RFC 8628.");
 
@@ -189,7 +191,7 @@ namespace GitHub
             var oauthClient = new GitHubOAuth2Client(HttpClient, Context.Settings, targetUri);
 
             // If we have a desktop session try authentication using the user's default web browser
-            if (Context.IsDesktopSession)
+            if (Context.SessionManager.IsDesktopSession)
             {
                 var browserOptions = new OAuth2WebBrowserOptions
                 {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             const string testUserName = "john.doe";
             const string testPassword = "letmein123";
 
-            var context = new TestCommandContext {IsDesktopSession = false};
+            var context = new TestCommandContext {SessionManager = {IsDesktopSession = false}};
             context.Terminal.SecretPrompts["Password"] = testPassword;
 
             var basicAuth = new BasicAuthentication(context);
@@ -44,7 +44,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             const string testUserName = "john.doe";
             const string testPassword = "letmein123";
 
-            var context = new TestCommandContext {IsDesktopSession = false};
+            var context = new TestCommandContext {SessionManager = {IsDesktopSession = false}};
             context.Terminal.Prompts["Username"] = testUserName;
             context.Terminal.SecretPrompts["Password"] = testPassword;
 
@@ -63,7 +63,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
 
             var context = new TestCommandContext
             {
-                IsDesktopSession = false,
+                SessionManager = {IsDesktopSession = false},
                 Settings = {IsInteractionAllowed = false},
             };
 
@@ -81,7 +81,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
 
             var context = new TestCommandContext
             {
-                IsDesktopSession = true,
+                SessionManager = {IsDesktopSession = true},
                 SystemPrompts =
                 {
                     CredentialPrompt = (resource, userName) =>
@@ -112,7 +112,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
 
             var context = new TestCommandContext
             {
-                IsDesktopSession = true,
+                SessionManager = {IsDesktopSession = true},
                 SystemPrompts =
                 {
                     CredentialPrompt = (resource, userName) =>
@@ -144,7 +144,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
 
             var context = new TestCommandContext
             {
-                IsDesktopSession = true,
+                SessionManager = {IsDesktopSession = true},
                 SystemPrompts =
                 {
                     CredentialPrompt = (resource, userName) =>

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
             ThrowIfUserInteractionDisabled();
 
             // TODO: we only support system GUI prompts on Windows currently
-            if (Context.IsDesktopSession && PlatformUtils.IsWindows())
+            if (Context.SessionManager.IsDesktopSession && PlatformUtils.IsWindows())
             {
                 return GetCredentialsByUi(resource, userName);
             }

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
             {
 #if NETFRAMEWORK
                 // If we're in an interactive session and on .NET Framework, let MSAL show the WinForms-based embeded UI
-                if (PlatformUtils.IsDesktopSession())
+                if (Context.SessionManager.IsDesktopSession)
                 {
                     result = await app.AcquireTokenInteractive(scopes)
                         .WithPrompt(Prompt.SelectAccount)
@@ -128,7 +128,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
                 }
 #elif NETSTANDARD
                 // MSAL requires the application redirect URI is a loopback address to use the System WebView
-                if (Context.IsDesktopSession && app.IsSystemWebViewAvailable && redirectUri.IsLoopback)
+                if (Context.SessionManager.IsDesktopSession && app.IsSystemWebViewAvailable && redirectUri.IsLoopback)
                 {
                     result = await app.AcquireTokenInteractive(scopes)
                         .WithPrompt(Prompt.SelectAccount)

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Git.CredentialManager
         ITerminal Terminal { get; }
 
         /// <summary>
-        /// Returns true if in a GUI session/desktop is available, false otherwise.
+        /// Provides services regarding user sessions.
         /// </summary>
-        bool IsDesktopSession { get; }
+        ISessionManager SessionManager { get; }
 
         /// <summary>
         /// Application tracing system.
@@ -85,6 +85,7 @@ namespace Microsoft.Git.CredentialManager
                 FileSystem      = new WindowsFileSystem();
                 Environment     = new WindowsEnvironment(FileSystem);
                 Terminal        = new WindowsTerminal(Trace);
+                SessionManager  = new WindowsSessionManager();
                 CredentialStore = WindowsCredentialManager.Open();
                 SystemPrompts   = new WindowsSystemPrompts();
             }
@@ -93,6 +94,7 @@ namespace Microsoft.Git.CredentialManager
                 if (PlatformUtils.IsMacOS())
                 {
                     FileSystem      = new MacOSFileSystem();
+                    SessionManager  = new MacOSSessionManager();
                     CredentialStore = MacOSKeychain.Open();
                     SystemPrompts   = new MacOSSystemPrompts();
                 }
@@ -108,7 +110,6 @@ namespace Microsoft.Git.CredentialManager
             string repoPath   = Git.GetRepositoryPath(FileSystem.GetCurrentDirectory());
             Settings          = new Settings(Environment, Git, repoPath);
             HttpClientFactory = new HttpClientFactory(Trace, Settings, Streams);
-            IsDesktopSession  = PlatformUtils.IsDesktopSession();
 
             // Set the parent window handle/ID
             SystemPrompts.ParentWindowId = Settings.ParentWindowId;
@@ -122,7 +123,7 @@ namespace Microsoft.Git.CredentialManager
 
         public ITerminal Terminal { get; }
 
-        public bool IsDesktopSession { get; }
+        public ISessionManager SessionManager { get; }
 
         public ITrace Trace { get; }
 

--- a/src/shared/Microsoft.Git.CredentialManager/ISessionManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ISessionManager.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.Git.CredentialManager
+{
+    public interface ISessionManager
+    {
+        /// <summary>
+        /// Determine if the current session has access to a desktop/can display UI.
+        /// </summary>
+        /// <returns>True if the session can display UI, false otherwise.</returns>
+        bool IsDesktopSession { get; }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSSessionManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSSessionManager.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.Git.CredentialManager.Interop.MacOS.Native;
+using Microsoft.Git.CredentialManager.Interop.Posix;
+
+namespace Microsoft.Git.CredentialManager.Interop.MacOS
+{
+    public class MacOSSessionManager : PosixSessionManager
+    {
+        public MacOSSessionManager()
+        {
+            PlatformUtils.EnsureMacOS();
+        }
+
+        public override bool IsDesktopSession
+        {
+            get
+            {
+                // Get information about the current session
+                int error = SecurityFramework.SessionGetInfo(SecurityFramework.CallerSecuritySession, out int id, out var sessionFlags);
+
+                // Check if the session supports Quartz
+                if (error == 0 && (sessionFlags & SessionAttributeBits.SessionHasGraphicAccess) != 0)
+                {
+                    return true;
+                }
+
+                // Fall-through and check if X11 is available on macOS
+                return base.IsDesktopSession;
+            }
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/SecurityFramework.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/SecurityFramework.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Git.CredentialManager.Interop.MacOS.Native
         private const string SecurityFrameworkLib = "/System/Library/Frameworks/Security.framework/Security";
 
         [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SessionGetInfo(int session, out int sessionId, out SessionAttributeBits attributes);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern int SecKeychainAddGenericPassword(
             IntPtr keychain,
             uint serviceNameLength,
@@ -62,6 +65,8 @@ namespace Microsoft.Git.CredentialManager.Interop.MacOS.Native
             IntPtr attrList, // SecKeychainAttributeList*
             IntPtr data);
 
+        public const int CallerSecuritySession = -1;
+
         // https://developer.apple.com/documentation/security/1542001-security_framework_result_codes
         public const int OK = 0;
         public const int ErrorSecNoSuchKeychain = -25294;
@@ -99,6 +104,15 @@ namespace Microsoft.Git.CredentialManager.Interop.MacOS.Native
                     throw new InteropException(defaultErrorMessage, error);
             }
         }
+    }
+
+    [Flags]
+    public enum SessionAttributeBits
+    {
+        SessionIsRoot = 0x0001,
+        SessionHasGraphicAccess = 0x0010,
+        SessionHasTty = 0x0020,
+        SessionIsRemote = 0x1000,
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixSessionManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixSessionManager.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+
+namespace Microsoft.Git.CredentialManager.Interop.Posix
+{
+    public class PosixSessionManager : ISessionManager
+    {
+        protected PosixSessionManager()
+        {
+            PlatformUtils.EnsurePosix();
+        }
+
+        // Check if we have an X11 environment available
+        public virtual bool IsDesktopSession => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY"));
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/User32.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/User32.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Git.CredentialManager.Interop.Windows.Native
+{
+    public static class User32
+    {
+        private const string LibraryName = "user32.dll";
+
+        public const int UOI_FLAGS = 1;
+        public const int WSF_VISIBLE = 0x0001;
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern IntPtr GetProcessWindowStation();
+
+        [DllImport(LibraryName, EntryPoint = "GetUserObjectInformation", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern unsafe bool GetUserObjectInformation(IntPtr hObj, int nIndex, void* pvBuffer, uint nLength, ref uint lpnLengthNeeded);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct USEROBJECTFLAGS
+    {
+        public int fInherit;
+        public int fReserved;
+        public int dwFlags;
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
@@ -8,15 +8,6 @@ namespace Microsoft.Git.CredentialManager
     public static class PlatformUtils
     {
         /// <summary>
-        /// Determine if the current session has access to a desktop/can display UI.
-        /// </summary>
-        /// <returns>True if the session can display UI, false otherwise.</returns>
-        public static bool IsDesktopSession()
-        {
-            return Environment.UserInteractive;
-        }
-
-        /// <summary>
         /// Get information about the current platform (OS and CLR details).
         /// </summary>
         /// <returns>Platform information.</returns>

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         {
             Streams = new TestStandardStreams();
             Terminal = new TestTerminal();
-            IsDesktopSession = true;
+            SessionManager = new TestSessionManager();
             Trace = new NullTrace();
             FileSystem = new TestFileSystem();
             CredentialStore = new TestCredentialStore();
@@ -29,7 +29,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         public TestSettings Settings { get; set; }
         public TestStandardStreams Streams { get; set; }
         public TestTerminal Terminal { get; set; }
-        public bool IsDesktopSession { get; set; }
+        public TestSessionManager SessionManager { get; set; }
         public ITrace Trace { get; set; }
         public TestFileSystem FileSystem { get; set; }
         public TestCredentialStore CredentialStore { get; set; }
@@ -46,7 +46,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         ITerminal ICommandContext.Terminal => Terminal;
 
-        bool ICommandContext.IsDesktopSession => IsDesktopSession;
+        ISessionManager ICommandContext.SessionManager => SessionManager;
 
         ITrace ICommandContext.Trace => Trace;
 

--- a/src/shared/TestInfrastructure/Objects/TestSessionManager.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSessionManager.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.Git.CredentialManager.Tests.Objects
+{
+    public class TestSessionManager : ISessionManager
+    {
+        public bool IsDesktopSession { get; set; }
+    }
+}


### PR DESCRIPTION
Replace the `PlatformUtils.IsDesktopSession` util method with platform specific components that check use native APIs to determine the state of the current session.

`Environment.UserInteractive` is hard-coded to return true for POSIX and Windows platforms on .NET Core 2.x and 3.x.
dotnet/runtime#770

The .NET 5 implementation (not yet released) fixes this for the Windows platform only. We take a copy of that implementation for Windows.

On macOS we use the `SessionGetInfo` from the Security.framework.

On POSIX in general we also check for the X11 $DISPLAY environment variable.