### PR TITLE
Fix bug in Git configuration filtering logic

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Git.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Git.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Git.CredentialManager
 
         public IGitConfiguration GetConfiguration(GitConfigurationLevel level)
         {
-            return new GitProcessConfiguration(_trace, this);
+            return new GitProcessConfiguration(_trace, this, level);
         }
 
         public Process CreateProcess(string args)

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -165,6 +165,11 @@ namespace Microsoft.Git.CredentialManager
 
         public void SetValue(string name, string value)
         {
+            if (_filterLevel == GitConfigurationLevel.All)
+            {
+                throw new InvalidOperationException("Must have a specific configuration level filter to modify values.");
+            }
+
             string level = GetLevelFilterArg();
             using (Process git = _git.CreateProcess($"config {level} {name} \"{value}\""))
             {
@@ -184,6 +189,11 @@ namespace Microsoft.Git.CredentialManager
 
         public void Unset(string name)
         {
+            if (_filterLevel == GitConfigurationLevel.All)
+            {
+                throw new InvalidOperationException("Must have a specific configuration level filter to modify values.");
+            }
+
             string level = GetLevelFilterArg();
             using (Process git = _git.CreateProcess($"config {level} --unset {name}"))
             {
@@ -236,6 +246,11 @@ namespace Microsoft.Git.CredentialManager
 
         public void ReplaceAll(string name, string valueRegex, string value)
         {
+            if (_filterLevel == GitConfigurationLevel.All)
+            {
+                throw new InvalidOperationException("Must have a specific configuration level filter to modify values.");
+            }
+
             string level = GetLevelFilterArg();
             using (Process git = _git.CreateProcess($"config {level} --replace-all {name} {value} {valueRegex}"))
             {
@@ -255,6 +270,11 @@ namespace Microsoft.Git.CredentialManager
 
         public void UnsetAll(string name, string valueRegex)
         {
+            if (_filterLevel == GitConfigurationLevel.All)
+            {
+                throw new InvalidOperationException("Must have a specific configuration level filter to modify values.");
+            }
+
             string level = GetLevelFilterArg();
             using (Process git = _git.CreateProcess($"config {level} --unset-all {name} {valueRegex}"))
             {


### PR DESCRIPTION
Ensure the desired GitConfigurationLevel is passed to the
GitConfiguration object so that the correct filter level can be
selected.

This is not so important for reading keys, but will fail when modifying
keys since you need to specific which configuration level to edit.

This bug resulted in calls to `git-credential-manager-core unconfigure`
to fail.

Basically we were calling `git config --unset <key>` without any `--global` or `--system`.