### PR TITLE
helpers: allow auth helpers to be overridden by config

### DIFF
--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -150,16 +148,11 @@ namespace Atlassian.Bitbucket
 
         private bool TryFindHelperExecutablePath(out string path)
         {
-            string helperName = BitbucketConstants.BitbucketAuthHelperName;
-
-            if (PlatformUtils.IsWindows())
-            {
-                helperName += ".exe";
-            }
-
-            string executableDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            path = Path.Combine(executableDirectory, helperName);
-            return Context.FileSystem.FileExists(path);
+            return TryFindHelperExecutablePath(
+                BitbucketConstants.EnvironmentVariables.AuthenticationHelper,
+                BitbucketConstants.GitConfiguration.Credential.AuthenticationHelper,
+                BitbucketConstants.DefaultAuthenticationHelper,
+                out path);
         }
 
         private HttpClient _httpClient;

--- a/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
@@ -8,7 +8,7 @@ namespace Atlassian.Bitbucket
     {
         public const string BitbucketBaseUrlHost = "bitbucket.org";
         public static readonly Uri BitbucketApiUri = new Uri("https://api.bitbucket.org");
-        public const string BitbucketAuthHelperName = "Atlassian.Bitbucket.UI";
+        public const string DefaultAuthenticationHelper = "Atlassian.Bitbucket.UI";
 
         // TODO: use the GCM client ID and secret once we have this approved.
         // Until then continue to use Sourcetree's values like GCM Windows.
@@ -30,6 +30,7 @@ namespace Atlassian.Bitbucket
 
         public static class EnvironmentVariables
         {
+            public const string AuthenticationHelper = "GCM_BITBUCKET_HELPER";
             public const string DevOAuthClientId = "GCM_DEV_BITBUCKET_CLIENTID";
             public const string DevOAuthClientSecret = "GCM_DEV_BITBUCKET_CLIENTSECRET";
             public const string DevOAuthRedirectUri = "GCM_DEV_BITBUCKET_REDIRECTURI";
@@ -39,6 +40,7 @@ namespace Atlassian.Bitbucket
         {
             public static class Credential
             {
+                public const string AuthenticationHelper = "bitbucketHelper";
                 public const string DevOAuthClientId = "bitbucketDevClientId";
                 public const string DevOAuthClientSecret = "bitbucketDevClientSecret";
                 public const string DevOAuthRedirectUri = "bitbucketDevRedirectUri";

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -3,9 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using Microsoft.Git.CredentialManager;
@@ -231,29 +229,11 @@ namespace GitHub
 
         private bool TryFindHelperExecutablePath(out string path)
         {
-            string helperName = GitHubConstants.AuthHelperName;
-
-            if (PlatformUtils.IsWindows())
-            {
-                helperName += ".exe";
-            }
-
-            string executableDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            path = Path.Combine(executableDirectory, helperName);
-            if (!Context.FileSystem.FileExists(path))
-            {
-                Context.Trace.WriteLine($"Did not find helper '{helperName}' in '{executableDirectory}'");
-
-                // We currently only have a helper on Windows. If we failed to find the helper we should warn the user.
-                if (PlatformUtils.IsWindows())
-                {
-                    Context.Streams.Error.WriteLine($"warning: missing '{helperName}' from installation.");
-                }
-
-                return false;
-            }
-
-            return true;
+            return TryFindHelperExecutablePath(
+                GitHubConstants.EnvironmentVariables.AuthenticationHelper,
+                GitHubConstants.GitConfiguration.Credential.AuthenticationHelper,
+                GitHubConstants.DefaultAuthenticationHelper,
+                out path);
         }
 
         private HttpClient _httpClient;

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -9,7 +9,7 @@ namespace GitHub
         public const string GitHubBaseUrlHost = "github.com";
         public const string GistBaseUrlHost = "gist." + GitHubBaseUrlHost;
 
-        public const string AuthHelperName = "GitHub.UI";
+        public const string DefaultAuthenticationHelper = "GitHub.UI";
 
         public const string OAuthClientId = "0120e057bd645470c1ed";
         public const string OAuthClientSecret = "18867509d956965542b521a529a79bb883344c90";
@@ -57,6 +57,7 @@ namespace GitHub
 
         public static class EnvironmentVariables
         {
+            public const string AuthenticationHelper = "GCM_GITHUB_HELPER";
             public const string AuthenticationModes = "GCM_GITHUB_AUTHMODES";
             public const string DevOAuthClientId = "GCM_DEV_GITHUB_CLIENTID";
             public const string DevOAuthClientSecret = "GCM_DEV_GITHUB_CLIENTSECRET";
@@ -67,7 +68,8 @@ namespace GitHub
         {
             public static class Credential
             {
-                public const string AuthModes = "gitHubAuthModes";
+                public const string AuthenticationHelper = "gitHubHelper";
+                public const string AuthenticationModes = "gitHubAuthModes";
                 public const string DevOAuthClientId = "gitHubDevClientId";
                 public const string DevOAuthClientSecret = "gitHubDevClientSecret";
                 public const string DevOAuthRedirectUri = "gitHubDevRedirectUri";

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -143,7 +143,7 @@ namespace GitHub
             // Check for an explicit override for supported authentication modes
             if (Context.Settings.TryGetSetting(
                 GitHubConstants.EnvironmentVariables.AuthenticationModes,
-                Constants.GitConfiguration.Credential.SectionName, GitHubConstants.GitConfiguration.Credential.AuthModes,
+                Constants.GitConfiguration.Credential.SectionName, GitHubConstants.GitConfiguration.Credential.AuthenticationModes,
                 out string authModesStr))
             {
                 if (Enum.TryParse(authModesStr, true, out AuthenticationModes authModes) && authModes != AuthenticationModes.None)

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
@@ -201,16 +200,11 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
         private bool TryFindHelperExecutablePath(out string path)
         {
-            string helperName = Constants.MicrosoftAuthHelperName;
-
-            if (PlatformUtils.IsWindows())
-            {
-                helperName += ".exe";
-            }
-
-            string executableDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            path = Path.Combine(executableDirectory, helperName);
-            return Context.FileSystem.FileExists(path);
+            return TryFindHelperExecutablePath(
+                Constants.EnvironmentVariables.MsAuthHelper,
+                Constants.GitConfiguration.Credential.MsAuthHelper,
+                Constants.DefaultMsAuthHelper,
+                out path);
         }
 
         private async Task RegisterVisualStudioTokenCacheAsync(IPublicClientApplication app)

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Git.CredentialManager
     {
         public const string PersonalAccessTokenUserName = "PersonalAccessToken";
         public const string OAuthTokenUserName = "OAuthToken";
-        public const string MicrosoftAuthHelperName = "Microsoft.Authentication.Helper";
+        public const string DefaultMsAuthHelper = "Microsoft.Authentication.Helper";
 
         public const string ProviderIdAuto  = "auto";
         public const string AuthorityIdAuto = "auto";
@@ -49,6 +49,7 @@ namespace Microsoft.Git.CredentialManager
             public const string GitSslNoVerify     = "GIT_SSL_NO_VERIFY";
             public const string GcmInteractive     = "GCM_INTERACTIVE";
             public const string GcmParentWindow    = "GCM_MODAL_PARENTHWND";
+            public const string MsAuthHelper       = "GCM_MSAUTH_HELPER";
         }
 
         public static class Http
@@ -74,6 +75,7 @@ namespace Microsoft.Git.CredentialManager
                 public const string HttpsProxy  = "httpsProxy";
                 public const string UseHttpPath = "useHttpPath";
                 public const string Interactive = "interactive";
+                public const string MsAuthHelper = "msauthHelper";
             }
 
             public static class Http


### PR DESCRIPTION
Allow authentication UI helpers to be overridden by environment variables and Git configuration options.

Closes #119