### PR TITLE
Fix bug where Allow Windows Integrated Authentication setting default wrong

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -320,6 +320,115 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_EnvarUnset_ReturnsTrue()
+        {
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_EnvarTruthy_ReturnsTrue()
+        {
+            var envars = new TestEnvironment
+            {
+                Variables = {[Constants.EnvironmentVariables.GcmAllowWia] = "1"}
+            };
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_EnvarFalsey_ReturnsFalse()
+        {
+            var envars = new TestEnvironment
+            {
+                Variables = {[Constants.EnvironmentVariables.GcmAllowWia] = "0"},
+            };
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_EnvarNonBooleanyValue_ReturnsTrue()
+        {
+            var envars = new TestEnvironment
+            {
+                Variables = {[Constants.EnvironmentVariables.GcmAllowWia] = Guid.NewGuid().ToString("N")},
+            };
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_ConfigUnset_ReturnsTrue()
+        {
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_ConfigTruthy_ReturnsTrue()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.AllowWia;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = "1";
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_ConfigFalsey_ReturnsFalse()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.AllowWia;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = "0";
+
+            var settings = new Settings(envars, git);
+
+            Assert.False(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
+        public void Settings_IsWindowsIntegratedAuthenticationEnabled_ConfigNonBooleanyValue_ReturnsTrue()
+        {
+            const string section = Constants.GitConfiguration.Credential.SectionName;
+            const string property = Constants.GitConfiguration.Credential.AllowWia;
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.GlobalConfiguration[$"{section}.{property}"] = Guid.NewGuid().ToString();
+
+            var settings = new Settings(envars, git);
+
+            Assert.True(settings.IsWindowsIntegratedAuthenticationEnabled);
+        }
+
+        [Fact]
         public void Settings_ProxyConfiguration_Unset_ReturnsNull()
         {
             const string remoteUrl = "http://example.com/foo.git";

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Git.CredentialManager
             TryGetSetting(KnownEnvars.GcmAuthority, GitCredCfg.SectionName, GitCredCfg.Authority, out string authority) ? authority : null;
 
         public bool IsWindowsIntegratedAuthenticationEnabled =>
-            TryGetSetting(KnownEnvars.GcmAllowWia, GitCredCfg.SectionName, GitCredCfg.AllowWia, out string value) && value.ToBooleanyOrDefault(true);
+            !TryGetSetting(KnownEnvars.GcmAllowWia, GitCredCfg.SectionName, GitCredCfg.AllowWia, out string value) || value.ToBooleanyOrDefault(true);
 
         public bool IsCertificateVerificationEnabled
         {


### PR DESCRIPTION
Fix a bug where the 'Allow Windows Integrated Authentication' setting was evaluating to `false` when unset, rather than `true` as per design and the documentation.

Fixes #194