### PR TITLE
Fix Azure Repos sign-in with Microsoft Accounts

### DIFF
--- a/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AzureRepos.Tests
         private const string ExpectedLocationServicePath = "_apis/ServiceDefinitions/LocationService2/951917AC-A960-4999-8464-E3F0AA25B381?api-version=1.0";
         private const string ExpectedIdentityServicePath = "_apis/token/sessiontokens?api-version=1.0&tokentype=compact";
         private const string CommonAuthority = "https://login.microsoftonline.com/common";
+        private const string OrganizationsAuthority = "https://login.microsoftonline.com/organizations";
 
         [Fact]
         public async Task AzureDevOpsRestApi_GetAuthorityAsync_NullUri_ThrowsException()
@@ -169,13 +170,15 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
-        public async Task AzureDevOpsRestApi_GetAuthorityAsync_VssResourceTenantMsa_ReturnsCommonAuthority()
+        public async Task AzureDevOpsRestApi_GetAuthorityAsync_VssResourceTenantMsa_ReturnsOrganizationsAuthority()
         {
             var context = new TestCommandContext();
             var uri = new Uri("https://example.com");
             var msaTenantId = Guid.Empty;
 
-            const string expectedAuthority = CommonAuthority;
+            // This is only the case because we're using MSA pass-through.. in the future, if and when we
+            // move away from MSA pass-through, this should be the common authority.
+            const string expectedAuthority = OrganizationsAuthority;
 
             var httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
             {


### PR DESCRIPTION
Use the /organizations authority for MSA accounts with Azure DevOps/Repos. This is because we're using MSA pass-through, an internal Microsoft mechanism to support both MSA and 'work' (AAD) accounts with the same auth stacks.

You should be able to use /common, but this doens't work. At the same time we're using ADAL Obj-C on macOS rather than MSAL.NET like we do on Windows, and ADAL speaks to the "v1" AAD endpoints, which don't know the /organizations tenant 😢 

For macOS we need to fudge the authority _back_ to /common for MSA accounts.

The "correct" fix here is to move from MSA pass-through, us our own client ID (#47) and drop the ADAL Obj-C component and add UI on .NET Core for MSAL.NET... all these things would take a _long_ time to do.

Fixes #143