### PR TITLE
Split Windows installer in to user/system flavours

### DIFF
--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tools.InnoSetup" Version="5.6.1" />
+    <PackageReference Include="Tools.InnoSetup" Version="6.0.5" />
     <PackageReference Include="MicroBuild.Core" Version="0.2.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -29,7 +29,7 @@
        before we attempt to sign any files or validate they exist. -->
   <Target Name="CreateFilesToSignItems" DependsOnTargets="GetBuildVersion" BeforeTargets="PrepareForRun">
     <ItemGroup>
-      <FilesToSign Include="$(OutDir)gcmcore-win-x86-$(BuildVersion).exe">
+      <FilesToSign Include="$(OutDir)gcmcore*-win-x86-$(BuildVersion).exe">
         <Authenticode>Microsoft400</Authenticode>
         <InProject>false</InProject>
       </FilesToSign>
@@ -47,10 +47,13 @@
 
   <Target Name="CoreCompile" Condition="'$(OSPlatform)'=='windows'">
     <PropertyGroup>
-      <InnoSetupCommand>$(NuGetPackageRoot)Tools.InnoSetup\5.6.1\tools\ISCC.exe /DPayloadDir=$(PayloadPath) Setup.iss /O$(OutputPath)</InnoSetupCommand>
+      <InnoSetupCommandSystem>$(NuGetPackageRoot)Tools.InnoSetup\6.0.5\tools\ISCC.exe /DPayloadDir=$(PayloadPath) /DInstallTarget=system Setup.iss /O$(OutputPath)</InnoSetupCommandSystem>
+      <InnoSetupCommandUser>$(NuGetPackageRoot)Tools.InnoSetup\6.0.5\tools\ISCC.exe /DPayloadDir=$(PayloadPath) /DInstallTarget=user Setup.iss /O$(OutputPath)</InnoSetupCommandUser>
     </PropertyGroup>
-    <Message Text="$(InnoSetupCommand)" Importance="High" />
-    <Exec Command="$(InnoSetupCommand)" />
+    <Message Text="$(InnoSetupCommandSystem)" Importance="High" />
+    <Exec Command="$(InnoSetupCommandSystem)" />
+    <Message Text="$(InnoSetupCommandUser)" Importance="High" />
+    <Exec Command="$(InnoSetupCommandUser)" />
   </Target>
 
   <!-- We don't produce or copy any dependent files for this project -->

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -1,43 +1,63 @@
-; This script requires Inno Setup Compiler 5.6.1 or later to compile
+; This script requires Inno Setup Compiler 6.0.0 or later to compile
 ; The Inno Setup Compiler (and IDE) can be found at http://www.jrsoftware.org/isinfo.php
 ; General documentation on how to use InnoSetup scripts: http://www.jrsoftware.org/ishelp/index.php
 
 ; Ensure minimum Inno Setup tooling version
-#if VER < EncodeVer(5,6,1)
-  #error Update your Inno Setup version (5.6.1 or newer)
+#if VER < EncodeVer(6,0,0)
+  #error Update your Inno Setup version (6.0.0 or newer)
 #endif
 
 #ifndef PayloadDir
   #error Payload directory path property 'PayloadDir' must be specified
 #endif
 
-#ifnexist PayloadDir + "\git-credential-manager-core.exe"
-  #error Payload files are missing
+#ifndef InstallTarget
+  #error Installer target property 'InstallTarget' must be specifed
+#endif
+
+#if InstallTarget == "user"
+  #define GcmAppId "{{aa76d31d-432c-42ee-844c-bc0bc801cef3}}"
+  #define GcmLongName "Git Credential Manager Manager Core (User)"
+  #define GcmSetupExe "gcmcoreuser"
+  #define GcmConfigureCmdArgs "--user"
+#elif InstallTarget == "system"
+  #define GcmAppId "{{fdfae50a-1bc1-4ead-9228-1e1c275e8d12}}"
+  #define GcmLongName "Git Credential Manager Manager Core"
+  #define GcmSetupExe "gcmcore"
+  #define GcmConfigureCmdArgs "--system"
+#else
+  #error Installer target property 'InstallTarget' must be 'user' or 'system'
 #endif
 
 ; Define core properties
-#define GcmName "Git Credential Manager Core"
+#define GcmShortName "Git Credential Manager Core"
 #define GcmPublisher "Microsoft Corporation"
 #define GcmPublisherUrl "https://www.microsoft.com"
-#define GcmCopyright "Copyright (c) Microsoft 2019"
-#define GcmUrl "https://github.com/microsoft/Git-Credential-Manager-Core"
+#define GcmCopyright "Copyright (c) Microsoft 2020"
+#define GcmUrl "https://aka.ms/gcmcore"
 #define GcmReadme "https://github.com/microsoft/Git-Credential-Manager-Core/blob/master/README.md"
 #define GcmRepoRoot "..\..\.."
 #define GcmAssets GcmRepoRoot + "\assets"
