### PR TITLE
Update the configure command to set the full path to GCM Core

### DIFF
--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -179,18 +179,15 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public async Task AzureReposHostProvider_ConfigureAsync_UseHttpPathSetTrue_DoesNothing()
         {
-            var provider = new AzureReposHostProvider(new TestCommandContext());
+            var context = new TestCommandContext();
+            var provider = new AzureReposHostProvider(context);
 
-            var environment = new TestEnvironment();
-            var git = new TestGit();
-            git.GlobalConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"true"};
+            context.Git.GlobalConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"true"};
 
-            await provider.ConfigureAsync(
-                environment, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
+            await provider.ConfigureAsync(ConfigurationTarget.User);
 
-            Assert.Single(git.GlobalConfiguration.Dictionary);
-            Assert.True(git.GlobalConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out IList<string> actualValues));
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out IList<string> actualValues));
             Assert.Single(actualValues);
             Assert.Equal("true", actualValues[0]);
         }
@@ -198,18 +195,15 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public async Task AzureReposHostProvider_ConfigureAsync_UseHttpPathSetFalse_SetsUseHttpPathTrue()
         {
-            var provider = new AzureReposHostProvider(new TestCommandContext());
+            var context = new TestCommandContext();
+            var provider = new AzureReposHostProvider(context);
 
-            var environment = new TestEnvironment();
-            var git = new TestGit();
-            git.GlobalConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"false"};
+            context.Git.GlobalConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"false"};
 
-            await provider.ConfigureAsync(
-                environment, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
+            await provider.ConfigureAsync(ConfigurationTarget.User);
 
-            Assert.Single(git.GlobalConfiguration.Dictionary);
-            Assert.True(git.GlobalConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out IList<string> actualValues));
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out IList<string> actualValues));
             Assert.Single(actualValues);
             Assert.Equal("true", actualValues[0]);
         }
@@ -217,17 +211,13 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public async Task AzureReposHostProvider_ConfigureAsync_UseHttpPathUnset_SetsUseHttpPathTrue()
         {
-            var provider = new AzureReposHostProvider(new TestCommandContext());
+            var context = new TestCommandContext();
+            var provider = new AzureReposHostProvider(context);
 
-            var environment = new TestEnvironment();
-            var git = new TestGit();
+            await provider.ConfigureAsync(ConfigurationTarget.User);
 
-            await provider.ConfigureAsync(
-                environment, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
-
-            Assert.Single(git.GlobalConfiguration.Dictionary);
-            Assert.True(git.GlobalConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out IList<string> actualValues));
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out IList<string> actualValues));
             Assert.Single(actualValues);
             Assert.Equal("true", actualValues[0]);
         }
@@ -236,17 +226,14 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public async Task AzureReposHostProvider_UnconfigureAsync_UseHttpPathSet_RemovesEntry()
         {
-            var provider = new AzureReposHostProvider(new TestCommandContext());
+            var context = new TestCommandContext();
+            var provider = new AzureReposHostProvider(context);
 
-            var environment = new TestEnvironment();
-            var git = new TestGit();
-            git.GlobalConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"true"};
+            context.Git.GlobalConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"true"};
 
-            await provider.UnconfigureAsync(
-                environment, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
+            await provider.UnconfigureAsync(ConfigurationTarget.User);
 
-            Assert.Empty(git.GlobalConfiguration.Dictionary);
+            Assert.Empty(context.Git.GlobalConfiguration.Dictionary);
         }
     }
 }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -250,13 +250,15 @@ namespace Microsoft.AzureRepos
 
         string IConfigurableComponent.Name => "Azure Repos provider";
 
