### PR TITLE
Fix workflows and builds

### DIFF
--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -1,5 +1,6 @@
-trigger: none
-
+pr:
+  - master
+  - release
 
 variables:
   configuration: Release

--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -14,19 +14,13 @@ jobs:
         github-token: ${{secrets.GITHUB_TOKEN}}
         result-encoding: string
         script: |
-          const { data: releases } = await github.repos.listReleases({
+          const { data } = await github.repos.getReleaseByTag({
             owner: context.repo.owner,
-            repo: context.repo.repo
+            repo: context.repo.repo,
+            tag: process.env.GITHUB_REF
           });
-          const release = releases.find(x => x.tag_name === process.env.GITHUB_REF);
-          if (!release) {
-            throw new Error(`unable to find release with tag '${process.env.GITHUB_REF}'`);
-          }
           const regex = /gcmcore-osx-(.*)\.pkg/;
-          const asset = release.assets.find(x => regex.test(x.name));
-          if (!asset) {
-            throw new Error(`unable to find asset matching '${regex}'`);
-          }
+          const asset = data.assets.find(x => regex.test(x.name));
           const matches = asset.name.match(regex);
           const version = matches[1];
           return version;


### PR DESCRIPTION
Ensure the PR build is triggered on PRs into master or release.
Also now that we're making real releases of GCM Core on GitHub and not
just pre-releases, move to the simpler syntax/API calls for the Action
that creates and updated the Homebrew cask on release publish.