### PR TITLE
Fix error message handling for LibGit2

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.Error.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Native/LibGit2.Error.cs
@@ -165,8 +165,8 @@ namespace Microsoft.Git.CredentialManager.Interop.Native
                 unsafe
                 {
                     string mainMessage = functionName is null
-                        ? $"libgit2 '{functionName}' returned non-zero value"
-                        : "libgit2 returned non-zero value";
+                        ? "libgit2 returned non-zero value"
+                        : $"libgit2 '{functionName}' returned non-zero value";
 
                     git_error* error = git_error_last();
 


### PR DESCRIPTION
Fix the reversed LibGit2 error message handling when no function-name was specified.