### PR TITLE
Fix bugs in release pipeline

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   configuration: Release
-  signPool: VSEng-MicroBuildVS2017
+  signPool: VSEng-MicroBuildVS2019
   winImage: vs2017-win2016
   osxImage: macos-latest
 
@@ -13,7 +13,7 @@ jobs:
   pool:
     name: $(signPool)
   steps:
-  - template: templates/windows/compile.yml
+  - template: templates/windows/compile.signed.yml
   - template: templates/windows/pack.yml
 
 - job: osx_step1

--- a/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
@@ -41,19 +41,19 @@ steps:
   - task: ArchiveFiles@2
     displayName: Create payload archive
     inputs:
-      rootFolderOrFile: '$(Build.StagingDirectory)\publish\payload\'
+      rootFolderOrFile: '$(Build.StagingDirectory)/publish/payload/'
       includeRootFolder: false
       archiveType: 'tar'
-      archiveFile: '$(Build.StagingDirectory)\publish\gcmcore-osx-$(GitBuildVersion).tar.gz'
+      archiveFile: '$(Build.StagingDirectory)/publish/gcmcore-osx-$(GitBuildVersion).tar.gz'
       replaceExistingArchive: true
 
   - task: ArchiveFiles@2
     displayName: Create symbol archive
     inputs:
-      rootFolderOrFile: '$(Build.StagingDirectory)\publish\payload.sym\'
+      rootFolderOrFile: '$(Build.StagingDirectory)/publish/payload.sym/'
       includeRootFolder: false
       archiveType: 'tar'
-      archiveFile: '$(Build.StagingDirectory)\publish\symbols-osx.tar.gz'
+      archiveFile: '$(Build.StagingDirectory)/publish/symbols-osx.tar.gz'
       replaceExistingArchive: true
 
   - task: PublishPipelineArtifact@0

--- a/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
@@ -20,8 +20,10 @@ steps:
       artifactName: 'tmp.macsymbols'
       downloadPath: '$(Build.StagingDirectory)/symbols'
 
