### PR TITLE
Remove username/password authentication for GitHub.com

### DIFF
--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -175,7 +175,7 @@ namespace GitHub.Tests
         public async Task GitHubHostProvider_GetSupportedAuthenticationModes_OverrideInvalid_ReturnsDetectedValue()
         {
             var targetUri = new Uri("https://github.com");
-            var expectedModes = GitHubConstants.DotDomAuthenticationModes;
+            var expectedModes = GitHubConstants.DotComAuthenticationModes;
 
             var context = new TestCommandContext
             {
@@ -205,7 +205,7 @@ namespace GitHub.Tests
         public async Task GitHubHostProvider_GetSupportedAuthenticationModes_OverrideNone_ReturnsDetectedValue()
         {
             var targetUri = new Uri("https://github.com");
-            var expectedModes = GitHubConstants.DotDomAuthenticationModes;
+            var expectedModes = GitHubConstants.DotComAuthenticationModes;
 
             var context = new TestCommandContext
             {
@@ -235,7 +235,7 @@ namespace GitHub.Tests
         public async Task GitHubHostProvider_GetSupportedAuthenticationModes_GitHubDotCom_ReturnsDotComModes()
         {
             var targetUri = new Uri("https://github.com");
-            var expectedModes = GitHubConstants.DotDomAuthenticationModes;
+            var expectedModes = GitHubConstants.DotComAuthenticationModes;
 
             var provider = new GitHubHostProvider(new TestCommandContext());
 

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -33,7 +33,7 @@ namespace GitHub
         /// <summary>
         /// Supported authentication modes for GitHub.com.
         /// </summary>
-        public const AuthenticationModes DotDomAuthenticationModes = AuthenticationModes.OAuth;
+        public const AuthenticationModes DotComAuthenticationModes = AuthenticationModes.OAuth;
 
         public static class TokenScopes
         {

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -33,8 +33,7 @@ namespace GitHub
         /// <summary>
         /// Supported authentication modes for GitHub.com.
         /// </summary>
-        // TODO: remove Basic once the GCM OAuth app is whitelisted and does not require installation in every organization
-        public const AuthenticationModes DotDomAuthenticationModes = AuthenticationModes.Basic | AuthenticationModes.OAuth;
+        public const AuthenticationModes DotDomAuthenticationModes = AuthenticationModes.OAuth;
 
         public static class TokenScopes
         {

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -189,8 +189,8 @@ namespace GitHub
             // GitHub.com should use OAuth authentication only
             if (IsGitHubDotCom(targetUri))
             {
-                Context.Trace.WriteLine($"{targetUri} is github.com - authentication schemes: '{GitHubConstants.DotDomAuthenticationModes}'");
-                return GitHubConstants.DotDomAuthenticationModes;
+                Context.Trace.WriteLine($"{targetUri} is github.com - authentication schemes: '{GitHubConstants.DotComAuthenticationModes}'");
+                return GitHubConstants.DotComAuthenticationModes;
             }
 
             // For GitHub Enterprise we must do some detection of supported modes


### PR DESCRIPTION
Now that we have the GCM OAuth application in the allow-list for GitHub apps, we no longer need to offer username/password authentication for GitHub.com!