### PR TITLE
Create and publish zip & tar.gz archives of app and symbols

### DIFF
--- a/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
@@ -12,10 +12,10 @@ steps:
       packageType: sdk
       version: '2.2.100'
 
-  - script: dotnet tool install --tool-path './.tmp' nbgv
+  - script: dotnet tool install --global nbgv
     displayName: Install Nerdbank.GitVersioning tool
 
-  - script: ./.tmp/nbgv cloud --common-vars
+  - script: nbgv cloud --common-vars
     displayName: Set version variables
 
   - script: src/osx/Installer.Mac/pack.sh --payload='$(Build.StagingDirectory)/payload' --version='$(GitBuildVersion)' --output='$(Build.StagingDirectory)/pkg/gcmcore-osx-$(GitBuildVersion).pkg'

--- a/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
@@ -28,7 +28,31 @@ steps:
       cp -f  "$(Build.StagingDirectory)"/pkg/*.pkg "$(Build.StagingDirectory)/publish/"
       cp -Rf "$(Build.StagingDirectory)/payload/"  "$(Build.StagingDirectory)/publish/payload/"
       cp -Rf "$(Build.StagingDirectory)/symbols/"  "$(Build.StagingDirectory)/publish/payload.sym/"
-    displayName: Prepare final build artifact
+    displayName: Prepare final build artifacts
+
+  - script: dotnet tool install --global nbgv
+    displayName: Install Nerdbank.GitVersioning tool
+
+  - script: nbgv cloud --common-vars
+    displayName: Set version variables
+
+  - task: ArchiveFiles@2
+    displayName: Create payload archive
+    inputs:
+      rootFolderOrFile: '$(Build.StagingDirectory)\publish\payload\'
+      includeRootFolder: false
+      archiveType: 'tar'
+      archiveFile: '$(Build.StagingDirectory)\publish\gcmcore-osx-$(GitBuildVersion).tar.gz'
+      replaceExistingArchive: true
+
+  - task: ArchiveFiles@2
+    displayName: Create symbol archive
+    inputs:
+      rootFolderOrFile: '$(Build.StagingDirectory)\publish\payload.sym\'
+      includeRootFolder: false
+      archiveType: 'tar'
+      archiveFile: '$(Build.StagingDirectory)\publish\symbols-osx.tar.gz'
+      replaceExistingArchive: true
 
   - task: PublishPipelineArtifact@0
     displayName: Publish signed installer artifacts

--- a/.azure-pipelines/templates/osx/pack.unsigned.yml
+++ b/.azure-pipelines/templates/osx/pack.unsigned.yml
@@ -1,6 +1,34 @@
 steps:
+  - script: |
+      cp -R "out/osx/Installer.Mac/pkg/$(configuration)" "$(Build.StagingDirectory)/publish/"
+    displayName: Prepare final build artifacts
+
+  - script: dotnet tool install --global nbgv
+    displayName: Install Nerdbank.GitVersioning tool
+
+  - script: nbgv cloud --common-vars
+    displayName: Set version variables
+
+  - task: ArchiveFiles@2
+    displayName: Create payload archive
+    inputs:
+      rootFolderOrFile: '$(Build.StagingDirectory)/publish/payload'
+      includeRootFolder: false
+      archiveType: 'tar'
+      archiveFile: '$(Build.StagingDirectory)/publish/gcmcore-osx-$(GitBuildVersion).tar.gz'
+      replaceExistingArchive: true
+
+  - task: ArchiveFiles@2
+    displayName: Create symbol archive
+    inputs:
+      rootFolderOrFile: '$(Build.StagingDirectory)/publish/payload.sym/'
+      includeRootFolder: false
+      archiveType: 'tar'
+      archiveFile: '$(Build.StagingDirectory)/publish/symbols-osx.tar.gz'
+      replaceExistingArchive: true
+
   - task: PublishPipelineArtifact@0
     displayName: Publish unsigned installer artifacts
     inputs:
         artifactName: 'Installer.Mac.Unsigned'
-        targetPath: 'out/osx/Installer.Mac/pkg/$(configuration)'
+        targetPath: '$(Build.StagingDirectory)/publish'

--- a/.azure-pipelines/templates/windows/pack.yml
+++ b/.azure-pipelines/templates/windows/pack.yml
@@ -1,10 +1,34 @@
 steps:
+  - script: dotnet tool install --global nbgv
+    displayName: Install Nerdbank.GitVersioning tool
+
+  - script: nbgv cloud --common-vars
+    displayName: Set version variables
+
   - script: |
       xcopy "out\windows\Installer.Windows\bin\$(configuration)\net461"       "$(Build.StagingDirectory)\publish\"
       xcopy "out\windows\Payload.Windows\bin\$(configuration)\net461\win-x64" "$(Build.StagingDirectory)\publish\payload\"
       mkdir "$(Build.StagingDirectory)\publish\payload.sym\"
       move  "$(Build.StagingDirectory)\publish\payload\*.pdb"                 "$(Build.StagingDirectory)\publish\payload.sym\"
-    displayName: Prepare final build artifact
+    displayName: Prepare final build artifacts
+
+  - task: ArchiveFiles@2
+    displayName: Create payload archive
+    inputs:
+      rootFolderOrFile: '$(Build.StagingDirectory)\publish\payload\'
+      includeRootFolder: false
+      archiveType: 'zip'
+      archiveFile: '$(Build.StagingDirectory)\publish\gcmcore-win-x64-$(GitBuildVersion).zip'
+      replaceExistingArchive: true
+
+  - task: ArchiveFiles@2
+    displayName: Create symbol archive
+    inputs:
+      rootFolderOrFile: '$(Build.StagingDirectory)\publish\payload.sym\'
+      includeRootFolder: false
+      archiveType: 'zip'
+      archiveFile: '$(Build.StagingDirectory)\publish\symbols-win-x64.zip'
+      replaceExistingArchive: true
 
   - task: PublishPipelineArtifact@0
     displayName: Publish unsigned installer artifacts


### PR DESCRIPTION
Create and publish ZIP and TAR archives on Windows and Mac containing the GCM Core app binaries, and symbols.

This is useful for consumers who wish to bundle GCM Core with their applications or installers, such as Git for Windows.