-  - script: src/osx/SignFiles.Mac/notarize-pkg.sh -id "$(AppleId)" -p "$(AppleIdPassword)" -pkg "$(Build.StagingDirectory)"/pkg/*.pkg
-    displayName: Notarize and staple installer package
+  # Skip notarization until we can preserve the hardened runtime bit and sign the .NET Core runtime bits
+  # Tracked: https://github.com/microsoft/Git-Credential-Manager-Core/issues/108
+  #- script: src/osx/SignFiles.Mac/notarize-pkg.sh -id "$(AppleId)" -p "$(AppleIdPassword)" -pkg "$(Build.StagingDirectory)"/pkg/*.pkg
+  #  displayName: Notarize and staple installer package
 
   - script: |
       mkdir -p "$(Build.StagingDirectory)/publish/payload" "$(Build.StagingDirectory)/publish/payload.sym"

--- a/.azure-pipelines/templates/windows/compile.signed.yml
+++ b/.azure-pipelines/templates/windows/compile.signed.yml
@@ -1,0 +1,41 @@
+steps:
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
+    displayName: Install signing plugin
+    condition: and(succeeded(), eq(variables['SignType'], 'real'))
+    inputs:
+      signType: '$(SignType)'
+
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK 3.1.x
+    inputs:
+      packageType: sdk
+      version: 3.1.x
+
+  - task: NuGetToolInstaller@0
+    displayName: Install NuGet tool >=4.3.0
+    inputs:
+      versionSpec: '>=4.3.0'
+
+  # Must use the NuGet & MSBuild toolchain here rather than `dotnet`
+  # because the signing tasks target the netfx MSBuild runtime only.
+  - task: NuGetCommand@2
+    displayName: Restore packages
+    inputs:
+      command: restore
+      restoreSolution: 'Git-Credential-Manager.sln'
+      configuration: 'Windows$(configuration)'
+
+  - task: MSBuild@1
+    displayName: Compile common code and Windows helpers
+    inputs:
+      solution: 'Git-Credential-Manager.sln'
+      configuration: 'Windows$(configuration)'
+
+  - task: VSTest@2
+    displayName: Run common unit tests
+    inputs:
+      testAssemblyVer2: |
+        out\shared\*.Tests\bin\**\*.Tests.dll
+      configuration: 'Windows$(configuration)'
+      otherConsoleOptions: '/Framework:.NETCoreApp,Version=2.1'
+      testRunTitle: 'Unit tests (Windows)'

--- a/.azure-pipelines/templates/windows/compile.yml
+++ b/.azure-pipelines/templates/windows/compile.yml
@@ -1,10 +1,4 @@
 steps:
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
-    displayName: Install signing plugin
-    condition: and(succeeded(), eq(variables['SignType'], 'real'))
-    inputs:
-      signType: '$(SignType)'
-
   - task: UseDotNet@2
     displayName: Use .NET Core SDK 3.1.x
     inputs:
@@ -33,4 +27,3 @@ steps:
       arguments: '--configuration=Mac$(configuration)'
       publishTestResults: true
       testRunTitle: 'Unit tests (Windows)'
-

--- a/.azure-pipelines/templates/windows/pack.yml
+++ b/.azure-pipelines/templates/windows/pack.yml
@@ -1,8 +1,8 @@
 steps:
-  - script: dotnet tool install --global nbgv
+  - script: dotnet tool install --tool-path .tools nbgv
     displayName: Install Nerdbank.GitVersioning tool
 
-  - script: nbgv cloud --common-vars
+  - script: .tools\nbgv cloud --common-vars
     displayName: Set version variables
 
   - script: |

--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,6 @@ out/
 
 # Temporary build directory
 .tmp/
+
+# dotnet local tools
+.tools/

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -123,8 +123,8 @@ namespace GitHub
                         var menuTitle = $"Select an authentication method for '{targetUri}'";
                         var menu = new TerminalMenu(Context.Terminal, menuTitle)
                         {
-                            new TerminalMenuItem(1, "Web browser", true),
-                            new TerminalMenuItem(2, "Username/password")
+                            new TerminalMenuItem(1, "Web browser"),
+                            new TerminalMenuItem(2, "Username/password", true)
                         };
 
                         int option = menu.Show();

--- a/src/windows/GitHub.UI.Windows/Login/Login2FaViewModel.cs
+++ b/src/windows/GitHub.UI.Windows/Login/Login2FaViewModel.cs
@@ -18,6 +18,8 @@ namespace GitHub.UI.Login
             NavigateLearnMoreCommand = new RelayCommand(NavigateLearnMore);
         }
 
+        public override bool IsValid => CanVerify();
+
         public override string Title => GitHubResources.TwoFactorTitle;
 
         public TwoFactorType TwoFactorType

--- a/src/windows/GitHub.UI.Windows/Login/LoginCredentialsViewModel.cs
+++ b/src/windows/GitHub.UI.Windows/Login/LoginCredentialsViewModel.cs
@@ -27,6 +27,8 @@ namespace GitHub.UI.Login
             }
         }
 
+        public override bool IsValid => IsLoginUsingBrowserVisible || CanLoginUsingUsernameAndPassword();
+
         public override string Title => GitHubResources.LoginTitle;
 
         /// <summary>


### PR DESCRIPTION
Several build (and two product) bugs have accumulated since we last released. We fix the following things:

- (product) The GitHub 2FA code prompt was not correctly reporting success when submitting a code
- Disable notarization because of #108 
- Revert to MSBuild/NuGet tool chain for release builds because of MicroBuild not working with the `dotnet` toolchain
- Fix macOS packaging job's use of Windows vs UNIX file path separators
- (product) Set username/password as the default option for GitHub until we have a whitelisted OAuth app

Will merge these changes back into master once we complete this PR.