### PR TITLE
Fix errors with 'git-credential-manager-core configure' with empty config

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -322,7 +322,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProxyConfiguration_Unset_ReturnsNull()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -341,7 +340,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProxyConfiguration_GcmHttpConfig_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string section = Constants.GitConfiguration.Credential.SectionName;
             const string property = Constants.GitConfiguration.Credential.HttpProxy;
@@ -366,7 +364,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProxyConfiguration_GcmHttpsConfig_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "https://example.com/foo.git";
             const string section = Constants.GitConfiguration.Credential.SectionName;
             const string property = Constants.GitConfiguration.Credential.HttpsProxy;
@@ -391,7 +388,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProxyConfiguration_GitHttpConfig_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string section = Constants.GitConfiguration.Http.SectionName;
             const string property = Constants.GitConfiguration.Http.Proxy;
@@ -416,7 +412,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProxyConfiguration_CurlHttpEnvar_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -441,7 +436,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProxyConfiguration_CurlHttpsEnvar_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "https://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -466,7 +460,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_TryGetProxy_CurlAllEnvar_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "https://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -491,7 +484,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProxyConfiguration_LegacyGcmEnvar_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -528,7 +520,6 @@ namespace Microsoft.Git.CredentialManager.Tests
             // 4. GCM proxy environment variable (deprecated)
             //      GCM_HTTP_PROXY
 
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -567,7 +558,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProviderOverride_Unset_ReturnsNull()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -586,7 +576,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProviderOverride_EnvarSet_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -610,7 +599,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProviderOverride_ConfigSet_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string section = Constants.GitConfiguration.Credential.SectionName;
             const string property = Constants.GitConfiguration.Credential.Provider;
@@ -634,7 +622,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_ProviderOverride_EnvarAndConfigSet_ReturnsEnvarValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string section = Constants.GitConfiguration.Credential.SectionName;
             const string property = Constants.GitConfiguration.Credential.Provider;
@@ -662,7 +649,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_LegacyAuthorityOverride_Unset_ReturnsNull()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -681,7 +667,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_LegacyAuthorityOverride_EnvarSet_ReturnsValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             var remoteUri = new Uri(remoteUrl);
 
@@ -705,7 +690,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_LegacyAuthorityOverride_ConfigSet_ReturnsTrueOutValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string section = Constants.GitConfiguration.Credential.SectionName;
             const string property = Constants.GitConfiguration.Credential.Authority;
@@ -729,7 +713,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_LegacyAuthorityOverride_EnvarAndConfigSet_ReturnsEnvarValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string section = Constants.GitConfiguration.Credential.SectionName;
             const string property = Constants.GitConfiguration.Credential.Authority;
@@ -757,7 +740,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_TryGetSetting_EnvarSet_ReturnsTrueOutValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string envarName = "GCM_TESTVAR";
             const string section = "gcmtest";
@@ -785,7 +767,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_TryGetSetting_EnvarUnset_ReturnsFalse()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string envarName = "GCM_TESTVAR";
             const string section = "gcmtest";
@@ -808,7 +789,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_TryGetSetting_GlobalConfig_ReturnsTrueAndValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string envarName = "GCM_TESTVAR";
             const string section = "gcmtest";
@@ -834,7 +814,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_TryGetSetting_RepoConfig_ReturnsTrueAndValue()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string envarName = "GCM_TESTVAR";
             const string section = "gcmtest";
@@ -860,7 +839,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_TryGetSetting_ScopedConfig()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo/bar/bazz.git";
             const string scope1 = "example.com";
             const string scope2 = "example.com/foo/bar";
@@ -890,7 +868,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_TryGetSetting_EnvarAndConfig_EnvarTakesPrecedence()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string envarName = "GCM_TESTVAR";
             const string section = "gcmtest";
@@ -920,7 +897,6 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void Settings_GetSettingValues_EnvarAndMultipleConfig_ReturnsAllWithCorrectPrecedence()
         {
-            const string repositoryPath = "/tmp/repos/foo/.git";
             const string remoteUrl = "http://example.com/foo.git";
             const string scope1 = "http://example.com";
             const string scope2 = "example.com";

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Git.CredentialManager
         public void SetValue(string name, string value)
         {
             string level = GetLevelFilterArg();
-            using (Process git = _git.CreateProcess($"config {level} {name} {value}"))
+            using (Process git = _git.CreateProcess($"config {level} {name} \"{value}\""))
             {
                 git.Start();
                 git.WaitForExit();
@@ -212,6 +212,7 @@ namespace Microsoft.Git.CredentialManager
                 switch (git.ExitCode)
                 {
                     case 0: // OK
+                    case 1: // No results
                         break;
                     default:
                         throw new Exception(
@@ -263,6 +264,7 @@ namespace Microsoft.Git.CredentialManager
                 switch (git.ExitCode)
                 {
                     case 0: // OK
+                    case 5: // Trying to unset a value that does not exist
                         break;
                     default:
                         throw new Exception(

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Git.CredentialManager
                 {
                     string[] kvp = entry.Split(new[]{'\n'}, count: 2);
 
-                    if (!cb(kvp[0], kvp[1]))
+                    if (kvp.Length == 2 && !cb(kvp[0], kvp[1]))
                     {
                         break;
                     }
@@ -226,7 +226,9 @@ namespace Microsoft.Git.CredentialManager
                 {
                     string[] kvp = entry.Split(new[]{'\n'}, count: 2);
 
-                    yield return kvp[1];
+                    if (kvp.Length == 2) {
+                        yield return kvp[1];
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolves #161. The failures were due to subtleties when working without any `credential.helper` values in any level of config. This is typical for a fresh install on a Linux machine, but never happens with Git for Windows. Git on macOS might also come pre-loaded with this config.