### PR TITLE
Revamp credential storage system to allow for smarter searching

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,18 +196,24 @@ directly implement the interface they can also derive from the `HostProvider`
 abstract class (which itself implements the `IHostProvider` interface).
 
 The `HostProvider` abstract class implements the
-`Get|Store|EraseCredentialAsync` methods and instead has a
-`GenerateCredentialAsync` and `GetCredentialKey` abstract methods. Calls to
-`get`, `store`, or `erase` result in first a call to `GetCredentialKey` which
-should return a stable and unique "key" for the request. This forms the key for
-any stored credential in the credential store. During a `get` operation the
-credential store is queried for an existing credential with the computed key.
+`Get|Store|EraseCredentialAsync` methods and instead has the
+`GenerateCredentialAsync` abstract method, and the `GetServiceName` virtual
+method. Calls to `get`, `store`, or `erase` result in first a call to
+`GetServiceName` which should return a stable and unique value for the provider
+and request. This value forms part of the attributes associated with any stored
+credential in the credential store. During a `get` operation the
+credential store is queried for an existing credential with such service name.
 If a credential is found it is returned immediately. Similarly, calls to `store`
 and `erase` are handles automatically to store credentials against, and erase
-credentials matching the computed key. Methods are implemented as `virtual`
+credentials matching the service name. Methods are implemented as `virtual`
 meaning you can always override this behaviour, for example to clear other
 custom caches on an `erase` request, without having to reimplement the
 lookup/store credential logic.
+
+The default implementation of `GetServiceName` is usually sufficient for most
+providers. It returns the computed remote URL (without a trailing slash) from
+the input arguments from Git - `<protocol>://<host>[/<path>]` - no username is
+included even if present.
 
 Host providers are queried in turn (registration order) via the
 `IHostProvider.IsSupported` method and passed the input received from Git. If

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,3 +168,20 @@ git config --global credential.gitHubAuthModes "oauth basic"
 ```
 
 **Also see: [GCM_GITHUB_AUTHMODES](environment.md#GCM_GITHUB_AUTHMODES)**
+
+---
+
+### credential.namespace
+
+Use a custom namespace prefix for credentials read and written in the OS credential store.
+Credentials will be stored in the format `{namespace}:{service}`.
+
+Defaults to the value `git`.
+
+#### Example
+
+```shell
+git config --global credential.namespace "my-namespace"
+```
+
+**Also see: [GCM_NAMESPACE](environment.md#GCM_NAMESPACE)**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -309,3 +309,26 @@ export GCM_GITHUB_AUTHMODES="oauth basic"
 ```
 
 **Also see: [credential.gitHubAuthModes](configuration.md#credentialgitHubAuthModes)**
+
+---
+
+### GCM_NAMESPACE
+
+Use a custom namespace prefix for credentials read and written in the OS credential store.
+Credentials will be stored in the format `{namespace}:{service}`.
+
+Defaults to the value `git`.
+
+##### Windows
+
+```batch
+SET GCM_NAMESPACE="my-namespace"
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_NAMESPACE="my-namespace"
+```
+
+**Also see: [credential.namespace](configuration.md#credentialnamespace)**

--- a/src/shared/GitHub.Tests/GitHubRestApiTests.cs
+++ b/src/shared/GitHub.Tests/GitHubRestApiTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Tests.Objects;
 using Xunit;
 
@@ -90,7 +88,7 @@ namespace GitHub.Tests
 
             Assert.Equal(GitHubAuthenticationResultType.Success, authResult.Type);
             Assert.NotNull(authResult.Token);
-            Assert.Equal(expectedTokenValue, authResult.Token.Password);
+            Assert.Equal(expectedTokenValue, authResult.Token);
         }
 
         [Fact]
@@ -167,7 +165,7 @@ namespace GitHub.Tests
 
             Assert.Equal(GitHubAuthenticationResultType.Success, authResult.Type);
             Assert.NotNull(authResult.Token);
-            Assert.Equal(expectedTokenValue, authResult.Token.Password);
+            Assert.Equal(expectedTokenValue, authResult.Token);
         }
 
         [Fact]
@@ -267,7 +265,7 @@ namespace GitHub.Tests
 
             Assert.Equal(GitHubAuthenticationResultType.Success, authResult.Type);
             Assert.NotNull(authResult.Token);
-            Assert.Equal(testOAuthToken, authResult.Token.Password);
+            Assert.Equal(testOAuthToken, authResult.Token);
         }
 
         [Fact]

--- a/src/shared/GitHub/AuthenticationResult.cs
+++ b/src/shared/GitHub/AuthenticationResult.cs
@@ -12,7 +12,7 @@ namespace GitHub
             Token = null;
         }
 
-        public AuthenticationResult(GitHubAuthenticationResultType type, GitCredential token)
+        public AuthenticationResult(GitHubAuthenticationResultType type, string token)
         {
             Type = type;
             Token = token;
@@ -20,7 +20,7 @@ namespace GitHub
 
         public GitHubAuthenticationResultType Type { get; }
 
-        public GitCredential Token { get; }
+        public string Token { get; }
     }
 
     public enum GitHubAuthenticationResultType

--- a/src/shared/GitHub/GitHubRestApi.cs
+++ b/src/shared/GitHub/GitHubRestApi.cs
@@ -145,8 +145,7 @@ namespace GitHub
             {
                 _context.Trace.WriteLine($"Authentication success: user supplied personal access token for '{targetUri}'.");
 
-                return new AuthenticationResult(GitHubAuthenticationResultType.Success,
-                    new GitCredential(Constants.PersonalAccessTokenUserName, password));
+                return new AuthenticationResult(GitHubAuthenticationResultType.Success, password);
             }
 
             _context.Trace.WriteLine($"Authentication failed for '{targetUri}'.");
@@ -182,7 +181,7 @@ namespace GitHub
 
         private async Task<AuthenticationResult> ParseSuccessResponseAsync(Uri targetUri, HttpResponseMessage response)
         {
-            GitCredential token = null;
+            string token = null;
             string responseText = await response.Content.ReadAsStringAsync();
 
             Match tokenMatch;
@@ -190,8 +189,7 @@ namespace GitHub
                     RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success
                 && tokenMatch.Groups.Count > 1)
             {
-                string tokenText = tokenMatch.Groups[1].Value;
-                token = new GitCredential(Constants.PersonalAccessTokenUserName, tokenText);
+                token = tokenMatch.Groups[1].Value;
             }
 
             if (token == null)
@@ -289,7 +287,7 @@ namespace GitHub
         {
             return api.CreatePersonalAccessTokenAsync(
                 targetUri,
-                credentials?.UserName,
+                credentials?.Account,
                 credentials?.Password,
                 authenticationCode,
                 scopes);

--- a/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
@@ -37,6 +37,42 @@ namespace Microsoft.AzureRepos.Tests
             Assert.Equal(expected, UriHelpers.IsAzureDevOpsHost(host));
         }
 
