### PR TITLE
Fix incorrect wording of installer welcome msg

### DIFF
--- a/src/osx/Installer.Mac/resources/en.lproj/welcome.html
+++ b/src/osx/Installer.Mac/resources/en.lproj/welcome.html
@@ -21,7 +21,7 @@
                 If you have the old Java-based <a href="https://github.com/microsoft/Git-Credential-Manager-for-Mac-and-Linux">Git Credential Manager for Mac & Linux</a> installed through Homebrew, it will be unlinked after installation.
             </p>
             <p>
-                Git Credential Manager Core will be configured as the Git credential helper for the system or user, depending on if it is installed for all users, or just the current user.
+                Git Credential Manager Core will be configured as the Git credential helper for the current user by updating the global Git configuration file (<code>~/.gitconfig</code>).
             </p>
         </div>
         <div class="section">


### PR DESCRIPTION
Fix the incorrect wording of the macOS installer welcome screen.

We do not configure different gitconfig files depending on the install mode - we always update the current user's gitconfig only.