### PR TITLE
release: add required token to release workflow

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -11,6 +11,7 @@ jobs:
       uses: actions/github-script@0.3.0
       id: version
       with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
         result-encoding: string
         script: |
           const { data } = await github.repos.getReleaseByTag({


### PR DESCRIPTION
Add the required GITHUB_TOKEN token to the release workflow.