### PR TITLE
Setup Microsoft ESRP Signing for .deb installer

### DIFF
--- a/.github/run_esrp_signing.py
+++ b/.github/run_esrp_signing.py
@@ -1,0 +1,112 @@
+import json
+import os
+import glob
+import pprint
+import subprocess
+import sys
+
+esrp_tool = os.path.join("esrp", "tools", "EsrpClient.exe")
+
+aad_id = os.environ['AZURE_AAD_ID'].strip()
+workspace = os.environ['GITHUB_WORKSPACE'].strip()
+
+source_root_location = os.path.join(workspace, "deb", "Release")
+destination_location = os.path.join(workspace)
+
+files = glob.glob(os.path.join(source_root_location, "*.deb"))
+
+print("Found files:")
+pprint.pp(files)
+
+if len(files) < 1 or not files[0].endswith(".deb"):
+	print("Error: cannot find .deb to sign")
+	exit(1)
+
+file_to_sign = os.path.basename(files[0])
+
+auth_json = {
+	"Version": "1.0.0",
+	"AuthenticationType": "AAD_CERT",
+	"TenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+	"ClientId": aad_id,
+	"AuthCert": {
+		"SubjectName": f"CN={aad_id}.microsoft.com",
+		"StoreLocation": "LocalMachine",
+		"StoreName": "My",
+	},
+	"RequestSigningCert": {
+		"SubjectName": f"CN={aad_id}",
+		"StoreLocation": "LocalMachine",
+		"StoreName": "My",
+	}
+}
+
+input_json = {
+	"Version": "1.0.0",
+	"SignBatches": [
+		{
+			"SourceLocationType": "UNC",
+			"SourceRootDirectory": source_root_location,
+			"DestinationLocationType": "UNC",
+			"DestinationRootDirectory": destination_location,
+			"SignRequestFiles": [
+				{
+					"CustomerCorrelationId": "01A7F55F-6CDD-4123-B255-77E6F212CDAD",
+					"SourceLocation": file_to_sign,
+					"DestinationLocation": os.path.join("Signed", file_to_sign),
+				}
+			],
+			"SigningInfo": {
+				"Operations": [
+					{
+						"KeyCode": "CP-450779-Pgp",
+						"OperationCode": "LinuxSign",
+						"Parameters": {},
+						"ToolName": "sign",
+						"ToolVersion": "1.0",
+					}
+				]
+			}
+		}
+	]
+}
+
+policy_json = {
+	"Version": "1.0.0",
+	"Intent": "production release",
+	"ContentType": "Debian package",
+}
+
+configs = [
+	("auth.json", auth_json),
+	("input.json", input_json),
+	("policy.json", policy_json),
+]
+
+for filename, data in configs:
+	with open(filename, 'w') as fp:
+		json.dump(data, fp)
+
+# Run ESRP Client
+esrp_out = "esrp_out.json"
+result = subprocess.run(
+	[esrp_tool, "sign",
+	"-a", "auth.json",
+	"-i", "input.json",
+	"-p", "policy.json",
+	"-o", esrp_out,
+	"-l", "Verbose"],
+	cwd=workspace)
+
+if result.returncode != 0:
+	print("Failed to run ESRPClient.exe")
+	sys.exit(1)
+
+if os.path.isfile(esrp_out):
+	print("ESRP output json:")
+	with open(esrp_out, 'r') as fp:
+		pprint.pp(json.load(fp))
+
+signed_file = os.path.join(destination_location, "Signed", file_to_sign)
+if os.path.isfile(signed_file):
+	print(f"Success!\nSigned {signed_file}")

--- a/.github/workflows/build-signed-deb.yml
+++ b/.github/workflows/build-signed-deb.yml
@@ -1,0 +1,92 @@
+name: "Build Signed Debian Installer"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.302
+
+    - name: Install dependencies
+      run: dotnet restore --force
+
+    - name: Build Linux Payloads
+      run: dotnet build -c Release src/linux/Packaging.Linux/Packaging.Linux.csproj
+
+    - name: Upload Installers
+      uses: actions/upload-artifact@v2
+      with:
+        name: LinuxInstallers
+        path: |
+          out/linux/Packaging.Linux/deb/Release/*.deb
+          out/linux/Packaging.Linux/tar/Release/*.tar.gz
+
+  sign:
+    name: 'Sign'
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - name: setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/checkout@v2
+
+    - name: 'Download Installer Artifact'
+      uses: actions/download-artifact@v2
+      with:
+        name: LinuxInstallers
+
+    - uses: Azure/login@v1.1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: 'Install ESRP Client'
+      shell: pwsh
+      env:
+        AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
+      run: |
+        az storage blob download --subscription  "$env:AZ_SUB" --account-name gitcitoolstore -c tools -n microsoft.esrpclient.1.2.47.nupkg -f esrp.zip
+        Expand-Archive -Path esrp.zip -DestinationPath .\esrp
+
+    - name: Install Certs
+      shell: pwsh
+      env:
+        AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
+        AZ_VAULT: ${{ secrets.AZURE_VAULT }}
+        SSL_CERT: ${{ secrets.VAULT_SSL_CERT_NAME }}
+        ESRP_CERT: ${{ secrets.VAULT_ESRP_CERT_NAME }}
+      run: |
+        az keyvault secret download --subscription "$env:AZ_SUB" --vault-name "$env:AZ_VAULT" --name "$env:SSL_CERT" -f out.pfx
+        certutil -f -importpfx out.pfx
+        Remove-Item out.pfx
+
+        az keyvault secret download --subscription "$env:AZ_SUB" --vault-name "$env:AZ_VAULT" --name "$env:ESRP_CERT" -f out.pfx
+        certutil -f -importpfx out.pfx
+        Remove-Item out.pfx
+
+    - name: Run ESRP Client
+      shell: pwsh
+      env:
+        AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
+      run: |
+        python .github/run_esrp_signing.py
+
+    - name: Upload Installer
+      uses: actions/upload-artifact@v2
+      with:
+        name: DebianInstallerSigned
+        path: |
+          Signed/*.deb

--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,7 @@ out/
 
 # dotnet local tools
 .tools/
+
+# Signing generated Files
+auth.json
+input.json


### PR DESCRIPTION
This adds a new workflow build-installers.yml, where hopefully we can either migrate all installer builds in the future (or rename and split them across the platforms.)

This workflow is heavily dependent on a lot of internal Microsoft infrastructure. What we have so far results in a GPG signed .deb for GCM-Core. This is currently uploaded as an artifact on the workflow itself but it not yet published. The 3rd and last build job yet to be added is using setting up yet another internal tool with the right security to use our internal publishing service.

This does the signing, but does not actually publish the package to the Microsoft package feed.

Replaces #170.