### PR TITLE
Don't attempt to deserialize nulls from bitbucket response

### DIFF
--- a/src/shared/Atlassian.Bitbucket/BitbucketRestApi.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketRestApi.cs
@@ -80,7 +80,7 @@ namespace Atlassian.Bitbucket
 
                     if (response.IsSuccessStatusCode)
                     {
-                        var obj = JsonConvert.DeserializeObject<UserInfo>(json);
+                        var obj = JsonConvert.DeserializeObject<UserInfo>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
                         return new RestApiResult<UserInfo>(response.StatusCode, obj);
                     }


### PR DESCRIPTION
In my case, the field `has_2fa_enabled` was coming back null and
that caused deserialization to fail with:

```
Error converting value {null} to type 'System.Boolean'. Path 'has_2fa_enabled', line 1, position 79.
```

Another alternative is to make the property `bool?` instead.