+#define GcmExe "git-credential-manager-core.exe"
+#define GcmArch "x86"
+
+#ifnexist PayloadDir + "\" + GcmExe
+  #error Payload files are missing
+#endif
 
 ; Generate the GCM version version from the CLI executable
 #define VerMajor
 #define VerMinor
 #define VerBuild
 #define VerRevision
-#expr ParseVersion(PayloadDir + "\git-credential-manager-core.exe", VerMajor, VerMinor, VerBuild, VerRevision)
+#expr ParseVersion(PayloadDir + "\" + GcmExe, VerMajor, VerMinor, VerBuild, VerRevision)
 #define GcmVersion str(VerMajor) + "." + str(VerMinor) + "." + str(VerBuild) + "." + str(VerRevision)
 
 [Setup]
-AppId={{fdfae50a-1bc1-4ead-9228-1e1c275e8d12}}
-AppName={#GcmName}
+AppId={#GcmAppId}
+AppName={#GcmLongName}
 AppVersion={#GcmVersion}
-AppVerName={#GcmName} {#GcmVersion}
+AppVerName={#GcmLongName} {#GcmVersion}
 AppPublisher={#GcmPublisher}
 AppPublisherURL={#GcmPublisherUrl}
 AppSupportURL={#GcmUrl}
@@ -47,13 +67,13 @@ AppCopyright={#GcmCopyright}
 AppReadmeFile={#GcmReadme}
 VersionInfoVersion={#GcmVersion}
 LicenseFile={#GcmRepoRoot}\LICENSE
-OutputBaseFilename=gcmcore-win-x86-{#GcmVersion}
-DefaultDirName={pf}\{#GcmName}
+OutputBaseFilename={#GcmSetupExe}-win-{#GcmArch}-{#GcmVersion}
+DefaultDirName={autopf}\{#GcmShortName}
 Compression=lzma2
 SolidCompression=yes
 MinVersion=6.1.7600
 DisableDirPage=yes
-UninstallDisplayIcon={app}\git-credential-manager-core.exe
+UninstallDisplayIcon={app}\{#GcmExe}
 SetupIconFile={#GcmAssets}\gcmicon.ico
 WizardImageFile={#GcmAssets}\gcmicon128.bmp
 WizardSmallImageFile={#GcmAssets}\gcmicon64.bmp
@@ -61,6 +81,9 @@ WizardStyle=modern
 WizardImageStretch=no
 WindowResizable=no
 ChangesEnvironment=yes
+#if InstallTarget == "user"
+  PrivilegesRequired=lowest
+#endif
 
 [Languages]
 Name: english; MessagesFile: "compiler:Default.isl";
@@ -72,10 +95,10 @@ Name: full; Description: "Full installation"; Flags: iscustom;
 ; No individual components
 
 [Run]
-Filename: "{app}\git-credential-manager-core.exe"; Parameters: "configure"; Flags: runhidden
+Filename: "{app}\{#GcmExe}"; Parameters: "configure {#GcmConfigureCmdArgs}"; Flags: runhidden
 
 [UninstallRun]
-Filename: "{app}\git-credential-manager-core.exe"; Parameters: "unconfigure"; Flags: runhidden
+Filename: "{app}\{#GcmExe}"; Parameters: "unconfigure {#GcmConfigureCmdArgs}"; Flags: runhidden
 
 [Files]
 Source: "{#PayloadDir}\Atlassian.Bitbucket.dll";                       DestDir: "{app}"; Flags: ignoreversion
@@ -95,3 +118,18 @@ Source: "{#PayloadDir}\Microsoft.IdentityModel.JsonWebTokens.dll";     DestDir: 
 Source: "{#PayloadDir}\Microsoft.IdentityModel.Logging.dll";           DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.IdentityModel.Tokens.dll";            DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Newtonsoft.Json.dll";                           DestDir: "{app}"; Flags: ignoreversion
+
+[Code]
+// Don't allow installing conflicting architectures
+function InitializeSetup(): Boolean;
+begin
+  Result := True;
+
+  #if InstallTarget == "user"
+    if not WizardSilent() and IsAdmin() then begin
+      if MsgBox('This User Installer is not meant to be run as an Administrator. If you would like to install Git Credential Manager Core for all users in this system, download the System Installer instead from https://aka.ms/gcmcore-latest. Are you sure you want to continue?', mbError, MB_OKCANCEL) = IDCANCEL then begin
+        Result := False;
+      end;
+    end;
+  #endif
+end;


### PR DESCRIPTION
Split the Windows installer into two versions: a single-user installer, and a system-wide installer.

The old installer installed in Program Files (x86) and set the system Git configuration, which is now what the system-flavoured installer does.

The new single-user installer places files in %LOCALAPPDATA% and updates the ~/.gitconfig (global) user Git configuration instead.

The benefit of the single-user installer is that it does not require an administrator to install it, and doesn't affect other users of the system.

There will now be two installers for Windows: `gcmcore-win....` and `gcmcoreuser-win....`. This is the same as VS Code.