### PR TITLE
Workaround Azure Pipelines build bug

### DIFF
--- a/.azure-pipelines/templates/windows/compile.yml
+++ b/.azure-pipelines/templates/windows/compile.yml
@@ -12,6 +12,13 @@ steps:
       version: 3.1.x
 
   - task: DotNetCoreCLI@2
+    displayName: Restore packages
+    inputs:
+      command: restore
+      projects: 'Git-Credential-Manager.sln'
+      arguments: '--configuration=Windows$(configuration)'
+
+  - task: DotNetCoreCLI@2
     displayName: Compile common code and Windows Helpers
     inputs:
       command: build


### PR DESCRIPTION
For some reason our Azure Pipelines builds are failing (occasionally) to restore packages _unless_ we explicitly run a `dotnet restore` before our `dotnet build`. The Azure Pipelines team are still not sure why this is failing, or why it only happens one some of the hosted agents and not others (despite compiling the same commit)!