+        [Theory]
+        [InlineData("dev.azure.com", true)]
+        [InlineData("myorg.visualstudio.com", false)]
+        [InlineData("vs-ssh.myorg.visualstudio.com", false)]
+        [InlineData("DEV.AZURE.COM", true)]
+        [InlineData("MYORG.VISUALSTUDIO.COM", false)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("    ", false)]
+        [InlineData("testdev.azure.com", false)]
+        [InlineData("test.dev.azure.com", false)]
+        [InlineData("visualstudio.com", false)]
+        [InlineData("testvisualstudio.com", false)]
+        public void UriHelpers_IsDevAzureComHost(string host, bool expected)
+        {
+            Assert.Equal(expected, UriHelpers.IsDevAzureComHost(host));
+        }
+
+        [Theory]
+        [InlineData("dev.azure.com", false)]
+        [InlineData("myorg.visualstudio.com", true)]
+        [InlineData("vs-ssh.myorg.visualstudio.com", true)]
+        [InlineData("DEV.AZURE.COM", false)]
+        [InlineData("MYORG.VISUALSTUDIO.COM", true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("    ", false)]
+        [InlineData("testdev.azure.com", false)]
+        [InlineData("test.dev.azure.com", false)]
+        [InlineData("visualstudio.com", false)]
+        [InlineData("testvisualstudio.com", false)]
+        public void UriHelpers_IsVisualStudioComHost(string host, bool expected)
+        {
+            Assert.Equal(expected, UriHelpers.IsVisualStudioComHost(host));
+        }
+
         [Fact]
         public void UriHelpers_CreateOrganizationUri_Null_ThrowsException()
         {

--- a/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
@@ -82,6 +82,36 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
+        public void UriHelpers_CreateOrganizationUri_AzureHost_WithPort_ReturnsCorrectUri()
+        {
+            var expected = new Uri("https://dev.azure.com:456/myorg");
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "dev.azure.com:456",
+                ["path"]     = "myorg/myproject/_git/myrepo"
+            });
+
+            Uri actual = UriHelpers.CreateOrganizationUri(input);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void UriHelpers_CreateOrganizationUri_AzureHost_WithBadPort_ThrowsException()
+        {
+            var expected = new Uri("https://dev.azure.com:456/myorg");
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "dev.azure.com:not-a-port",
+                ["path"]     = "myorg/myproject/_git/myrepo"
+            });
+
+            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+        }
+
+        [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_OrgAlsoInUser_PrefersPathOrg()
         {
             var expected = new Uri("https://dev.azure.com/myorg-path");

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -10,8 +10,9 @@ using KnownGitCfg = Microsoft.Git.CredentialManager.Constants.GitConfiguration;
 
 namespace Microsoft.AzureRepos
 {
-    public class AzureReposHostProvider : HostProvider, IConfigurableComponent
+    public class AzureReposHostProvider : DisposableObject, IHostProvider, IConfigurableComponent
     {
+        private readonly ICommandContext _context;
         private readonly IAzureDevOpsRestApi _azDevOps;
         private readonly IMicrosoftAuthentication _msAuth;
 
@@ -22,47 +23,107 @@ namespace Microsoft.AzureRepos
 
         public AzureReposHostProvider(ICommandContext context, IAzureDevOpsRestApi azDevOps,
             IMicrosoftAuthentication msAuth)
-            : base(context)
         {
+            EnsureArgument.NotNull(context, nameof(context));
             EnsureArgument.NotNull(azDevOps, nameof(azDevOps));
             EnsureArgument.NotNull(msAuth, nameof(msAuth));
 
+            _context = context;
             _azDevOps = azDevOps;
             _msAuth = msAuth;
         }
 
-        #region HostProvider
+        #region IHostProvider
 
-        public override string Id => "azure-repos";
+        public string Id => "azure-repos";
 
-        public override string Name => "Azure Repos";
+        public string Name => "Azure Repos";
 
-        public override IEnumerable<string> SupportedAuthorityIds => MicrosoftAuthentication.AuthorityIds;
+        public IEnumerable<string> SupportedAuthorityIds => MicrosoftAuthentication.AuthorityIds;
 
-        public override bool IsSupported(InputArguments input)
+        public bool IsSupported(InputArguments input)
         {
             if (input is null)
             {
                 return false;
             }
 
-            // Split port number and hostname from host input argument
-            input.TryGetHostAndPort(out string hostName, out _);
-
             // We do not support unencrypted HTTP communications to Azure Repos,
             // but we report `true` here for HTTP so that we can show a helpful
             // error message for the user in `CreateCredentialAsync`.
-            return (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http") ||
-                   StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "https")) &&
+            return input.TryGetHostAndPort(out string hostName, out _)
+                   && (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http") ||
+                       StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "https")) &&
                    UriHelpers.IsAzureDevOpsHost(hostName);
         }
 
-        public override string GetServiceName(InputArguments input)
+        public async Task<ICredential> GetCredentialAsync(InputArguments input)
         {
-            return UriHelpers.CreateOrganizationUri(input).AbsoluteUri.TrimEnd('/');
+            string service = GetServiceName(input);
+            string account = GetAccountNameForCredentialQuery(input);
+
+            _context.Trace.WriteLine($"Looking for existing credential in store with service={service} account={account}...");
+
+            ICredential credential = _context.CredentialStore.Get(service, account);
+            if (credential == null)
+            {
+                _context.Trace.WriteLine("No existing credentials found.");
+
+                // No existing credential was found, create a new one
+                _context.Trace.WriteLine("Creating new credential...");
+                credential = await GenerateCredentialAsync(input);
+                _context.Trace.WriteLine("Credential created.");
+            }
+            else
+            {
+                _context.Trace.WriteLine("Existing credential found.");
+            }
+
+            return credential;
         }
 
-        public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
+        public virtual Task StoreCredentialAsync(InputArguments input)
+        {
+            string service = GetServiceName(input);
+
+            // We always store credentials against the given username argument for
+            // both vs.com and dev.azure.com-style URLs.
+            string account = input.UserName;
+
+            // Add or update the credential in the store.
+            _context.Trace.WriteLine($"Storing credential with service={service} account={account}...");
+            _context.CredentialStore.AddOrUpdate(service, account, input.Password);
+            _context.Trace.WriteLine("Credential was successfully stored.");
+
+            return Task.CompletedTask;
+        }
+
+        public Task EraseCredentialAsync(InputArguments input)
+        {
+            string service = GetServiceName(input);
+            string account = GetAccountNameForCredentialQuery(input);
+
+            // Try to locate an existing credential
+            _context.Trace.WriteLine($"Erasing stored credential in store with service={service} account={account}...");
+            if (_context.CredentialStore.Remove(service, account))
+            {
+                _context.Trace.WriteLine("Credential was successfully erased.");
+            }
+            else
+            {
+                _context.Trace.WriteLine("No credential was erased.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        protected override void ReleaseManagedResources()
+        {
+            _azDevOps.Dispose();
+            base.ReleaseManagedResources();
+        }
+
+        private async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
             ThrowIfDisposed();
 
@@ -76,12 +137,12 @@ namespace Microsoft.AzureRepos
             Uri remoteUri = input.GetRemoteUri();
 
             // Determine the MS authentication authority for this organization
-            Context.Trace.WriteLine("Determining Microsoft Authentication Authority...");
+            _context.Trace.WriteLine("Determining Microsoft Authentication Authority...");
             string authAuthority = await _azDevOps.GetAuthorityAsync(orgUri);
-            Context.Trace.WriteLine($"Authority is '{authAuthority}'.");
+            _context.Trace.WriteLine($"Authority is '{authAuthority}'.");
 
             // Get an AAD access token for the Azure DevOps SPS
-            Context.Trace.WriteLine("Getting Azure AD access token...");
+            _context.Trace.WriteLine("Getting Azure AD access token...");
             JsonWebToken accessToken = await _msAuth.GetAccessTokenAsync(
                 authAuthority,
                 AzureDevOpsConstants.AadClientId,
@@ -90,7 +151,7 @@ namespace Microsoft.AzureRepos
                 remoteUri,
                 null);
             string atUser = accessToken.GetAzureUserName();
-            Context.Trace.WriteLineSecrets($"Acquired Azure access token. User='{atUser}' Token='{{0}}'", new object[] {accessToken.EncodedToken});
+            _context.Trace.WriteLineSecrets($"Acquired Azure access token. User='{atUser}' Token='{{0}}'", new object[] {accessToken.EncodedToken});
 
             // Ask the Azure DevOps instance to create a new PAT
             var patScopes = new[]
@@ -98,20 +159,89 @@ namespace Microsoft.AzureRepos
                 AzureDevOpsConstants.PersonalAccessTokenScopes.ReposWrite,
                 AzureDevOpsConstants.PersonalAccessTokenScopes.ArtifactsRead
             };
-            Context.Trace.WriteLine($"Creating Azure DevOps PAT with scopes '{string.Join(", ", patScopes)}'...");
+            _context.Trace.WriteLine($"Creating Azure DevOps PAT with scopes '{string.Join(", ", patScopes)}'...");
             string pat = await _azDevOps.CreatePersonalAccessTokenAsync(
                 orgUri,
                 accessToken,
                 patScopes);
-            Context.Trace.WriteLineSecrets("PAT created. PAT='{0}'", new object[] {pat});
+            _context.Trace.WriteLineSecrets("PAT created. PAT='{0}'", new object[] {pat});
 
             return new GitCredential(atUser, pat);
         }
 
-        protected override void ReleaseManagedResources()
+        /// <remarks>
+        /// For dev.azure.com-style URLs we use the path arg to get the Azure DevOps organization name.
+        /// We ensure the presence of the path arg by setting credential.useHttpPath = true at install time.
+        ///
+        /// The result of this workaround is that we are now unable to determine if the user wanted to store
+        /// credentials with the full path or not for dev.azure.com-style URLs.
+        ///
+        /// Rather than always assume we're storing credentials against the full path, and therefore resulting
+        /// in an personal access token being created per remote URL/repository, we never store against
+        /// the full path and always store with the organization URL "dev.azure.com/org".
+        ///
+        /// For visualstudio.com-style URLs we know the AzDevOps organization name from the host arg, and
+        /// don't set the useHttpPath option. This means if we get the full path for a vs.com-style URL
+        /// we can store against the full remote path (the intended design).
+        ///
+        /// Users that need to clone a repository from Azure Repos against the full path therefore must
+        /// use the vs.com-style remote URL and not the dev.azure.com one.
+        /// </remarks>
+        private static string GetServiceName(InputArguments input)
         {
-            _azDevOps.Dispose();
-            base.ReleaseManagedResources();
+            if (!input.TryGetHostAndPort(out string hostName, out _))
+            {
+                throw new InvalidOperationException("Failed to parse host name and/or port");
+            }
+
+            // dev.azure.com
+            if (UriHelpers.IsDevAzureComHost(hostName))
+            {
+                // We can never store the new dev.azure.com-style URLs against the full path because
+                // we have forced the useHttpPath option to true to in order to retrieve the AzDevOps
+                // organization name from Git.
+                return UriHelpers.CreateOrganizationUri(input).AbsoluteUri.TrimEnd('/');
+            }
+
+            // *.visualstudio.com
+            if (UriHelpers.IsVisualStudioComHost(hostName))
+            {
+                // If we're given the full path for an older *.visualstudio.com-style URL then we should
+                // respect that in the service name.
+                return input.GetRemoteUri().AbsoluteUri.TrimEnd('/');
+            }
+
+            throw new InvalidOperationException("Host is not Azure DevOps.");
+        }
+
+        private static string GetAccountNameForCredentialQuery(InputArguments input)
+        {
+            if (!input.TryGetHostAndPort(out string hostName, out _))
+            {
+                throw new InvalidOperationException("Failed to parse host name and/or port");
+            }
+
+            // dev.azure.com
+            if (UriHelpers.IsDevAzureComHost(hostName))
+            {
+                // We ignore the given username for dev.azure.com-style URLs because AzDevOps recommends
+                // adding the organization name as the user in the remote URL (resulting in URLs like
+                // https://org@dev.azure.com/org/foo/_git/bar) and we don't know if the given username
+                // is an actual username, or the org name.
+                // Use `null` as the account name so we match all possible credentials (regardless of
+                // the account).
+                return null;
+            }
+
+            // *.visualstudio.com
+            if (UriHelpers.IsVisualStudioComHost(hostName))
+            {
+                // If we're given a username for the vs.com-style URLs we can and should respect any
+                // specified username in the remote URL/input arguments.
+                return input.UserName;
+            }
+
+            throw new InvalidOperationException("Host is not Azure DevOps.");
         }
 
         #endregion
@@ -130,11 +260,11 @@ namespace Microsoft.AzureRepos
 
             if (targetConfig.TryGetValue(useHttpPathKey, out string currentValue) && currentValue.IsTruthy())
             {
-                Context.Trace.WriteLine("Git configuration 'credential.useHttpPath' is already set to 'true' for https://dev.azure.com.");
+                _context.Trace.WriteLine("Git configuration 'credential.useHttpPath' is already set to 'true' for https://dev.azure.com.");
             }
             else
             {
-                Context.Trace.WriteLine("Setting Git configuration 'credential.useHttpPath' to 'true' for https://dev.azure.com...");
+                _context.Trace.WriteLine("Setting Git configuration 'credential.useHttpPath' to 'true' for https://dev.azure.com...");
                 targetConfig.SetValue(useHttpPathKey, "true");
             }
 
@@ -147,7 +277,7 @@ namespace Microsoft.AzureRepos
         {
             string useHttpPathKey = $"{KnownGitCfg.Credential.SectionName}.https://dev.azure.com.{KnownGitCfg.Credential.UseHttpPath}";
 
-            Context.Trace.WriteLine("Clearing Git configuration 'credential.useHttpPath' for https://dev.azure.com...");
+            _context.Trace.WriteLine("Clearing Git configuration 'credential.useHttpPath' for https://dev.azure.com...");
 
             IGitConfiguration targetConfig = git.GetConfiguration(configurationLevel);
             targetConfig.Unset(useHttpPathKey);

--- a/src/shared/Microsoft.AzureRepos/UriHelpers.cs
+++ b/src/shared/Microsoft.AzureRepos/UriHelpers.cs
@@ -76,7 +76,12 @@ namespace Microsoft.AzureRepos
                 throw new InvalidOperationException("Input arguments must include host");
             }
 
-            if (!IsAzureDevOpsHost(input.Host))
+            if (!input.TryGetHostAndPort(out string hostName, out _))
+            {
+                throw new InvalidOperationException("Host name and/or port is invalid");
+            }
+
+            if (!IsAzureDevOpsHost(hostName))
             {
                 throw new InvalidOperationException("Host is not Azure DevOps");
             }
@@ -84,12 +89,12 @@ namespace Microsoft.AzureRepos
             var ub = new UriBuilder
             {
                 Scheme = input.Protocol,
-                Host = input.Host,
+                Host = hostName,
             };
 
             // Extract the organization name for Azure ('dev.azure.com') style URLs.
             // The older *.visualstudio.com URLs contained the organization name in the host already.
-            if (StringComparer.OrdinalIgnoreCase.Equals(input.Host, AzureDevOpsConstants.AzureDevOpsHost))
+            if (StringComparer.OrdinalIgnoreCase.Equals(hostName, AzureDevOpsConstants.AzureDevOpsHost))
             {
                 // dev.azure.com/{org}
                 string[] pathParts = input.Path?.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
 
             ICredential credential = basicAuth.GetCredentials(testResource, testUserName);
 
-            Assert.Equal(testUserName, credential.UserName);
+            Assert.Equal(testUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
 
             ICredential credential = basicAuth.GetCredentials(testResource);
 
-            Assert.Equal(testUserName, credential.UserName);
+            Assert.Equal(testUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             ICredential credential = basicAuth.GetCredentials(testResource);
 
             Assert.NotNull(credential);
-            Assert.Equal(testUserName, credential.UserName);
+            Assert.Equal(testUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
         }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             ICredential credential = basicAuth.GetCredentials(testResource, testUserName);
 
             Assert.NotNull(credential);
-            Assert.Equal(testUserName, credential.UserName);
+            Assert.Equal(testUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
         }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             ICredential credential = basicAuth.GetCredentials(testResource, testUserName);
 
             Assert.NotNull(credential);
-            Assert.Equal(newUserName, credential.UserName);
+            Assert.Equal(newUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
         }
     }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GenericHostProviderTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GenericHostProviderTests.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
-        public void GenericHostProvider_GetCredentialKey_ReturnsCorrectKey()
+        public void GenericHostProvider_GetCredentialServiceUrl_ReturnsCorrectKey()
         {
-            const string expectedKey = "git:https://john.doe@example.com/foo/bar";
+            const string expectedService = "https://example.com/foo/bar";
 
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -53,9 +53,9 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             var provider = new GenericHostProvider(new TestCommandContext());
 
-            string actualKey = provider.GetCredentialKey(input);
+            string actualService = provider.GetServiceName(input);
 
-            Assert.Equal(expectedKey, actualKey);
+            Assert.Equal(expectedService, actualService);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
-            Assert.Equal(testUserName, credential.UserName);
+            Assert.Equal(testUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
             wiaAuthMock.Verify(x => x.GetIsSupportedAsync(It.IsAny<Uri>()), Times.Never);
             basicAuthMock.Verify(x => x.GetCredentials(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
@@ -121,7 +121,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
-            Assert.Equal(testUserName, credential.UserName);
+            Assert.Equal(testUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
             wiaAuthMock.Verify(x => x.GetIsSupportedAsync(It.IsAny<Uri>()), Times.Never);
             basicAuthMock.Verify(x => x.GetCredentials(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
@@ -168,7 +168,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
-            Assert.Equal(string.Empty, credential.UserName);
+            Assert.Equal(string.Empty, credential.Account);
             Assert.Equal(string.Empty, credential.Password);
             basicAuthMock.Verify(x => x.GetCredentials(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
@@ -199,7 +199,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
-            Assert.Equal(testUserName, credential.UserName);
+            Assert.Equal(testUserName, credential.Account);
             Assert.Equal(testPassword, credential.Password);
             basicAuthMock.Verify(x => x.GetCredentials(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
@@ -95,6 +95,71 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public void InputArguments_GetRemoteUri_IncludeUser_Authority_ReturnsUriWithAuthorityAndUser()
+        {
+            var expectedUri = new Uri("https://john.doe@example.com/");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com",
+
+                // Username should appear in the returned URI; the password should not
+                ["username"] = "john.doe",
+                ["password"] = "password123"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri(includeUser: true);
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
+        public void InputArguments_GetRemoteUri_IncludeUserSpecialCharacters_Authority_ReturnsUriWithAuthorityAndUser()
+        {
+            var expectedUri = new Uri("https://john.doe%40domain.com@example.com/");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com",
+
+                // Username should appear in the returned URI; the password should not
+                ["username"] = "john.doe@domain.com",
+                ["password"] = "password123"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri(includeUser: true);
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
+        public void InputArguments_GetRemoteUri_AuthorityAndPort_ReturnsUriWithAuthorityAndPort()
+        {
+            var expectedUri = new Uri("https://example.com:456/");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com:456"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri();
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
         public void InputArguments_GetRemoteUri_AuthorityPath_ReturnsUriWithAuthorityAndPath()
         {
             var expectedUri = new Uri("https://example.com/an/example/path");
@@ -136,6 +201,106 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             Assert.NotNull(actualUri);
             Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
+        public void InputArguments_GetRemoteUri_IncludeUser_AuthorityPathUserInfo_ReturnsUriWithAll()
+        {
+            var expectedUri = new Uri("https://john.doe@example.com/an/example/path");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com",
+                ["path"]     = "an/example/path",
+
+                // Username should appear in the returned URI; the password should not
+                ["username"] = "john.doe",
+                ["password"] = "password123"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri(includeUser: true);
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
+        public void InputArguments_TryGetHostAndPort_NoPort_ReturnsHostName()
+        {
+            const string expectedHostName = "example.com";
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            bool result = inputArgs.TryGetHostAndPort(out string actualHostName, out int? actualPort);
+
+            Assert.True(result);
+            Assert.NotNull(actualHostName);
+            Assert.Equal(expectedHostName, actualHostName);
+            Assert.Null(actualPort);
+        }
+
+        [Fact]
+        public void InputArguments_TryGetHostAndPort_Port_ReturnsHostNameAndPort()
+        {
+            const string expectedHostName = "example.com";
+            const int expectedPort = 456;
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com:456"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            bool result = inputArgs.TryGetHostAndPort(out string actualHostName, out int? actualPort);
+
+            Assert.True(result);
+            Assert.NotNull(actualHostName);
+            Assert.Equal(expectedHostName, actualHostName);
+            Assert.NotNull(actualPort);
+            Assert.Equal(expectedPort, actualPort);
+        }
+
+        [Fact]
+        public void InputArguments_TryGetHostAndPort_BadPort_ReturnsFalse()
+        {
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com:not-a-port"
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            bool result = inputArgs.TryGetHostAndPort(out _, out int? actualPort);
+
+            Assert.False(result);
+            Assert.Null(actualPort);
+        }
+
+        [Fact]
+        public void InputArguments_TryGetHostAndPort_NoHostNoPort_ReturnsFalse()
+        {
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            bool result = inputArgs.TryGetHostAndPort(out _, out _);
+
+            Assert.False(result);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Linux/SecretServiceCollectionTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Linux/SecretServiceCollectionTests.cs
@@ -8,57 +8,58 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Linux
 {
     public class SecretServiceCollectionTests
     {
+        private const string TestNamespace = "git-test";
+
         [PlatformFact(Platform.Linux, Skip = "Cannot run headless")]
         public void SecretServiceCollection_ReadWriteDelete()
         {
-            SecretServiceCollection collection = SecretServiceCollection.Open();
+            SecretServiceCollection collection = SecretServiceCollection.Open(TestNamespace);
 
-            // Create a key that is guarenteed to be unique
-            string key = $"secretkey-{Guid.NewGuid():N}";
+            // Create a service that is guaranteed to be unique
+            string service = $"https://example.com/{Guid.NewGuid():N}";
             const string userName = "john.doe";
             const string password = "letmein123";
-            var credential = new GitCredential(userName, password);
 
             try
             {
                 // Write
-                collection.AddOrUpdate(key, credential);
+                collection.AddOrUpdate(service, userName, password);
 
                 // Read
-                ICredential outCredential = collection.Get(key);
+                ICredential outCredential = collection.Get(service, userName);
 
                 Assert.NotNull(outCredential);
-                Assert.Equal(credential.UserName, outCredential.UserName);
-                Assert.Equal(credential.Password, outCredential.Password);
+                Assert.Equal(userName, userName);
+                Assert.Equal(password, outCredential.Password);
             }
             finally
             {
                 // Ensure we clean up after ourselves even in case of 'get' failures
-                collection.Remove(key);
+                collection.Remove(service, userName);
             }
         }
 
         [PlatformFact(Platform.Linux, Skip = "Cannot run headless")]
-        public void SecretServiceCollection_Get_KeyNotFound_ReturnsNull()
+        public void SecretServiceCollection_Get_NotFound_ReturnsNull()
         {
-            SecretServiceCollection collection = SecretServiceCollection.Open();
+            SecretServiceCollection collection = SecretServiceCollection.Open(TestNamespace);
 
-            // Unique key; guaranteed not to exist!
-            string key = Guid.NewGuid().ToString("N");
+            // Unique service; guaranteed not to exist!
+            string service = $"https://example.com/{Guid.NewGuid():N}";
 
-            ICredential credential = collection.Get(key);
+            ICredential credential = collection.Get(service, null);
             Assert.Null(credential);
         }
 
         [PlatformFact(Platform.Linux, Skip = "Cannot run headless")]
-        public void SecretServiceCollection_Remove_KeyNotFound_ReturnsFalse()
+        public void SecretServiceCollection_Remove_NotFound_ReturnsFalse()
         {
-            SecretServiceCollection collection = SecretServiceCollection.Open();
+            SecretServiceCollection collection = SecretServiceCollection.Open(TestNamespace);
 
-            // Unique key; guaranteed not to exist!
-            string key = Guid.NewGuid().ToString("N");
+            // Unique service; guaranteed not to exist!
+            string service = $"https://example.com/{Guid.NewGuid():N}";
 
-            bool result = collection.Remove(key);
+            bool result = collection.Remove(service, account: null);
             Assert.False(result);
         }
     }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/MacOS/MacOSKeychainTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/MacOS/MacOSKeychainTests.cs
@@ -8,57 +8,58 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.MacOS
 {
     public class MacOSKeychainTests
     {
+        private const string TestNamespace = "git-test";
+
         [PlatformFact(Platform.MacOS)]
         public void MacOSKeychain_ReadWriteDelete()
         {
-            MacOSKeychain keychain = MacOSKeychain.Open();
+            MacOSKeychain keychain = MacOSKeychain.Open(TestNamespace);
 
-            // Create a key that is guarenteed to be unique
-            string key = $"secretkey-{Guid.NewGuid():N}";
-            const string userName = "john.doe";
+            // Create a service that is guaranteed to be unique
+            string service = $"https://example.com/{Guid.NewGuid():N}";
+            const string account = "john.doe";
             const string password = "letmein123";
-            var credential = new GitCredential(userName, password);
 
             try
             {
                 // Write
-                keychain.AddOrUpdate(key, credential);
+                keychain.AddOrUpdate(service, account, password);
 
                 // Read
-                ICredential outCredential = keychain.Get(key);
+                ICredential outCredential = keychain.Get(service, account);
 
                 Assert.NotNull(outCredential);
-                Assert.Equal(credential.UserName, outCredential.UserName);
-                Assert.Equal(credential.Password, outCredential.Password);
+                Assert.Equal(account, outCredential.Account);
+                Assert.Equal(password, outCredential.Password);
             }
             finally
             {
                 // Ensure we clean up after ourselves even in case of 'get' failures
-                keychain.Remove(key);
+                keychain.Remove(service, account);
             }
         }
 
         [PlatformFact(Platform.MacOS)]
-        public void MacOSKeychain_Get_KeyNotFound_ReturnsNull()
+        public void MacOSKeychain_Get_NotFound_ReturnsNull()
         {
-            MacOSKeychain keychain = MacOSKeychain.Open();
+            MacOSKeychain keychain = MacOSKeychain.Open(TestNamespace);
 
-            // Unique key; guaranteed not to exist!
-            string key = Guid.NewGuid().ToString("N");
+            // Unique service; guaranteed not to exist!
+            string service = $"https://example.com/{Guid.NewGuid():N}";
 
-            ICredential credential = keychain.Get(key);
+            ICredential credential = keychain.Get(service, account: null);
             Assert.Null(credential);
         }
 
         [PlatformFact(Platform.MacOS)]
-        public void MacOSKeychain_Remove_KeyNotFound_ReturnsFalse()
+        public void MacOSKeychain_Remove_NotFound_ReturnsFalse()
         {
-            MacOSKeychain keychain = MacOSKeychain.Open();
+            MacOSKeychain keychain = MacOSKeychain.Open(TestNamespace);
 
-            // Unique key; guaranteed not to exist!
-            string key = Guid.NewGuid().ToString("N");
+            // Unique service; guaranteed not to exist!
+            string service = $"https://example.com/{Guid.NewGuid():N}";
 
-            bool result = keychain.Remove(key);
+            bool result = keychain.Remove(service, account: null);
             Assert.False(result);
         }
     }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
@@ -206,5 +206,34 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Windows
                 credManager.Remove(service, userName2);
             }
         }
+
+        [Theory]
+        [InlineData("https://example.com", "https://example.com")]
+        [InlineData("https://example.com/", "https://example.com/")]
+        [InlineData("https://example.com/@", "https://example.com/@")]
+        [InlineData("https://example.com/path", "https://example.com/path")]
+        [InlineData("https://example.com/path@", "https://example.com/path@")]
+        [InlineData("https://example.com:123/path@", "https://example.com:123/path@")]
+        [InlineData("https://example.com/path/", "https://example.com/path/")]
+        [InlineData("https://example.com/path@/", "https://example.com/path@/")]
+        [InlineData("https://example.com:123/path@/", "https://example.com:123/path@/")]
+        [InlineData("https://example.com/path/foo", "https://example.com/path/foo")]
+        [InlineData("https://example.com/path@/foo", "https://example.com/path@/foo")]
+        [InlineData("https://userinfo@example.com", "https://example.com")]
+        [InlineData("https://userinfo@example.com/", "https://example.com/")]
+        [InlineData("https://userinfo@example.com/@", "https://example.com/@")]
+        [InlineData("https://userinfo@example.com/path", "https://example.com/path")]
+        [InlineData("https://userinfo@example.com/path@", "https://example.com/path@")]
+        [InlineData("https://userinfo@example.com/path/", "https://example.com/path/")]
+        [InlineData("https://userinfo@example.com:123/path/", "https://example.com:123/path/")]
+        [InlineData("https://userinfo@example.com/path@/", "https://example.com/path@/")]
+        [InlineData("https://userinfo@example.com:123/path@/", "https://example.com:123/path@/")]
+        [InlineData("https://userinfo@example.com/path/foo", "https://example.com/path/foo")]
+        [InlineData("https://userinfo@example.com/path@/foo", "https://example.com/path@/foo")]
+        public void WindowsCredentialManager_RemoveUriUserInfo(string input, string expected)
+        {
+            string actual = WindowsCredentialManager.RemoveUriUserInfo(input);
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Git.CredentialManager
                                             FileSystem.GetCurrentDirectory()
                                         );
                 Settings          = new Settings(Environment, Git);
-                CredentialStore   = WindowsCredentialManager.Open();
+                CredentialStore   = WindowsCredentialManager.Open(Constants.CredentialNamespace);
             }
             else if (PlatformUtils.IsMacOS())
             {
@@ -123,7 +123,7 @@ namespace Microsoft.Git.CredentialManager
                                             FileSystem.GetCurrentDirectory()
                                         );
                 Settings          = new Settings(Environment, Git);
-                CredentialStore   = new LinuxCredentialStore(Settings, Git);
+                CredentialStore   = new LinuxCredentialStore(Settings, Git, Constants.CredentialNamespace);
             }
             else
             {

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Git.CredentialManager
                                             FileSystem.GetCurrentDirectory()
                                         );
                 Settings          = new Settings(Environment, Git);
-                CredentialStore   = MacOSKeychain.Open();
+                CredentialStore   = MacOSKeychain.Open(Constants.CredentialNamespace);
             }
             else if (PlatformUtils.IsLinux())
             {

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Git.CredentialManager
                                             FileSystem.GetCurrentDirectory()
                                         );
                 Settings          = new Settings(Environment, Git);
-                CredentialStore   = WindowsCredentialManager.Open(Constants.CredentialNamespace);
+                CredentialStore   = WindowsCredentialManager.Open(Settings.CredentialNamespace);
             }
             else if (PlatformUtils.IsMacOS())
             {
@@ -107,7 +107,7 @@ namespace Microsoft.Git.CredentialManager
                                             FileSystem.GetCurrentDirectory()
                                         );
                 Settings          = new Settings(Environment, Git);
-                CredentialStore   = MacOSKeychain.Open(Constants.CredentialNamespace);
+                CredentialStore   = MacOSKeychain.Open(Settings.CredentialNamespace);
             }
             else if (PlatformUtils.IsLinux())
             {
@@ -123,7 +123,7 @@ namespace Microsoft.Git.CredentialManager
                                             FileSystem.GetCurrentDirectory()
                                         );
                 Settings          = new Settings(Environment, Git);
-                CredentialStore   = new LinuxCredentialStore(Settings, Git, Constants.CredentialNamespace);
+                CredentialStore   = new LinuxCredentialStore(Settings, Git, Settings.CredentialNamespace);
             }
             else
             {

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Git.CredentialManager.Commands
             }
 
             // Return the credential to Git
-            output["username"] = credential.UserName;
+            output["username"] = credential.Account;
             output["password"] = credential.Password;
 
             // Write the values to standard out

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Git.CredentialManager
         public const string PersonalAccessTokenUserName = "PersonalAccessToken";
         public const string OAuthTokenUserName = "OAuthToken";
         public const string DefaultMsAuthHelper = "Microsoft.Authentication.Helper";
+        public const string CredentialNamespace = "git";
 
         public const string ProviderIdAuto  = "auto";
         public const string AuthorityIdAuto = "auto";

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -8,9 +8,8 @@ namespace Microsoft.Git.CredentialManager
     public static class Constants
     {
         public const string PersonalAccessTokenUserName = "PersonalAccessToken";
-        public const string OAuthTokenUserName = "OAuthToken";
         public const string DefaultMsAuthHelper = "Microsoft.Authentication.Helper";
-        public const string CredentialNamespace = "git";
+        public const string DefaultCredentialNamespace = "git";
 
         public const string ProviderIdAuto  = "auto";
         public const string AuthorityIdAuto = "auto";
@@ -51,6 +50,7 @@ namespace Microsoft.Git.CredentialManager
             public const string GcmInteractive     = "GCM_INTERACTIVE";
             public const string GcmParentWindow    = "GCM_MODAL_PARENTHWND";
             public const string MsAuthHelper       = "GCM_MSAUTH_HELPER";
+            public const string GcmCredNamespace   = "GCM_NAMESPACE";
         }
 
         public static class Http
@@ -77,6 +77,7 @@ namespace Microsoft.Git.CredentialManager
                 public const string UseHttpPath = "useHttpPath";
                 public const string Interactive = "interactive";
                 public const string MsAuthHelper = "msauthHelper";
+                public const string CredNamespace = "namespace";
             }
 
             public static class Http

--- a/src/shared/Microsoft.Git.CredentialManager/Credential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Credential.cs
@@ -4,14 +4,14 @@
 namespace Microsoft.Git.CredentialManager
 {
     /// <summary>
-    /// Represents a simple credential; user name and password pair.
+    /// Represents a credential.
     /// </summary>
     public interface ICredential
     {
         /// <summary>
-        /// User name.
+        /// Account associated with this credential.
         /// </summary>
-        string UserName { get; }
+        string Account { get; }
 
         /// <summary>
         /// Password.
@@ -26,11 +26,11 @@ namespace Microsoft.Git.CredentialManager
     {
         public GitCredential(string userName, string password)
         {
-            UserName = userName;
+            Account = userName;
             Password = password;
         }
 
-        public string UserName { get; }
+        public string Account { get; }
 
         public string Password { get; }
     }

--- a/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
@@ -46,16 +46,11 @@ namespace Microsoft.Git.CredentialManager
                                      StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "https"));
         }
 
-        public override string GetCredentialKey(InputArguments input)
-        {
-            return $"git:{GetUriFromInput(input).AbsoluteUri}";
-        }
-
         public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
             ThrowIfDisposed();
 
-            Uri uri = GetUriFromInput(input);
+            Uri uri = input.GetRemoteUri();
 
             // Determine the if the host supports Windows Integration Authentication (WIA)
             if (IsWindowsAuthAllowed)
@@ -89,7 +84,7 @@ namespace Microsoft.Git.CredentialManager
             }
 
             Context.Trace.WriteLine("Prompting for basic credentials...");
-            return _basicAuth.GetCredentials(uri.AbsoluteUri, uri.UserInfo);
+            return _basicAuth.GetCredentials(uri.AbsoluteUri, input.UserName);
         }
 
         /// <summary>
@@ -121,21 +116,6 @@ namespace Microsoft.Git.CredentialManager
         {
             _winAuth.Dispose();
             base.ReleaseManagedResources();
-        }
-
-        #endregion
-
-        #region Helpers
-
-        private static Uri GetUriFromInput(InputArguments input)
-        {
-            return new UriBuilder
-            {
-                Scheme   = input.Protocol,
-                UserName = input.UserName,
-                Host     = input.Host,
-                Path     = input.Path
-            }.Uri;
         }
 
         #endregion

--- a/src/shared/Microsoft.Git.CredentialManager/ICredentialStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ICredentialStore.cs
@@ -9,24 +9,27 @@ namespace Microsoft.Git.CredentialManager
     public interface ICredentialStore
     {
         /// <summary>
-        /// Get credential from the store with the specified key.
+        /// Get the first credential from the store that matches the given query.
         /// </summary>
-        /// <param name="key">Key for credential to retrieve.</param>
-        /// <returns>Stored credential or null if not found.</returns>
-        ICredential Get(string key);
+        /// <param name="service">Name of the service to match against. Use null to match all values.</param>
+        /// <param name="account">Account name to match against. Use null to match all values.</param>
+        /// <returns>First matching credential or null if none are found.</returns>
+        ICredential Get(string service, string account);
 
         /// <summary>
         /// Add or update credential in the store with the specified key.
         /// </summary>
-        /// <param name="key">Key for credential to add/update.</param>
-        /// <param name="credential">Credential to store.</param>
-        void AddOrUpdate(string key, ICredential credential);
+        /// <param name="service">Name of the service this credential is for. Use null to match all values.</param>
+        /// <param name="account">Account associated with this credential. Use null to match all values.</param>
+        /// <param name="secret">Secret value to store.</param>
+        void AddOrUpdate(string service, string account, string secret);
 
         /// <summary>
-        /// Delete credential from the store with the specified key.
+        /// Delete credential from the store that matches the given query.
         /// </summary>
-        /// <param name="key">Key of credential to delete.</param>
+        /// <param name="service">Name of the service to match against. Use null to match all values.</param>
+        /// <param name="account">Account name to match against. Use null to match all values.</param>
         /// <returns>True if the credential was deleted, false otherwise.</returns>
-        bool Remove(string key);
+        bool Remove(string service, string account);
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxCredentialStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxCredentialStore.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Microsoft.Git.CredentialManager.Interop.Linux
 {
@@ -10,36 +7,38 @@ namespace Microsoft.Git.CredentialManager.Interop.Linux
     {
         private readonly ISettings _settings;
         private readonly IGit _git;
+        private readonly string _namespace;
 
         private ICredentialStore _backingStore;
 
-        public LinuxCredentialStore(ISettings settings, IGit git)
+        public LinuxCredentialStore(ISettings settings, IGit git, string @namespace = null)
         {
             EnsureArgument.NotNull(settings, nameof(settings));
             EnsureArgument.NotNull(git, nameof(git));
 
             _settings = settings;
             _git = git;
+            _namespace = @namespace;
         }
 
         #region ICredentialStore
 
-        public ICredential Get(string key)
+        public ICredential Get(string service, string account)
         {
             EnsureBackingStore();
-            return _backingStore.Get(key);
+            return _backingStore.Get(service, account);
         }
 
-        public void AddOrUpdate(string key, ICredential credential)
+        public void AddOrUpdate(string service, string account, string secret)
         {
             EnsureBackingStore();
-            _backingStore.AddOrUpdate(key, credential);
+            _backingStore.AddOrUpdate(service, account, secret);
         }
 
-        public bool Remove(string key)
+        public bool Remove(string service, string account)
         {
             EnsureBackingStore();
-            return _backingStore.Remove(key);
+            return _backingStore.Remove(service, account);
         }
 
         #endregion
@@ -51,7 +50,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Linux
                 // TODO: determine the available backing stores based on the current session
                 // TODO: prompt for the desired backing store
                 // TODO: store the desired backing store to ~/.gitconfig
-                _backingStore = SecretServiceCollection.Open();
+                _backingStore = SecretServiceCollection.Open(_namespace);
             }
         }
     }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Gobject.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Gobject.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Git.CredentialManager.Interop.Linux.Native
         private const string LibraryName = "libgobject-2.0.so.0";
 
         [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void g_object_ref(IntPtr @object);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern void g_object_unref(IntPtr @object);
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Libsecret.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Libsecret.cs
@@ -147,5 +147,8 @@ namespace Microsoft.Git.CredentialManager.Interop.Linux.Native
 
         [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern void secret_password_free(IntPtr password);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe bool secret_item_delete_sync(SecretItem* self, IntPtr cancellable, out Glib.GError* error);
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/SecretServiceCredential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/SecretServiceCredential.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.Diagnostics;
+
+namespace Microsoft.Git.CredentialManager.Interop.Linux
+{
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class SecretServiceCredential : ICredential
+    {
+        internal SecretServiceCredential(string service, string account, string password)
+        {
+            Service = service;
+            Account = account;
+            Password = password;
+        }
+
+        public string Service { get; }
+
+        public string Account { get; }
+
+        public string Password { get; }
+
+        private string DebuggerDisplay => $"[Service: {Service}, Account: {Account}]";
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSKeychainCredential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSKeychainCredential.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.Diagnostics;
+
+namespace Microsoft.Git.CredentialManager.Interop.MacOS
+{
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class MacOSKeychainCredential : ICredential
+    {
+        internal MacOSKeychainCredential(string service, string account, string password, string label)
+        {
+            Service = service;
+            Account = account;
+            Password = password;
+            Label = label;
+        }
+
+        public string Service  { get; }
+
+        public string Account { get; }
+
+        public string Label { get; }
+
+        public string Password { get; }
+
+        private string DebuggerDisplay => $"{Label} [Service: {Service}, Account: {Account}]";
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/CoreFoundation.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/CoreFoundation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
+using static Microsoft.Git.CredentialManager.Interop.MacOS.Native.LibSystem;
 
 namespace Microsoft.Git.CredentialManager.Interop.MacOS.Native
 {
@@ -9,7 +10,89 @@ namespace Microsoft.Git.CredentialManager.Interop.MacOS.Native
     {
         private const string CoreFoundationFrameworkLib = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
 
+        public static readonly IntPtr Handle;
+        public static readonly IntPtr kCFBooleanTrue;
+        public static readonly IntPtr kCFBooleanFalse;
+
+        static CoreFoundation()
+        {
+            Handle = dlopen(CoreFoundationFrameworkLib, 0);
+
+            kCFBooleanTrue  = GetGlobal(Handle, "kCFBooleanTrue");
+            kCFBooleanFalse = GetGlobal(Handle, "kCFBooleanFalse");
+        }
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFArrayCreateMutable(IntPtr allocator, long capacity, IntPtr callbacks);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFArrayInsertValueAtIndex(IntPtr theArray, long idx, IntPtr value);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long CFArrayGetCount(IntPtr theArray);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFArrayGetValueAtIndex(IntPtr theArray, long idx);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFDictionaryCreateMutable(
+            IntPtr allocator,
+            long capacity,
+            IntPtr keyCallBacks,
+            IntPtr valueCallBacks);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFDictionaryAddValue(
+            IntPtr theDict,
+            IntPtr key,
+            IntPtr value);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFDictionaryGetValue(IntPtr theDict, IntPtr key);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool CFDictionaryGetValueIfPresent(IntPtr theDict, IntPtr key, out IntPtr value);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFStringCreateWithBytes(IntPtr alloc, byte[] bytes, long numBytes,
+            CFStringEncoding encoding, bool isExternalRepresentation);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long CFStringGetLength(IntPtr theString);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool CFStringGetCString(IntPtr theString, IntPtr buffer, long bufferSize, CFStringEncoding encoding);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFRetain(IntPtr cf);
+
         [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern void CFRelease(IntPtr cf);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFGetTypeID(IntPtr cf);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFStringGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFDataGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFDictionaryGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFArrayGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFDataGetBytePtr(IntPtr theData);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFDataGetLength(IntPtr theData);
+    }
+
+    public enum CFStringEncoding
+    {
+        kCFStringEncodingUTF8 = 0x08000100,
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/LibSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/LibSystem.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Git.CredentialManager.Interop.MacOS.Native
+{
+    public static class LibSystem
+    {
+        private const string LibSystemLib = "/System/Library/Frameworks/System.framework/System";
+
+        [DllImport(LibSystemLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr dlopen(string name, int flags);
+
+        [DllImport(LibSystemLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+        public static IntPtr GetGlobal(IntPtr handle, string symbol)
+        {
+            IntPtr ptr = dlsym(handle, symbol);
+            return Marshal.PtrToStructure<IntPtr>(ptr);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixEnvironment.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
             const string whichPath = "/usr/bin/which";
             var psi = new ProcessStartInfo(whichPath, program)
             {
+                UseShellExecute = false,
                 RedirectStandardOutput = true
             };
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Advapi32.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Advapi32.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
 namespace Microsoft.Git.CredentialManager.Interop.Windows.Native
@@ -31,8 +30,15 @@ namespace Microsoft.Git.CredentialManager.Interop.Windows.Native
             int flags);
 
         [DllImport(LibraryName, EntryPoint = "CredFree", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern void CredFree(
+        public static extern void CredFree(
             IntPtr credential);
+
+        [DllImport(LibraryName, EntryPoint = "CredEnumerateW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredEnumerate(
+            string filter,
+            CredentialEnumerateFlags flags,
+            out int count,
+            out IntPtr credentialsList);
     }
 
     public enum CredentialType
@@ -50,6 +56,13 @@ namespace Microsoft.Git.CredentialManager.Interop.Windows.Native
         Enterprise = 3,
     }
 
+    [Flags]
+    public enum CredentialEnumerateFlags
+    {
+        None = 0,
+        AllCredentials = 0x1
+    }
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct Win32Credential
     {
@@ -64,7 +77,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Windows.Native
         public IntPtr CredentialBlob;
         public CredentialPersist Persist;
         public int AttributeCount;
-        public IntPtr CredAttribute;
+        public IntPtr Attributes;
         [MarshalAs(UnmanagedType.LPWStr)]
         public string TargetAlias;
         [MarshalAs(UnmanagedType.LPWStr)]

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredential.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.Git.CredentialManager.Interop.Windows
+{
+    public class WindowsCredential : ICredential
+    {
+        public WindowsCredential(string service, string userName, string password, string targetName)
+        {
+            Service = service;
+            UserName = userName;
+            Password = password;
+            TargetName = targetName;
+        }
+
+        public string Service { get; }
+
+        public string UserName { get; }
+
+        public string Password { get; }
+
+        public string TargetName { get; }
+
+        string ICredential.Account => UserName;
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredentialManager.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Git.CredentialManager.Interop.Windows.Native;
@@ -9,119 +11,289 @@ namespace Microsoft.Git.CredentialManager.Interop.Windows
 {
     public class WindowsCredentialManager : ICredentialStore
     {
+        private const string TargetNameLegacyGenericPrefix = "LegacyGeneric:target=";
+
+        private readonly string _namespace;
+
         #region Constructors
 
         /// <summary>
         /// Open the Windows Credential Manager vault for the current user.
         /// </summary>
+        /// <param name="namespace">Optional namespace to scope credential operations.</param>
         /// <returns>Current user's Credential Manager vault.</returns>
-        public static WindowsCredentialManager Open()
+        public static WindowsCredentialManager Open(string @namespace = null)
         {
-            return new WindowsCredentialManager();
+            return new WindowsCredentialManager(@namespace);
         }
 
-        private WindowsCredentialManager()
+        private WindowsCredentialManager(string @namespace)
         {
             PlatformUtils.EnsureWindows();
+            _namespace = @namespace;
         }
 
         #endregion
 
         #region ICredentialStore
 
-        public ICredential Get(string key)
+        public ICredential Get(string service, string account)
         {
-            IntPtr credPtr = IntPtr.Zero;
-
-            try
-            {
-                int result = Win32Error.GetLastError(
-                    Advapi32.CredRead(key, CredentialType.Generic, 0, out credPtr)
-                );
-
-                switch (result)
-                {
-                    case Win32Error.Success:
-                        Win32Credential credential = Marshal.PtrToStructure<Win32Credential>(credPtr);
-
-                        var userName = credential.UserName;
-
-                        byte[] passwordBytes = InteropUtils.ToByteArray(credential.CredentialBlob, credential.CredentialBlobSize);
-                        var password = Encoding.Unicode.GetString(passwordBytes);
-
-                        return new GitCredential(userName, password);
-
-                    case Win32Error.NotFound:
-                        return null;
-
-                    default:
-                        Win32Error.ThrowIfError(result, "Failed to read item from store.");
-                        return null;
-                }
-            }
-            finally
-            {
-                if (credPtr != IntPtr.Zero)
-                {
-                    Advapi32.CredFree(credPtr);
-                }
-            }
+            return Enumerate(service, account).FirstOrDefault();
         }
 
-        public void AddOrUpdate(string key, ICredential credential)
+        public void AddOrUpdate(string service, string account, string secret)
         {
-            byte[] passwordBytes = Encoding.Unicode.GetBytes(credential.Password);
+            EnsureArgument.NotNullOrWhiteSpace(service, nameof(service));
 
-            var w32Credential = new Win32Credential
-            {
-                Type = CredentialType.Generic,
-                TargetName = key,
-                CredentialBlob = Marshal.AllocHGlobal(passwordBytes.Length),
-                CredentialBlobSize = passwordBytes.Length,
-                Persist = CredentialPersist.LocalMachine,
-                AttributeCount = 0,
-                UserName = credential.UserName,
-            };
+            IntPtr existingCredPtr = IntPtr.Zero;
+            IntPtr credBlob = IntPtr.Zero;
 
             try
             {
-                Marshal.Copy(passwordBytes, 0, w32Credential.CredentialBlob, passwordBytes.Length);
+                // Determine if we need to update an existing credential, which might have
+                // a target name that does not include the account name.
+                //
+                // We first check for the presence of a credential with an account-less
+                // target name.
+                //
+                //  - If such credential exists and *has the same account* then we will
+                //    update that entry.
+                //  - If such credential exists and does *not* have the same account then
+                //    we must create a new entry with the account in the target name.
+                //  - If no such credential exists then we create a new entry with the
+                //    account-less target name.
+                //
+                string targetName = CreateTargetName(service, account: null);
+                if (Advapi32.CredRead(targetName, CredentialType.Generic, 0, out existingCredPtr))
+                {
+                    var existingCred = Marshal.PtrToStructure<Win32Credential>(existingCredPtr);
+                    if (!StringComparer.Ordinal.Equals(existingCred.UserName, account))
+                    {
+                        // Create new entry with the account in the target name
+                        targetName = CreateTargetName(service, account);
+                    }
+                }
+
+                byte[] secretBytes = Encoding.Unicode.GetBytes(secret);
+                credBlob = Marshal.AllocHGlobal(secretBytes.Length);
+                Marshal.Copy(secretBytes, 0, credBlob, secretBytes.Length);
+
+                var newCred = new Win32Credential
+                {
+                    Type = CredentialType.Generic,
+                    TargetName = targetName,
+                    CredentialBlobSize = secretBytes.Length,
+                    CredentialBlob = credBlob,
+                    Persist = CredentialPersist.LocalMachine,
+                    UserName = account,
+                };
+
 
                 int result = Win32Error.GetLastError(
-                    Advapi32.CredWrite(ref w32Credential, 0)
+                    Advapi32.CredWrite(ref newCred, 0)
                 );
 
                 Win32Error.ThrowIfError(result, "Failed to write item to store.");
             }
             finally
             {
-                if (w32Credential.CredentialBlob != IntPtr.Zero)
+                if (credBlob != IntPtr.Zero)
                 {
-                    Marshal.FreeHGlobal(w32Credential.CredentialBlob);
+                    Marshal.FreeHGlobal(credBlob);
+                }
+
+                if (existingCredPtr != IntPtr.Zero)
+                {
+                    Advapi32.CredFree(existingCredPtr);
                 }
             }
         }
 
-        public bool Remove(string key)
+        public bool Remove(string service, string account)
         {
-            int result = Win32Error.GetLastError(
-                Advapi32.CredDelete(key, CredentialType.Generic, 0)
-            );
+            WindowsCredential credential = Enumerate(service, account).FirstOrDefault();
 
-            switch (result)
+            if (credential != null)
             {
-                case Win32Error.Success:
-                    return true;
+                int result = Win32Error.GetLastError(
+                    Advapi32.CredDelete(credential.TargetName, CredentialType.Generic, 0)
+                );
 
-                case Win32Error.NotFound:
-                    return false;
+                switch (result)
+                {
+                    case Win32Error.Success:
+                        return true;
 
-                default:
-                    Win32Error.ThrowIfError(result);
-                    return false;
+                    case Win32Error.NotFound:
+                        return false;
+
+                    default:
+                        Win32Error.ThrowIfError(result);
+                        return false;
+                }
             }
+
+            return false;
         }
 
         #endregion
+
+        private IEnumerable<WindowsCredential> Enumerate(string service, string account)
+        {
+            IntPtr credList = IntPtr.Zero;
+
+            try
+            {
+                int result = Win32Error.GetLastError(
+                    Advapi32.CredEnumerate(
+                        null,
+                        CredentialEnumerateFlags.AllCredentials,
+                        out int count,
+                        out credList)
+                );
+
+                switch (result)
+                {
+                    case Win32Error.Success:
+                        int ptrSize = Marshal.SizeOf<IntPtr>();
+                        for (int i = 0; i < count; i++)
+                        {
+                            IntPtr credPtr = Marshal.ReadIntPtr(credList, i * ptrSize);
+                            Win32Credential credential = Marshal.PtrToStructure<Win32Credential>(credPtr);
+
+                            if (!IsMatch(service, account, credential))
+                            {
+                                continue;
+                            }
+
+                            yield return CreateCredentialFromStructure(credential);
+                        }
+                        break;
+
+                    case Win32Error.NotFound:
+                        yield break;
+
+                    default:
+                        Win32Error.ThrowIfError(result, "Failed to enumerate credentials.");
+                        yield break;
+                }
+            }
+            finally
+            {
+                if (credList != IntPtr.Zero)
+                {
+                    Advapi32.CredFree(credList);
+                }
+            }
+        }
+
+        private WindowsCredential CreateCredentialFromStructure(Win32Credential credential)
+        {
+            string password = null;
+            if (credential.CredentialBlobSize != 0 && credential.CredentialBlob != IntPtr.Zero)
+            {
+                byte[] passwordBytes = InteropUtils.ToByteArray(
+                    credential.CredentialBlob,
+                    credential.CredentialBlobSize);
+                password = Encoding.Unicode.GetString(passwordBytes);
+            }
+
+            // Recover the service name from the target name
+            string service = credential.TargetName.TrimUntilIndexOf(TargetNameLegacyGenericPrefix);
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                service = service.TrimUntilIndexOf($"{_namespace}:");
+            }
+
+            return new WindowsCredential(service, credential.UserName, password, credential.TargetName);
+        }
+
+        private bool IsMatch(string service, string account, Win32Credential credential)
+        {
+            // Match against the username first
+            if (!string.IsNullOrWhiteSpace(account) &&
+                !StringComparer.Ordinal.Equals(account, credential.UserName))
+            {
+                return false;
+            }
+
+            // Trim the "LegacyGeneric" prefix Windows adds and any namespace we have been filtered with
+            string targetName = credential.TargetName.TrimUntilIndexOf(TargetNameLegacyGenericPrefix);
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                targetName = targetName.TrimUntilIndexOf($"{_namespace}:");
+            }
+
+            // If the target name matches the service name exactly then return 'match'
+            if (StringComparer.Ordinal.Equals(service, targetName))
+            {
+                return true;
+            }
+
+            // Try matching the target and service as URIs
+            if (Uri.TryCreate(service, UriKind.Absolute, out Uri serviceUri) &&
+                Uri.TryCreate(targetName, UriKind.Absolute, out Uri targetUri))
+            {
+                // Match host name
+                if (!StringComparer.OrdinalIgnoreCase.Equals(serviceUri.Host, targetUri.Host))
+                {
+                    return false;
+                }
+
+                // Match port number
+                if (!serviceUri.IsDefaultPort && serviceUri.Port == targetUri.Port)
+                {
+                    return false;
+                }
+
+                // Match path
+                if (!string.IsNullOrWhiteSpace(serviceUri.AbsolutePath) &&
+                    !StringComparer.OrdinalIgnoreCase.Equals(serviceUri.AbsolutePath, targetUri.AbsolutePath))
+                {
+                    return false;
+                }
+
+                // URLs match
+                return true;
+            }
+
+            // Unable to match
+            return false;
+        }
+
+        private string CreateTargetName(string service, string account)
+        {
+            var serviceUri = new Uri(service, UriKind.Absolute);
+            var sb = new StringBuilder();
+
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                sb.AppendFormat("{0}:", _namespace);
+            }
+
+            if (!string.IsNullOrWhiteSpace(serviceUri.Scheme))
+            {
+                sb.AppendFormat("{0}://", serviceUri.Scheme);
+            }
+
+            if (!string.IsNullOrWhiteSpace(account))
+            {
+                string escapedAccount = account.Replace('@', '_');
+                sb.AppendFormat("{0}@", escapedAccount);
+            }
+
+            if (!string.IsNullOrWhiteSpace(serviceUri.Host))
+            {
+                sb.Append(serviceUri.Host);
+            }
+
+            if (!string.IsNullOrWhiteSpace(serviceUri.AbsolutePath.TrimEnd('/')))
+            {
+                sb.Append(serviceUri.AbsolutePath);
+            }
+
+            return sb.ToString();
+        }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsEnvironment.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Windows
             string wherePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "where.exe");
             var psi = new ProcessStartInfo(wherePath, program)
             {
+                UseShellExecute = false,
                 RedirectStandardOutput = true
             };
 

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -109,6 +109,12 @@ namespace Microsoft.Git.CredentialManager
         /// </summary>
         /// <remarks>This value is platform specific.</remarks>
         string ParentWindowId { get; }
+
+        /// <summary>
+        /// Credential storage namespace prefix.
+        /// </summary>
+        /// <remarks>The default value is "git" if unset.</remarks>
+        string CredentialNamespace { get; }
     }
 
     public class Settings : ISettings
@@ -406,7 +412,14 @@ namespace Microsoft.Git.CredentialManager
             return null;
         }
 
-        public string ParentWindowId => _environment.Variables.TryGetValue(Constants.EnvironmentVariables.GcmParentWindow, out string parentWindowId) ? parentWindowId : null;
+        public string ParentWindowId => _environment.Variables.TryGetValue(KnownEnvars.GcmParentWindow, out string parentWindowId) ? parentWindowId : null;
+
+        public string CredentialNamespace =>
+            TryGetSetting(KnownEnvars.GcmCredNamespace,
+                KnownGitCfg.Credential.SectionName, KnownGitCfg.Credential.CredNamespace,
+                out string @namespace)
+                ? @namespace
+                : Constants.DefaultCredentialNamespace;
 
         #region IDisposable
 

--- a/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public Func<InputArguments, bool> IsSupportedFunc { get; set; }
 
-        public string CredentialKey { get; set; }
-
         public string LegacyAuthorityIdValue { get; set; }
 
         public Func<InputArguments, ICredential> GenerateCredentialFunc { get; set; }
@@ -27,11 +25,6 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         public string LegacyAuthorityId => LegacyAuthorityIdValue;
 
         public override bool IsSupported(InputArguments input) => IsSupportedFunc(input);
-
-        public override string GetCredentialKey(InputArguments input)
-        {
-            return CredentialKey;
-        }
 
         public override Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public string ParentWindowId { get; set; }
 
+        public string CredentialNamespace { get; set; } = "git-test";
+
         #region ISettings
 
         public bool TryGetSetting(string envarName, string section, string property, out string value)
@@ -114,6 +116,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         }
 
         string ISettings.ParentWindowId => ParentWindowId;
+
+        string ISettings.CredentialNamespace => CredentialNamespace;
 
         #endregion
 

--- a/src/windows/GitHub.UI.Windows/AuthenticationPrompts.cs
+++ b/src/windows/GitHub.UI.Windows/AuthenticationPrompts.cs
@@ -16,14 +16,14 @@ namespace GitHub.UI
 
         private readonly IGui _gui;
 
-        public CredentialPromptResult ShowCredentialPrompt(string enterpriseUrl, bool showBasic, bool showOAuth, out string username, out string password)
+        public CredentialPromptResult ShowCredentialPrompt(string enterpriseUrl, bool showBasic, bool showOAuth, ref string username, out string password)
         {
-            username = null;
             password = null;
 
             var viewModel = new LoginCredentialsViewModel(showBasic, showOAuth)
             {
-                GitHubEnterpriseUrl = enterpriseUrl
+                GitHubEnterpriseUrl = enterpriseUrl,
+                UsernameOrEmail = username
             };
 
             bool valid = _gui.ShowDialogWindow(viewModel, () => new LoginCredentialsView());

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -31,6 +31,7 @@ namespace GitHub.UI
                         string enterpriseUrl = CommandLineUtils.GetParameter(args, "--enterprise-url");
                         bool basic = CommandLineUtils.TryGetSwitch(args, "--basic");
                         bool oauth = CommandLineUtils.TryGetSwitch(args, "--oauth");
+                        string username = CommandLineUtils.GetParameter(args, "--username");
 
                         if (!basic && !oauth)
                         {
@@ -39,7 +40,7 @@ namespace GitHub.UI
 
                         var result = prompts.ShowCredentialPrompt(
                             enterpriseUrl, basic, oauth,
-                            out string username,
+                            ref username,
                             out string password);
 
                         switch (result)


### PR DESCRIPTION
This PR should hopefully address several bugs which originate from the (flawed) design of the credential storage abstraction ( https://github.com/microsoft/Git-Credential-Manager-Core/issues/142, https://github.com/microsoft/Git-Credential-Manager-Core/issues/160) as well as a simple port number parsing bug (https://github.com/microsoft/Git-Credential-Manager-Core/issues/156)

The original design/assumption was that for each request we get from Git (via a `get` call) we could create a unique 'credential key' that encoded the username and URL for the hosting provider. Whilst this worked for GitHub, Azure Repos, and Bitbucket when using _one user_ per provider (or AzDevOps organisation), it failed to work for the generic provider when the username was not specified as part of the remote URL, nor did it work for multi-user scenarios with the other providers.

Following the design of the `osxkeychain` and `wincred` Git credential helpers, we now store the username in a separate field from the URL (called a 'service' to use the macOS Keychain terminology). This means when doing a credential lookup in response to a `get` call, we can search for a credential with the matching URL (service), and optionally a matching account if a username was passed, or _any_ user if none was specified.

One problem however arises from this multi-user support which is specific to the Azure Repos provider..

**Background:** Azure Repos supports two kinds of URL: `org.visualstudio.com` and `dev.azure.com/org`. In the former we have all the information we need to perform authentication in the authority (protocol + hostname + orgname), but with the latter we require at least the first component of the path to get the organisation name.

Git only supplies the authority information (protocol + hostname) by default, meaning we have to force the `useHttpPath` Git configuration option to `true` meaning we always get the path component. This also meant that for Azure Repos users using the dev.azure.com-style URL we could not differentiate between a real desire to store credentials against the full remote URL including path or not. This was already an existing limitation.

However, to help 'workaround' this URL+Git design incompatibility, Azure Repos also made the decision to recommend users put the AzDevOps organisation name as the _user info_ in the remote URL for dev.azure.com URLs. For example: `https://org@dev.azure.com/org/project/_git/repo`. Previously we ignored the username (since we only supported one user), but now we have a problem with storing credentials against the _real_ username vs the 'fake' org username value.

Without a change to Git to either: a) always provide the full remote URL on each `get` request as a separate input line, or b) provide a way to maintain state between the `get` and `store/erase` calls, we cannot implement multi-user _nor_ full-path support for `dev.azure.com` users. For now, we maintain the existing behaviour of one _one user_ and _no full path_ storage support for credentials against the `dev.azure.com`-style URLs.

We _do_ however implement full mutli-user and full-path-storage support for the older `*.visualstudio.com`-style URLs.
For those who wish to use multiple users per Azure DevOps organisation, or store a credential against the full remote URL, they must use the `vs.com`-style URLs which are still supported.