### PR TITLE
Update CI, PR, and release YAML to use macOS 10.14

### DIFF
--- a/.azure-pipelines/continuous-integration.yml
+++ b/.azure-pipelines/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
 - job: osx
   displayName: macOS
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-10.14
   steps:
   - template: templates/osx/compile.yml
   - template: templates/osx/pack.unsigned.yml

--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
 - job: osx
   displayName: macOS
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-10.14
   steps:
   - template: templates/osx/compile.yml
   - template: templates/osx/pack.unsigned.yml

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -16,7 +16,7 @@ jobs:
 - job: osx_step1
   displayName: macOS (Build & Layout)
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-10.14
   steps:
   - template: templates/osx/compile.yml
   - template: templates/osx/pack.signed/step1-layout.yml
@@ -35,7 +35,7 @@ jobs:
   dependsOn: osx_step2
   condition: succeeded()
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-10.14
   steps:
   - template: templates/osx/pack.signed/step3-pack.yml
 
@@ -53,6 +53,6 @@ jobs:
   dependsOn: osx_step4
   condition: succeeded()
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-10.14
   steps:
   - template: templates/osx/pack.signed/step5-dist.yml


### PR DESCRIPTION
macOS 10.13 is deprecated on Azure Pipelines. Update our vm images to be macOS-10.14 for Mac builds.