### PR TITLE
homebrew: publish new package version on release

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -1,0 +1,33 @@
+name: "release-homebrew"
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get macOS package version
+      uses: actions/github-script@0.3.0
+      id: version
+      with:
+        result-encoding: string
+        script: |
+          const { data } = await github.repos.getReleaseByTag({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag: process.env.GITHUB_REF
+          });
+          const regex = /gcmcore-osx-(.*)\.pkg/;
+          const asset = data.assets.find(x => regex.test(x.name));
+          const matches = asset.name.match(regex);
+          const version = matches[1];
+          return version;
+    - name: Update Homebrew tap
+      uses: mjcheetham/update-homebrew@v1
+      with:
+        token: ${{ secrets.HOMEBREW_TOKEN }}
+        tap: microsoft/git
+        name: git-credential-manager-core
+        type: cask
+        version: ${{ steps.version.outputs.result }}


### PR DESCRIPTION
Publish a new Homebrew Cask version on release via a GitHub action.