-        public Task ConfigureAsync(
-            IEnvironment environment, EnvironmentVariableTarget environmentTarget,
-            IGit git, GitConfigurationLevel configurationLevel)
+        public Task ConfigureAsync(ConfigurationTarget target)
         {
             string useHttpPathKey = $"{KnownGitCfg.Credential.SectionName}.https://dev.azure.com.{KnownGitCfg.Credential.UseHttpPath}";
 
-            IGitConfiguration targetConfig = git.GetConfiguration(configurationLevel);
+            GitConfigurationLevel configurationLevel = target == ConfigurationTarget.System
+                ? GitConfigurationLevel.System
+                : GitConfigurationLevel.Global;
+
+            IGitConfiguration targetConfig = _context.Git.GetConfiguration(configurationLevel);
 
             if (targetConfig.TryGetValue(useHttpPathKey, out string currentValue) && currentValue.IsTruthy())
             {
@@ -271,15 +273,17 @@ namespace Microsoft.AzureRepos
             return Task.CompletedTask;
         }
 
-        public Task UnconfigureAsync(
-            IEnvironment environment, EnvironmentVariableTarget environmentTarget,
-            IGit git, GitConfigurationLevel configurationLevel)
+        public Task UnconfigureAsync(ConfigurationTarget target)
         {
             string useHttpPathKey = $"{KnownGitCfg.Credential.SectionName}.https://dev.azure.com.{KnownGitCfg.Credential.UseHttpPath}";
 
             _context.Trace.WriteLine("Clearing Git configuration 'credential.useHttpPath' for https://dev.azure.com...");
 
-            IGitConfiguration targetConfig = git.GetConfiguration(configurationLevel);
+            GitConfigurationLevel configurationLevel = target == ConfigurationTarget.System
+                ? GitConfigurationLevel.System
+                : GitConfigurationLevel.Global;
+
+            IGitConfiguration targetConfig = _context.Git.GetConfiguration(configurationLevel);
             targetConfig.Unset(useHttpPathKey);
 
             return Task.CompletedTask;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
@@ -1,217 +1,277 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Tests.Objects;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests
 {
     public class ApplicationTests
     {
-        #region Common configuration tests
-
         [Fact]
-        public async Task Application_ConfigureAsync_HelperSet_DoesNothing()
+        public async Task Application_ConfigureAsync_NoHelpers_AddsEmptyAndGcm()
         {
             const string emptyHelper = "";
-            const string gcmConfigName = "manager-core";
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+            await application.ConfigureAsync(ConfigurationTarget.User);
 
-            var environment = new Mock<IEnvironment>();
-
-            var git = new TestGit();
-            git.GlobalConfiguration.Dictionary[key] = new List<string>
-            {
-                emptyHelper, gcmConfigName
-            };
-
-            await application.ConfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
-
-            Assert.Single(git.GlobalConfiguration.Dictionary);
-            Assert.True(git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
             Assert.Equal(2, actualValues.Count);
             Assert.Equal(emptyHelper, actualValues[0]);
-            Assert.Equal(gcmConfigName, actualValues[1]);
+            Assert.Equal(executablePath, actualValues[1]);
         }
 
         [Fact]
-        public async Task Application_ConfigureAsync_HelperSetWithOthersPreceding_DoesNothing()
+        public async Task Application_ConfigureAsync_Gcm_AddsEmptyBeforeGcm()
         {
             const string emptyHelper = "";
-            const string gcmConfigName = "manager-core";
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
 
-            var environment = new Mock<IEnvironment>();
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string> {executablePath};
 
-            var git = new TestGit();
-            git.GlobalConfiguration.Dictionary[key] = new List<string>
+            await application.ConfigureAsync(ConfigurationTarget.User);
+
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Equal(2, actualValues.Count);
+            Assert.Equal(emptyHelper, actualValues[0]);
+            Assert.Equal(executablePath, actualValues[1]);
+        }
+
+        [Fact]
+        public async Task Application_ConfigureAsync_EmptyAndGcm_DoesNothing()
+        {
+            const string emptyHelper = "";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
             {
-                "foo", "bar", emptyHelper, gcmConfigName
+                emptyHelper, executablePath
             };
 
-            await application.ConfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
+            await application.ConfigureAsync(ConfigurationTarget.User);
 
-            Assert.Single(git.GlobalConfiguration.Dictionary);
-            Assert.True(git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Equal(2, actualValues.Count);
+            Assert.Equal(emptyHelper, actualValues[0]);
+            Assert.Equal(executablePath, actualValues[1]);
+        }
+
+        [Fact]
+        public async Task Application_ConfigureAsync_EmptyAndGcmWithOthersBefore_DoesNothing()
+        {
+            const string emptyHelper = "";
+            const string beforeHelper = "foo";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
+            {
+                beforeHelper, emptyHelper, executablePath
+            };
+
+            await application.ConfigureAsync(ConfigurationTarget.User);
+
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Equal(3, actualValues.Count);
+            Assert.Equal(beforeHelper, actualValues[0]);
+            Assert.Equal(emptyHelper, actualValues[1]);
+            Assert.Equal(executablePath, actualValues[2]);
+        }
+
+        [Fact]
+        public async Task Application_ConfigureAsync_EmptyAndGcmWithOthersAfter_DoesNothing()
+        {
+            const string emptyHelper = "";
+            const string afterHelper = "foo";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
+            {
+                emptyHelper, executablePath, afterHelper
+            };
+
+            await application.ConfigureAsync(ConfigurationTarget.User);
+
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Equal(3, actualValues.Count);
+            Assert.Equal(emptyHelper, actualValues[0]);
+            Assert.Equal(executablePath, actualValues[1]);
+            Assert.Equal(afterHelper, actualValues[2]);
+        }
+
+        [Fact]
+        public async Task Application_ConfigureAsync_EmptyAndGcmWithOthersBeforeAndAfter_DoesNothing()
+        {
+            const string emptyHelper = "";
+            const string beforeHelper = "foo";
+            const string afterHelper = "bar";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
+            {
+                beforeHelper, emptyHelper, executablePath, afterHelper
+            };
+
+            await application.ConfigureAsync(ConfigurationTarget.User);
+
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
             Assert.Equal(4, actualValues.Count);
-            Assert.Equal("foo", actualValues[0]);
-            Assert.Equal("bar", actualValues[1]);
-            Assert.Equal(emptyHelper, actualValues[2]);
-            Assert.Equal(gcmConfigName, actualValues[3]);
+            Assert.Equal(beforeHelper, actualValues[0]);
+            Assert.Equal(emptyHelper, actualValues[1]);
+            Assert.Equal(executablePath, actualValues[2]);
+            Assert.Equal(afterHelper, actualValues[3]);
         }
 
         [Fact]
-        public async Task Application_ConfigureAsync_HelperSetWithOthersFollowing_ClearsEntriesSetsHelper()
+        public async Task Application_UnconfigureAsync_NoHelpers_DoesNothing()
         {
-            const string emptyHelper = "";
-            const string gcmConfigName = "manager-core";
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+            await application.UnconfigureAsync(ConfigurationTarget.User);
 
-            var environment = new Mock<IEnvironment>();
+            Assert.Empty(context.Git.GlobalConfiguration.Dictionary);
+        }
 
-            var git = new TestGit();
-            git.GlobalConfiguration.Dictionary[key] = new List<string>
+        [Fact]
+        public async Task Application_UnconfigureAsync_Gcm_RemovesGcm()
+        {
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string> {executablePath};
+
+            await application.UnconfigureAsync(ConfigurationTarget.User);
+
+            Assert.Empty(context.Git.GlobalConfiguration.Dictionary);
+        }
+
+        [Fact]
+        public async Task Application_UnconfigureAsync_EmptyAndGcm_RemovesEmptyAndGcm()
+        {
+            const string emptyHelper = "";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string> {emptyHelper, executablePath};
+
+            await application.UnconfigureAsync(ConfigurationTarget.User);
+
+            Assert.Empty(context.Git.GlobalConfiguration.Dictionary);
+        }
+
+        [Fact]
+        public async Task Application_UnconfigureAsync_EmptyAndGcmWithOthersBefore_RemovesEmptyAndGcm()
+        {
+            const string emptyHelper = "";
+            const string beforeHelper = "foo";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
             {
-                "bar", emptyHelper, executablePath, "foo"
+                beforeHelper, emptyHelper, executablePath
             };
 
-            await application.ConfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
+            await application.UnconfigureAsync(ConfigurationTarget.User);
 
-            Assert.Single(git.GlobalConfiguration.Dictionary);
-            Assert.True(git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
-            Assert.Equal(2, actualValues.Count);
-            Assert.Equal(emptyHelper, actualValues[0]);
-            Assert.Equal(gcmConfigName, actualValues[1]);
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Equal(1, actualValues.Count);
+            Assert.Equal(beforeHelper, actualValues[0]);
         }
 
         [Fact]
-        public async Task Application_ConfigureAsync_HelperNotSet_SetsHelper()
+        public async Task Application_UnconfigureAsync_EmptyAndGcmWithOthersAfterBefore_RemovesGcmOnly()
         {
             const string emptyHelper = "";
-            const string gcmConfigName = "manager-core";
+            const string afterHelper = "bar";
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
 
-            var environment = new Mock<IEnvironment>();
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
+            {
+                emptyHelper, executablePath, afterHelper
+            };
 
-            var git = new TestGit();
+            await application.UnconfigureAsync(ConfigurationTarget.User);
 
-            await application.ConfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
-
-            Assert.Single(git.GlobalConfiguration.Dictionary);
-            Assert.True(git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
             Assert.Equal(2, actualValues.Count);
             Assert.Equal(emptyHelper, actualValues[0]);
-            Assert.Equal(gcmConfigName, actualValues[1]);
+            Assert.Equal(afterHelper, actualValues[1]);
         }
 
         [Fact]
-        public async Task Application_UnconfigureAsync_HelperSet_RemovesEntries()
+        public async Task Application_UnconfigureAsync_EmptyAndGcmWithOthersBeforeAndAfter_RemovesGcmOnly()
         {
             const string emptyHelper = "";
-            const string gcmConfigName = "manager-core";
+            const string beforeHelper = "foo";
+            const string afterHelper = "bar";
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
 
-            var environment = new Mock<IEnvironment>();
-            var git = new TestGit();
-            git.GlobalConfiguration.Dictionary[key] = new List<string> {emptyHelper, gcmConfigName};
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
+            {
+                beforeHelper, emptyHelper, executablePath, afterHelper
+            };
 
-            await application.UnconfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
+            await application.UnconfigureAsync(ConfigurationTarget.User);
 
-            Assert.Empty(git.GlobalConfiguration.Dictionary);
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Equal(3, actualValues.Count);
+            Assert.Equal(beforeHelper, actualValues[0]);
+            Assert.Equal(emptyHelper, actualValues[1]);
+            Assert.Equal(afterHelper, actualValues[2]);
         }
-
-        #endregion
-
-        #region Windows-specific configuration tests
-
-        [PlatformFact(Platforms.Windows)]
-        public async Task Application_ConfigureAsync_User_PathSet_DoesNothing()
-        {
-            const string directoryPath = @"X:\Install Location";
-            const string executablePath = @"X:\Install Location\git-credential-manager-core.exe";
-
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
-
-            var environment = new Mock<IEnvironment>();
-            environment.Setup(x => x.IsDirectoryOnPath(directoryPath)).Returns(true);
-
-            var git = new TestGit();
-
-            await application.ConfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
-
-            environment.Verify(x => x.AddDirectoryToPath(It.IsAny<string>(), It.IsAny<EnvironmentVariableTarget>()), Times.Never);
-        }
-
-        [PlatformFact(Platforms.Windows)]
-        public async Task Application_ConfigureAsync_User_PathNotSet_SetsUserPath()
-        {
-            const string directoryPath = @"X:\Install Location";
-            const string executablePath = @"X:\Install Location\git-credential-manager-core.exe";
-
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
-
-            var environment = new Mock<IEnvironment>();
-            environment.Setup(x => x.IsDirectoryOnPath(directoryPath)).Returns(false);
-
-            var git = new TestGit();
-
-            await application.ConfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
-
-            environment.Verify(x => x.AddDirectoryToPath(directoryPath, EnvironmentVariableTarget.User), Times.Once);
-        }
-
-        [PlatformFact(Platforms.Windows)]
-        public async Task Application_UnconfigureAsync_User_PathSet_RemovesFromUserPath()
-        {
-            const string directoryPath = @"X:\Install Location";
-            const string executablePath = @"X:\Install Location\git-credential-manager-core.exe";
-
-            IConfigurableComponent application = new Application(new TestCommandContext(), executablePath);
-
-            var environment = new Mock<IEnvironment>();
-            environment.Setup(x => x.IsDirectoryOnPath(directoryPath)).Returns(true);
-
-            var git = new TestGit();
-
-            await application.UnconfigureAsync(
-                environment.Object, EnvironmentVariableTarget.User,
-                git, GitConfigurationLevel.Global);
-
-            environment.Verify(x => x.RemoveDirectoryFromPath(directoryPath, EnvironmentVariableTarget.User), Times.Once);
-        }
-
-        #endregion
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/ConfigurationServiceTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/ConfigurationServiceTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Tests.Objects;
 using Moq;
@@ -26,17 +25,11 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             await service.ConfigureAsync(ConfigurationTarget.System);
 
-            component1.Verify(x => x.ConfigureAsync(
-                context.Environment, EnvironmentVariableTarget.Machine,
-                context.Git, GitConfigurationLevel.System),
+            component1.Verify(x => x.ConfigureAsync(ConfigurationTarget.System),
                 Times.Once);
-            component2.Verify(x => x.ConfigureAsync(
-                context.Environment, EnvironmentVariableTarget.Machine,
-                context.Git, GitConfigurationLevel.System),
+            component2.Verify(x => x.ConfigureAsync(ConfigurationTarget.System),
                 Times.Once);
-            component3.Verify(x => x.ConfigureAsync(
-                context.Environment, EnvironmentVariableTarget.Machine,
-                context.Git, GitConfigurationLevel.System),
+            component3.Verify(x => x.ConfigureAsync(ConfigurationTarget.System),
                 Times.Once);
         }
 
@@ -56,17 +49,11 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             await service.ConfigureAsync(ConfigurationTarget.User);
 
-            component1.Verify(x => x.ConfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.User,
-                    context.Git, GitConfigurationLevel.Global),
+            component1.Verify(x => x.ConfigureAsync(ConfigurationTarget.User),
                 Times.Once);
-            component2.Verify(x => x.ConfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.User,
-                    context.Git, GitConfigurationLevel.Global),
+            component2.Verify(x => x.ConfigureAsync(ConfigurationTarget.User),
                 Times.Once);
-            component3.Verify(x => x.ConfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.User,
-                    context.Git, GitConfigurationLevel.Global),
+            component3.Verify(x => x.ConfigureAsync(ConfigurationTarget.User),
                 Times.Once);
         }
 
@@ -86,17 +73,11 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             await service.UnconfigureAsync(ConfigurationTarget.System);
 
-            component1.Verify(x => x.UnconfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.Machine,
-                    context.Git, GitConfigurationLevel.System),
+            component1.Verify(x => x.UnconfigureAsync(ConfigurationTarget.System),
                 Times.Once);
-            component2.Verify(x => x.UnconfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.Machine,
-                    context.Git, GitConfigurationLevel.System),
+            component2.Verify(x => x.UnconfigureAsync(ConfigurationTarget.System),
                 Times.Once);
-            component3.Verify(x => x.UnconfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.Machine,
-                    context.Git, GitConfigurationLevel.System),
+            component3.Verify(x => x.UnconfigureAsync(ConfigurationTarget.System),
                 Times.Once);
         }
 
@@ -116,17 +97,11 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             await service.UnconfigureAsync(ConfigurationTarget.User);
 
-            component1.Verify(x => x.UnconfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.User,
-                    context.Git, GitConfigurationLevel.Global),
+            component1.Verify(x => x.UnconfigureAsync(ConfigurationTarget.User),
                 Times.Once);
-            component2.Verify(x => x.UnconfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.User,
-                    context.Git, GitConfigurationLevel.Global),
+            component2.Verify(x => x.UnconfigureAsync(ConfigurationTarget.User),
                 Times.Once);
-            component3.Verify(x => x.UnconfigureAsync(
-                    context.Environment, EnvironmentVariableTarget.User,
-                    context.Git, GitConfigurationLevel.Global),
+            component3.Verify(x => x.UnconfigureAsync(ConfigurationTarget.User),
                 Times.Once);
         }
     }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
@@ -11,6 +11,39 @@ namespace Microsoft.Git.CredentialManager.Tests
 {
     public class GitConfigurationTests
     {
+        [Theory]
+        [InlineData(null, "\"\"")]
+        [InlineData("", "\"\"")]
+        [InlineData("hello", "hello")]
+        [InlineData("hello world", "\"hello world\"")]
+        [InlineData("C:\\app.exe", "C:\\app.exe")]
+        [InlineData("C:\\path with space\\app.exe", "\"C:\\path with space\\app.exe\"")]
+        [InlineData("''", "\"''\"")]
+        [InlineData("'hello'", "\"'hello'\"")]
+        [InlineData("'hello world'", "\"'hello world'\"")]
+        [InlineData("'C:\\app.exe'", "\"'C:\\app.exe'\"")]
+        [InlineData("'C:\\path with space\\app.exe'", "\"'C:\\path with space\\app.exe'\"")]
+        [InlineData("\"\"", "\"\\\"\\\"\"")]
+        [InlineData("\"hello\"", "\"\\\"hello\\\"\"")]
+        [InlineData("\"hello world\"", "\"\\\"hello world\\\"\"")]
+        [InlineData("\"C:\\app.exe\"", "\"\\\"C:\\app.exe\\\"\"")]
+        [InlineData("\"C:\\path with space\\app.exe\"", "\"\\\"C:\\path with space\\app.exe\\\"\"")]
+        [InlineData("\\", "\\")]
+        [InlineData("\\\\", "\\\\")]
+        [InlineData("\\\\\\", "\\\\\\")]
+        [InlineData("\"", "\"\\\"\"")]
+        [InlineData("\\\"", "\"\\\\\\\"\"")]
+        [InlineData("\\\\\"", "\"\\\\\\\\\\\"\"")]
+        [InlineData("\"\\", "\"\\\"\\\\\"")]
+        [InlineData("\"\\\\", "\"\\\"\\\\\\\\\"")]
+        [InlineData("ab\\", "ab\\")]
+        [InlineData("a b\\", "\"a b\\\\\"")]
+        public void GitConfiguration_QuoteCmdArg(string input, string expected)
+        {
+            string actual = GitProcessConfiguration.QuoteCmdArg(input);
+            Assert.Equal(expected, actual);
+        }
+
         [Fact]
         public void GitProcess_GetConfiguration_ReturnsConfiguration()
         {

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Commands;
@@ -141,90 +142,128 @@ namespace Microsoft.Git.CredentialManager
 
         string IConfigurableComponent.Name => "Git Credential Manager";
 
-        Task IConfigurableComponent.ConfigureAsync(
-            IEnvironment environment, EnvironmentVariableTarget environmentTarget,
-            IGit git, GitConfigurationLevel configurationLevel)
+        Task IConfigurableComponent.ConfigureAsync(ConfigurationTarget target)
         {
-            // NOTE: We currently only update the PATH in Windows installations and leave putting the GCM executable
-            //       on the PATH on other platform to their installers.
-            if (PlatformUtils.IsWindows())
-            {
-                string directoryPath = Path.GetDirectoryName(_appPath);
-                if (!environment.IsDirectoryOnPath(directoryPath))
-                {
-                    Context.Trace.WriteLine("Adding application to PATH...");
-                    environment.AddDirectoryToPath(directoryPath, environmentTarget);
-                }
-                else
-                {
-                    Context.Trace.WriteLine("Application is already on the PATH.");
-                }
-            }
-
             string helperKey = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
-            string gitConfigAppName = GetGitConfigAppName();
+            string appPath = GetGitConfigAppPath();
 
-            IGitConfiguration targetConfig = git.GetConfiguration(configurationLevel);
-
-            /*
-             * We are looking for the following to be considered already set:
-             *
-             * [credential]
-             *     ...                         # any number of helper entries
-             *     helper =                    # an empty value to reset/clear any previous entries
-             *     helper = {gitConfigAppName} # the expected executable value in the last position & directly following the empty value
-             *
-             */
-
-            string[] currentValues = targetConfig.GetRegex(helperKey, Constants.RegexPatterns.Any).ToArray();
-            if (currentValues.Length < 2 ||
-                !string.IsNullOrWhiteSpace(currentValues[currentValues.Length - 2]) ||    // second to last entry is empty
-                currentValues[currentValues.Length - 1] != gitConfigAppName)              // last entry is the expected executable
+            IGitConfiguration config;
+            switch (target)
             {
-                Context.Trace.WriteLine("Updating Git credential helper configuration...");
+                case ConfigurationTarget.User:
+                    // For per-user configuration, we are looking for the following to be set in the global config:
+                    //
+                    // [credential]
+                    //     ...                 # any number of helper entries (possibly none)
+                    //     helper =            # an empty value to reset/clear any previous entries (if applicable)
+                    //     helper = {appPath} # the expected executable value & directly following the empty value
+                    //     ...                 # any number of helper entries (possibly none)
+                    //
+                    config = Context.Git.GetConfiguration(GitConfigurationLevel.Global);
+                    string[] currentValues = config.GetRegex(helperKey, Constants.RegexPatterns.Any).ToArray();
 
-                // Clear any existing entries in the configuration.
-                targetConfig.UnsetAll(helperKey, Constants.RegexPatterns.Any);
+                    // Try to locate an existing app entry with a blank reset/clear entry immediately preceding
+                    int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
+                    if (appIndex > 0 && string.IsNullOrWhiteSpace(currentValues[appIndex - 1]))
+                    {
+                        Context.Trace.WriteLine("Credential helper user configuration is already set correctly.");
+                    }
+                    else
+                    {
+                        Context.Trace.WriteLine("Updating Git credential helper user configuration...");
 
-                // Add an empty value for `credential.helper`, which has the effect of clearing any helper value
-                // from any lower-level Git configuration, then add a second value which is the actual executable path.
-                targetConfig.SetValue(helperKey, string.Empty);
-                targetConfig.ReplaceAll(helperKey, Constants.RegexPatterns.None, gitConfigAppName);
+                        // Clear any existing app entries in the configuration
+                        config.UnsetAll(helperKey, Regex.Escape(appPath));
+
+                        // Add an empty value for `credential.helper`, which has the effect of clearing any helper value
+                        // from any lower-level Git configuration, then add a second value which is the actual executable path.
+                        config.ReplaceAll(helperKey, Constants.RegexPatterns.None, string.Empty);
+                        config.ReplaceAll(helperKey, Constants.RegexPatterns.None, appPath);
+                    }
+                    break;
+
+                case ConfigurationTarget.System:
+                    // For machine-wide configuration, we are looking for the following to be set in the system config:
+                    //
+                    // [credential]
+                    //     helper = {appPath}
+                    //
+                    config = Context.Git.GetConfiguration(GitConfigurationLevel.System);
+                    string currentValue = config.GetValue(helperKey);
+                    if (Context.FileSystem.IsSamePath(currentValue, appPath))
+                    {
+                        Context.Trace.WriteLine("Credential helper system configuration is already set correctly.");
+                    }
+                    else
+                    {
+                        Context.Trace.WriteLine("Updating Git credential helper system configuration...");
+                        config.SetValue(helperKey, appPath);
+                    }
+
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(target), target, "Unknown configuration target.");
             }
-            else
-            {
-                Context.Trace.WriteLine("Credential helper configuration is already set correctly.");
-            }
-
 
             return Task.CompletedTask;
         }
 
-        Task IConfigurableComponent.UnconfigureAsync(
-            IEnvironment environment, EnvironmentVariableTarget environmentTarget,
-            IGit git, GitConfigurationLevel configurationLevel)
+        Task IConfigurableComponent.UnconfigureAsync(ConfigurationTarget target)
         {
             string helperKey = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
-            string gitConfigAppName = GetGitConfigAppName();
+            string appPath = GetGitConfigAppPath();
 
-            IGitConfiguration targetConfig = git.GetConfiguration(configurationLevel);
-
-            Context.Trace.WriteLine("Removing Git credential helper configuration...");
-
-            // Clear any blank 'reset' entries
-            targetConfig.UnsetAll(helperKey, Constants.RegexPatterns.Empty);
-
-            // Clear GCM executable entries
-            targetConfig.UnsetAll(helperKey, Regex.Escape(gitConfigAppName));
-
-            // NOTE: We currently only update the PATH in Windows installations and leave removing the GCM executable
-            //       on the PATH on other platform to their installers.
-            // Remove GCM executable from the PATH
-            if (PlatformUtils.IsWindows())
+            IGitConfiguration config;
+            switch (target)
             {
-                Context.Trace.WriteLine("Removing application from the PATH...");
-                string directoryPath = Path.GetDirectoryName(_appPath);
-                environment.RemoveDirectoryFromPath(directoryPath, environmentTarget);
+                case ConfigurationTarget.User:
+                    // For per-user configuration, we are looking for the following to be set in the global config:
+                    //
+                    // [credential]
+                    //     ...                 # any number of helper entries (possibly none)
+                    //     helper =            # an empty value to reset/clear any previous entries (if applicable)
+                    //     helper = {appPath} # the expected executable value & directly following the empty value
+                    //     ...                 # any number of helper entries (possibly none)
+                    //
+                    // We should remove the {appPath} entry, and any blank entries immediately preceding IFF there are no more entries following.
+                    //
+                    Context.Trace.WriteLine("Removing Git credential helper user configuration...");
+
+                    config = Context.Git.GetConfiguration(GitConfigurationLevel.Global);
+                    string[] currentValues = config.GetRegex(helperKey, Constants.RegexPatterns.Any).ToArray();
+
+                    int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
+                    if (appIndex > -1)
+                    {
+                        // Check for the presence of a blank entry immediately preceding an app entry in the last position
+                        if (appIndex > 0 && appIndex == currentValues.Length - 1 &&
+                            string.IsNullOrWhiteSpace(currentValues[appIndex - 1]))
+                        {
+                            // Clear the blank entry
+                            config.UnsetAll(helperKey, Constants.RegexPatterns.Empty);
+                        }
+
+                        // Clear app entry
+                        config.UnsetAll(helperKey, Regex.Escape(appPath));
+                    }
+                    break;
+
+                case ConfigurationTarget.System:
+                    // For machine-wide configuration, we are looking for the following to be set in the system config:
+                    //
+                    // [credential]
+                    //     helper = {appPath}
+                    //
+                    // We should remove the {appPath} entry if it exists.
+                    //
+                    Context.Trace.WriteLine("Removing Git credential helper system configuration...");
+                    config = Context.Git.GetConfiguration(GitConfigurationLevel.System);
+                    config.UnsetAll(helperKey, Regex.Escape(appPath));
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(target), target, "Unknown configuration target.");
             }
 
             return Task.CompletedTask;
@@ -241,6 +280,23 @@ namespace Microsoft.Git.CredentialManager
             }
 
             return _appPath;
+        }
+
+        private string GetGitConfigAppPath()
+        {
+            string path = _appPath;
+
+            // On Windows we must use UNIX style path separators
+            if (PlatformUtils.IsWindows())
+            {
+                path = path.Replace('\\', '/');
+            }
+
+            // We must escape escape characters like ' ', '(', and ')'
+            return path
+                .Replace(" ", "\\ ")
+                .Replace("(", "\\(")
+                .Replace(")", "\\)");;
         }
 
         #endregion


### PR DESCRIPTION
Update the configure and unconfigure actions to now set the full file path to GCM Core, rather than rely on `manager-core` resolving to `git-credential-manager-core` on the PATH by Git.

This was a problem because Git for Windows now bundles GCM Core, and even if a standalone install of GCM Core was present on the system with a higher version, since the bundled copy is found on the PATH before anything else, Git was always picking the old one.

The change to using full paths helps fix this issue, and also another issue on macOS where sometimes the /usr/local/bin directory is not on the PATH (such as for the root user, or during a postinstall script for a flat-package [.pkg] file).