### PR TITLE
Allow GitHub OAuth params to be overridden at runtime

### DIFF
--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -188,7 +188,7 @@ namespace GitHub
         {
             ThrowIfUserInteractionDisabled();
 
-            var oauthClient = new GitHubOAuth2Client(HttpClient, targetUri);
+            var oauthClient = new GitHubOAuth2Client(HttpClient, Context.Settings, targetUri);
 
             // If we have a desktop session try authentication using the user's default web browser
             if (Context.IsDesktopSession)

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -11,6 +11,13 @@ namespace GitHub
 
         public const string AuthHelperName = "GitHub.UI";
 
+        public const string OAuthClientId = "0120e057bd645470c1ed";
+        public const string OAuthClientSecret = "18867509d956965542b521a529a79bb883344c90";
+        public static readonly Uri OAuthRedirectUri = new Uri("http://localhost/");
+        public static readonly Uri OAuthAuthorizationEndpointRelativeUri = new Uri("/login/oauth/authorize", UriKind.Relative);
+        public static readonly Uri OAuthTokenEndpointRelativeUri = new Uri("/login/oauth/access_token", UriKind.Relative);
+        public static readonly Uri OAuthDeviceEndpointRelativeUri = new Uri("/login/oauth/authorize/device", UriKind.Relative);
+
         /// <summary>
         /// The GitHub required HTTP accepts header value
         /// </summary>
@@ -51,6 +58,9 @@ namespace GitHub
         public static class EnvironmentVariables
         {
             public const string AuthenticationModes = "GCM_GITHUB_AUTHMODES";
+            public const string DevOAuthClientId = "GCM_DEV_GITHUB_CLIENTID";
+            public const string DevOAuthClientSecret = "GCM_DEV_GITHUB_CLIENTSECRET";
+            public const string DevOAuthRedirectUri = "GCM_DEV_GITHUB_REDIRECTURI";
         }
 
         public static class GitConfiguration
@@ -58,6 +68,9 @@ namespace GitHub
             public static class Credential
             {
                 public const string AuthModes = "gitHubAuthModes";
+                public const string DevOAuthClientId = "gitHubDevClientId";
+                public const string DevOAuthClientSecret = "gitHubDevClientSecret";
+                public const string DevOAuthRedirectUri = "gitHubDevRedirectUri";
             }
         }
     }

--- a/src/shared/GitHub/GitHubOAuth2Client.cs
+++ b/src/shared/GitHub/GitHubOAuth2Client.cs
@@ -1,33 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Net.Http;
+using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication.OAuth;
 
 namespace GitHub
 {
     public class GitHubOAuth2Client : OAuth2Client
     {
-        private static readonly string ClientId = "0120e057bd645470c1ed";
-        private static readonly string ClientSecret = "18867509d956965542b521a529a79bb883344c90";
-        private static readonly Uri RedirectUri = new Uri("http://localhost/");
-
-        public GitHubOAuth2Client(HttpClient httpClient, Uri baseUri)
-            : base(httpClient, CreateEndpoints(baseUri), ClientId, RedirectUri, ClientSecret) { }
+        public GitHubOAuth2Client(HttpClient httpClient, ISettings settings, Uri baseUri)
+            : base(httpClient, CreateEndpoints(baseUri),
+                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings)) { }
 
         private static OAuth2ServerEndpoints CreateEndpoints(Uri baseUri)
         {
-            Uri authEndpoint = new Uri(baseUri, "/login/oauth/authorize");
-            Uri tokenEndpoint = new Uri(baseUri, "/login/oauth/access_token");
+            Uri authEndpoint = new Uri(baseUri, GitHubConstants.OAuthAuthorizationEndpointRelativeUri);
+            Uri tokenEndpoint = new Uri(baseUri, GitHubConstants.OAuthTokenEndpointRelativeUri);
 
             Uri deviceAuthEndpoint = null;
             if (GitHubConstants.IsOAuthDeviceAuthSupported)
             {
-                deviceAuthEndpoint = new Uri(baseUri, "/login/oauth/authorize/device");
+                deviceAuthEndpoint = new Uri(baseUri, GitHubConstants.OAuthDeviceEndpointRelativeUri);
             }
 
             return new OAuth2ServerEndpoints(authEndpoint, tokenEndpoint)
             {
                 DeviceAuthorizationEndpoint = deviceAuthEndpoint
             };
+        }
+
+        private static string GetClientId(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                GitHubConstants.EnvironmentVariables.DevOAuthClientId,
+                Constants.GitConfiguration.Credential.SectionName, GitHubConstants.GitConfiguration.Credential.DevOAuthClientId,
+                out string clientId))
+            {
+                return clientId;
+            }
+
+            return GitHubConstants.OAuthClientId;
+        }
+
+        private static Uri GetRedirectUri(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                GitHubConstants.EnvironmentVariables.DevOAuthRedirectUri,
+                Constants.GitConfiguration.Credential.SectionName, GitHubConstants.GitConfiguration.Credential.DevOAuthRedirectUri,
+                out string redirectUriStr) && Uri.TryCreate(redirectUriStr, UriKind.Absolute, out Uri redirectUri))
+            {
+                return redirectUri;
+            }
+
+            return GitHubConstants.OAuthRedirectUri;
+        }
+
+        private static string GetClientSecret(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                GitHubConstants.EnvironmentVariables.DevOAuthClientSecret,
+                Constants.GitConfiguration.Credential.SectionName, GitHubConstants.GitConfiguration.Credential.DevOAuthClientSecret,
+                out string clientSecret))
+            {
+                return clientSecret;
+            }
+
+            return GitHubConstants.OAuthClientSecret;
         }
     }
 }


### PR DESCRIPTION
Allow the OAuth client ID, secret, and redirect URI to be overridden at runtime using environment variables or config.
This allows for easier testing for developers. These configuration options are not officially supported and are therefore not documented. They are for development only.