### PR TITLE
CI: update configuration to build native bits

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,8 +28,17 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
 
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+    - name: Build Windows
+      if: contains(matrix.os, 'windows')
+      run: dotnet build --configuration WindowsRelease
+
+    - name: Build Linux
+      if: contains(matrix.os, 'ubuntu')
+      run: dotnet build --configuration LinuxRelease
+
+    - name: Build macOS
+      if: contains(matrix.os, 'macos')
+      run: dotnet build --configuration MacRelease
 
     - name: Test
       run: dotnet test --no-restore --verbosity normal


### PR DESCRIPTION
The build configuration "Release" only builds the managed portions of
GCM Core. However, on macOS and Windows we have UI bits that are native
to each platform. Update the --configuration build option to include
these native bits by casing on the "os" variable in the matrix build.

Resolves #165.