### PR TITLE
Make the system installer always append GCM Core entries, not outright set/replace existing values (and fix a typo)

### DIFF
--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication;
+using Microsoft.Git.CredentialManager.Tests;
 using Microsoft.Git.CredentialManager.Tests.Objects;
 using Moq;
 using Xunit;
@@ -14,6 +15,8 @@ namespace Microsoft.AzureRepos.Tests
 {
     public class AzureReposHostProviderTests
     {
+        private static readonly string HelperKey =
+            $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
         private static readonly string AzDevUseHttpPathKey =
             $"{Constants.GitConfiguration.Credential.SectionName}.https://dev.azure.com.{Constants.GitConfiguration.Credential.UseHttpPath}";
 
@@ -222,7 +225,6 @@ namespace Microsoft.AzureRepos.Tests
             Assert.Equal("true", actualValues[0]);
         }
 
-
         [Fact]
         public async Task AzureReposHostProvider_UnconfigureAsync_UseHttpPathSet_RemovesEntry()
         {
@@ -234,6 +236,49 @@ namespace Microsoft.AzureRepos.Tests
             await provider.UnconfigureAsync(ConfigurationTarget.User);
 
             Assert.Empty(context.Git.GlobalConfiguration.Dictionary);
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public async Task AzureReposHostProvider_UnconfigureAsync_System_Windows_UseHttpPathSetAndManagerCoreHelper_DoesNotRemoveEntry()
+        {
+            var context = new TestCommandContext();
+            var provider = new AzureReposHostProvider(context);
+
+            context.Git.SystemConfiguration.Dictionary[HelperKey] = new List<string> {"manager-core"};
+            context.Git.SystemConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"true"};
+
+            await provider.UnconfigureAsync(ConfigurationTarget.System);
+
+            Assert.True(context.Git.SystemConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out IList<string> actualValues));
+            Assert.Single(actualValues);
+            Assert.Equal("true", actualValues[0]);
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public async Task AzureReposHostProvider_UnconfigureAsync_System_Windows_UseHttpPathSetNoManagerCoreHelper_RemovesEntry()
+        {
+            var context = new TestCommandContext();
+            var provider = new AzureReposHostProvider(context);
+
+            context.Git.SystemConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"true"};
+
+            await provider.UnconfigureAsync(ConfigurationTarget.System);
+
+            Assert.Empty(context.Git.SystemConfiguration.Dictionary);
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public async Task AzureReposHostProvider_UnconfigureAsync_User_Windows_UseHttpPathSetAndManagerCoreHelper_RemovesEntry()
+        {
+            var context = new TestCommandContext();
+            var provider = new AzureReposHostProvider(context);
+
+            context.Git.GlobalConfiguration.Dictionary[HelperKey] = new List<string> {"manager-core"};
+            context.Git.GlobalConfiguration.Dictionary[AzDevUseHttpPathKey] = new List<string> {"true"};
+
+            await provider.UnconfigureAsync(ConfigurationTarget.User);
+
+            Assert.False(context.Git.GlobalConfiguration.Dictionary.TryGetValue(AzDevUseHttpPathKey, out _));
         }
     }
 }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -260,14 +260,14 @@ namespace Microsoft.AzureRepos
 
             IGitConfiguration targetConfig = _context.Git.GetConfiguration(configurationLevel);
 
-            if (targetConfig.TryGetValue(useHttpPathKey, out string currentValue) && currentValue.IsTruthy())
+            if (targetConfig.TryGet(useHttpPathKey, out string currentValue) && currentValue.IsTruthy())
             {
                 _context.Trace.WriteLine("Git configuration 'credential.useHttpPath' is already set to 'true' for https://dev.azure.com.");
             }
             else
             {
                 _context.Trace.WriteLine("Setting Git configuration 'credential.useHttpPath' to 'true' for https://dev.azure.com...");
-                targetConfig.SetValue(useHttpPathKey, "true");
+                targetConfig.Set(useHttpPathKey, "true");
             }
 
             return Task.CompletedTask;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
@@ -153,6 +153,34 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public async Task Application_ConfigureAsync_EmptyAndGcmWithEmptyAfter_RemovesExistingGcmAndAddsEmptyAndGcm()
+        {
+            const string emptyHelper = "";
+            const string afterHelper = "foo";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext();
+            IConfigurableComponent application = new Application(context, executablePath);
+
+            context.Git.GlobalConfiguration.Dictionary[key] = new List<string>
+            {
+                emptyHelper, executablePath, emptyHelper, afterHelper
+            };
+
+            await application.ConfigureAsync(ConfigurationTarget.User);
+
+            Assert.Single(context.Git.GlobalConfiguration.Dictionary);
+            Assert.True(context.Git.GlobalConfiguration.Dictionary.TryGetValue(key, out var actualValues));
+            Assert.Equal(5, actualValues.Count);
+            Assert.Equal(emptyHelper, actualValues[0]);
+            Assert.Equal(emptyHelper, actualValues[1]);
+            Assert.Equal(afterHelper, actualValues[2]);
+            Assert.Equal(emptyHelper, actualValues[3]);
+            Assert.Equal(executablePath, actualValues[4]);
+        }
+
+        [Fact]
         public async Task Application_UnconfigureAsync_NoHelpers_DoesNothing()
         {
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
-        public void GitConfiguration_TryGetValue_Name_Exists_ReturnsTrueOutString()
+        public void GitConfiguration_TryGet_Name_Exists_ReturnsTrueOutString()
         {
             string repoPath = CreateRepository(out string workDirPath);
             Git(repoPath, workDirPath, "config --local user.name john.doe").AssertSuccess();
@@ -140,14 +140,14 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            bool result = config.TryGetValue("user.name", out string value);
+            bool result = config.TryGet("user.name", out string value);
             Assert.True(result);
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
 
         [Fact]
-        public void GitConfiguration_TryGetValue_Name_DoesNotExists_ReturnsFalse()
+        public void GitConfiguration_TryGet_Name_DoesNotExists_ReturnsFalse()
         {
             string repoPath = CreateRepository();
 
@@ -157,13 +157,13 @@ namespace Microsoft.Git.CredentialManager.Tests
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
-            bool result = config.TryGetValue(randomName, out string value);
+            bool result = config.TryGet(randomName, out string value);
             Assert.False(result);
             Assert.Null(value);
         }
 
         [Fact]
-        public void GitConfiguration_TryGetValue_SectionProperty_Exists_ReturnsTrueOutString()
+        public void GitConfiguration_TryGet_SectionProperty_Exists_ReturnsTrueOutString()
         {
             string repoPath = CreateRepository(out string workDirPath);
             Git(repoPath, workDirPath, "config --local user.name john.doe").AssertSuccess();
@@ -173,14 +173,14 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            bool result = config.TryGetValue("user", "name", out string value);
+            bool result = config.TryGet("user", "name", out string value);
             Assert.True(result);
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
 
         [Fact]
-        public void GitConfiguration_TryGetValue_SectionProperty_DoesNotExists_ReturnsFalse()
+        public void GitConfiguration_TryGet_SectionProperty_DoesNotExists_ReturnsFalse()
         {
             string repoPath = CreateRepository();
 
@@ -191,13 +191,13 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string randomSection = Guid.NewGuid().ToString("N");
             string randomProperty = Guid.NewGuid().ToString("N");
-            bool result = config.TryGetValue(randomSection, randomProperty, out string value);
+            bool result = config.TryGet(randomSection, randomProperty, out string value);
             Assert.False(result);
             Assert.Null(value);
         }
 
         [Fact]
-        public void GitConfiguration_TryGetValue_SectionScopeProperty_Exists_ReturnsTrueOutString()
+        public void GitConfiguration_TryGet_SectionScopeProperty_Exists_ReturnsTrueOutString()
         {
             string repoPath = CreateRepository(out string workDirPath);
             Git(repoPath, workDirPath, "config --local user.example.com.name john.doe").AssertSuccess();
@@ -207,14 +207,14 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            bool result = config.TryGetValue("user", "example.com", "name", out string value);
+            bool result = config.TryGet("user", "example.com", "name", out string value);
             Assert.True(result);
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
 
         [Fact]
-        public void GitConfiguration_TryGetValue_SectionScopeProperty_NullScope_ReturnsTrueOutUnscopedString()
+        public void GitConfiguration_TryGet_SectionScopeProperty_NullScope_ReturnsTrueOutUnscopedString()
         {
             string repoPath = CreateRepository(out string workDirPath);
             Git(repoPath, workDirPath, "config --local user.name john.doe").AssertSuccess();
@@ -224,14 +224,14 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            bool result = config.TryGetValue("user", null, "name", out string value);
+            bool result = config.TryGet("user", null, "name", out string value);
             Assert.True(result);
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
 
         [Fact]
-        public void GitConfiguration_TryGetValue_SectionScopeProperty_DoesNotExists_ReturnsFalse()
+        public void GitConfiguration_TryGet_SectionScopeProperty_DoesNotExists_ReturnsFalse()
         {
             string repoPath = CreateRepository();
 
@@ -243,7 +243,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             string randomSection = Guid.NewGuid().ToString("N");
             string randomScope = Guid.NewGuid().ToString("N");
             string randomProperty = Guid.NewGuid().ToString("N");
-            bool result = config.TryGetValue(randomSection, randomScope, randomProperty, out string value);
+            bool result = config.TryGet(randomSection, randomScope, randomProperty, out string value);
             Assert.False(result);
             Assert.Null(value);
         }
@@ -259,7 +259,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            string value = config.GetValue("user.name");
+            string value = config.Get("user.name");
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
@@ -275,7 +275,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
-            Assert.Throws<KeyNotFoundException>(() => config.GetValue(randomName));
+            Assert.Throws<KeyNotFoundException>(() => config.Get(randomName));
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            string value = config.GetValue("user", "name");
+            string value = config.Get("user", "name");
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
@@ -306,7 +306,7 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string randomSection = Guid.NewGuid().ToString("N");
             string randomProperty = Guid.NewGuid().ToString("N");
-            Assert.Throws<KeyNotFoundException>(() => config.GetValue(randomSection, randomProperty));
+            Assert.Throws<KeyNotFoundException>(() => config.Get(randomSection, randomProperty));
         }
 
         [Fact]
@@ -320,7 +320,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            string value = config.GetValue("user", "example.com", "name");
+            string value = config.Get("user", "example.com", "name");
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
@@ -336,7 +336,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            string value = config.GetValue("user", null, "name");
+            string value = config.Get("user", null, "name");
             Assert.NotNull(value);
             Assert.Equal("john.doe", value);
         }
@@ -354,11 +354,11 @@ namespace Microsoft.Git.CredentialManager.Tests
             string randomSection = Guid.NewGuid().ToString("N");
             string randomScope = Guid.NewGuid().ToString("N");
             string randomProperty = Guid.NewGuid().ToString("N");
-            Assert.Throws<KeyNotFoundException>(() => config.GetValue(randomSection, randomScope, randomProperty));
+            Assert.Throws<KeyNotFoundException>(() => config.Get(randomSection, randomScope, randomProperty));
         }
 
         [Fact]
-        public void GitConfiguration_SetValue_Local_SetsLocalConfig()
+        public void GitConfiguration_Set_Local_SetsLocalConfig()
         {
             string repoPath = CreateRepository(out string workDirPath);
 
@@ -367,7 +367,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration(GitConfigurationLevel.Local);
 
-            config.SetValue("core.foobar", "foo123");
+            config.Set("core.foobar", "foo123");
 
             GitResult localResult = Git(repoPath, workDirPath, "config --local core.foobar");
 
@@ -375,7 +375,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
-        public void GitConfiguration_SetValue_All_ThrowsException()
+        public void GitConfiguration_Set_All_ThrowsException()
         {
             string repoPath = CreateRepository(out _);
 
@@ -384,7 +384,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var git = new GitProcess(trace, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration(GitConfigurationLevel.All);
 
-            Assert.Throws<InvalidOperationException>(() => config.SetValue("core.foobar", "test123"));
+            Assert.Throws<InvalidOperationException>(() => config.Set("core.foobar", "test123"));
         }
 
         [Fact]

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -160,13 +160,15 @@ namespace Microsoft.Git.CredentialManager
             //     ...                # any number of helper entries (possibly none)
             //     helper =           # an empty value to reset/clear any previous entries (if applicable)
             //     helper = {appPath} # the expected executable value & directly following the empty value
-            //     ...                # any number of helper entries (possibly none)
+            //     ...                # any number of helper entries (possibly none, but not the empty value '')
             //
             string[] currentValues = config.GetAll(helperKey).ToArray();
 
-            // Try to locate an existing app entry with a blank reset/clear entry immediately preceding
+            // Try to locate an existing app entry with a blank reset/clear entry immediately preceding,
+            // and no other blank empty/clear entries following (which effectively disable us).
             int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
-            if (appIndex > 0 && string.IsNullOrWhiteSpace(currentValues[appIndex - 1]))
+            int lastEmptyIndex = Array.FindLastIndex(currentValues, string.IsNullOrWhiteSpace);
+            if (appIndex > 0 && string.IsNullOrWhiteSpace(currentValues[appIndex - 1]) && lastEmptyIndex < appIndex)
             {
                 Context.Trace.WriteLine("Credential helper configuration is already set correctly.");
             }

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Git.CredentialManager
             //     helper = {appPath} # the expected executable value & directly following the empty value
             //     ...                # any number of helper entries (possibly none)
             //
-            string[] currentValues = config.GetRegex(helperKey, Constants.RegexPatterns.Any).ToArray();
+            string[] currentValues = config.GetAll(helperKey).ToArray();
 
             // Try to locate an existing app entry with a blank reset/clear entry immediately preceding
             int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
@@ -179,8 +179,8 @@ namespace Microsoft.Git.CredentialManager
 
                 // Add an empty value for `credential.helper`, which has the effect of clearing any helper value
                 // from any lower-level Git configuration, then add a second value which is the actual executable path.
-                config.ReplaceAll(helperKey, Constants.RegexPatterns.None, string.Empty);
-                config.ReplaceAll(helperKey, Constants.RegexPatterns.None, appPath);
+                config.Add(helperKey, string.Empty);
+                config.Add(helperKey, appPath);
             }
 
             return Task.CompletedTask;
@@ -211,7 +211,7 @@ namespace Microsoft.Git.CredentialManager
             //
             Context.Trace.WriteLine("Removing Git credential helper configuration...");
 
-            string[] currentValues = config.GetRegex(helperKey, Constants.RegexPatterns.Any).ToArray();
+            string[] currentValues = config.GetAll(helperKey).ToArray();
 
             int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
             if (appIndex > -1)

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -267,17 +267,22 @@ namespace Microsoft.Git.CredentialManager
                 switch (git.ExitCode)
                 {
                     case 0: // OK
+                        string[] entries = data.Split('\0');
+
+                        // Because each line terminates with the \0 character, splitting leaves us with one
+                        // bogus blank entry at the end of the array which we should ignore
+                        for (var i = 0; i < entries.Length - 1; i++)
+                        {
+                            yield return entries[i];
+                        }
+                        break;
+
                     case 1: // No results
                         break;
+
                     default:
                         _trace.WriteLine($"Failed to get all config entries '{name}' (exit={git.ExitCode}, level={_filterLevel})");
                         throw CreateGitException(git, $"Failed to get all Git configuration entries '{name}'");
-                }
-
-                string[] entries = data.Split('\0');
-                foreach (string entry in entries)
-                {
-                    yield return entry;
                 }
             }
         }

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="name">Configuration entry name.</param>
         /// <param name="value">Configuration entry value.</param>
         /// <returns>True if the value was found, false otherwise.</returns>
-        bool TryGetValue(string name, out string value);
+        bool TryGet(string name, out string value);
 
         /// <summary>
         /// Set the value of a configuration entry.
         /// </summary>
         /// <param name="name">Configuration entry name.</param>
         /// <param name="value">Configuration entry value.</param>
-        void SetValue(string name, string value);
+        void Set(string name, string value);
 
         /// <summary>
         /// Add a new value for a configuration entry.
@@ -143,7 +143,7 @@ namespace Microsoft.Git.CredentialManager
             }
         }
 
-        public bool TryGetValue(string name, out string value)
+        public bool TryGet(string name, out string value)
         {
             string level = GetLevelFilterArg();
             using (Process git = _git.CreateProcess($"config {level} {QuoteCmdArg(name)}"))
@@ -178,7 +178,7 @@ namespace Microsoft.Git.CredentialManager
             }
         }
 
-        public void SetValue(string name, string value)
+        public void Set(string name, string value)
         {
             if (_filterLevel == GitConfigurationLevel.All)
             {
@@ -482,9 +482,9 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="config">Configuration object.</param>
         /// <param name="name">Configuration entry name.</param>
         /// <returns>Configuration entry value.</returns>
-        public static string GetValue(this IGitConfiguration config, string name)
+        public static string Get(this IGitConfiguration config, string name)
         {
-            if (!config.TryGetValue(name, out string value))
+            if (!config.TryGet(name, out string value))
             {
                 throw new KeyNotFoundException($"Git configuration entry with the name '{name}' was not found.");
             }
@@ -500,9 +500,9 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <exception cref="System.Collections.Generic.KeyNotFoundException">A configuration entry with the specified key was not found.</exception>
         /// <returns>Configuration entry value.</returns>
-        public static string GetValue(this IGitConfiguration config, string section, string property)
+        public static string Get(this IGitConfiguration config, string section, string property)
         {
-            return GetValue(config, $"{section}.{property}");
+            return Get(config, $"{section}.{property}");
         }
 
         /// <summary>
@@ -514,14 +514,14 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <exception cref="System.Collections.Generic.KeyNotFoundException">A configuration entry with the specified key was not found.</exception>
         /// <returns>Configuration entry value.</returns>
-        public static string GetValue(this IGitConfiguration config, string section, string scope, string property)
+        public static string Get(this IGitConfiguration config, string section, string scope, string property)
         {
             if (scope is null)
             {
-                return GetValue(config, section, property);
+                return Get(config, section, property);
             }
 
-            return GetValue(config, $"{section}.{scope}.{property}");
+            return Get(config, $"{section}.{scope}.{property}");
         }
 
         /// <summary>
@@ -532,9 +532,9 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <param name="value">Configuration entry value.</param>
         /// <returns>True if the value was found, false otherwise.</returns>
-        public static bool TryGetValue(this IGitConfiguration config, string section, string property, out string value)
+        public static bool TryGet(this IGitConfiguration config, string section, string property, out string value)
         {
-            return config.TryGetValue($"{section}.{property}", out value);
+            return config.TryGet($"{section}.{property}", out value);
         }
 
         /// <summary>
@@ -546,14 +546,14 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="property">Configuration property name.</param>
         /// <param name="value">Configuration entry value.</param>
         /// <returns>True if the value was found, false otherwise.</returns>
-        public static bool TryGetValue(this IGitConfiguration config, string section, string scope, string property, out string value)
+        public static bool TryGet(this IGitConfiguration config, string section, string scope, string property, out string value)
         {
             if (scope is null)
             {
-                return TryGetValue(config, section, property, out value);
+                return TryGet(config, section, property, out value);
             }
 
-            return config.TryGetValue($"{section}.{scope}.{property}", out value);
+            return config.TryGet($"{section}.{scope}.{property}", out value);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Git.CredentialManager
                  *        property = value
                  *
                  */
-                if (config.TryGetValue($"{section}.{property}", out value))
+                if (config.TryGet($"{section}.{property}", out value))
                 {
                     yield return value;
                 }

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -90,6 +90,17 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             }
         }
 
+        public void Add(string name, string value)
+        {
+            if (!Dictionary.TryGetValue(name, out IList<string> values))
+            {
+                values = new List<string>();
+                Dictionary[name] = values;
+            }
+
+            values.Add(value);
+        }
+
         public void Unset(string name)
         {
             // TODO: simulate git
@@ -101,11 +112,24 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             Dictionary.Remove(name);
         }
 
+        public IEnumerable<string> GetAll(string name)
+        {
+            if (Dictionary.TryGetValue(name, out IList<string> values))
+            {
+                return values;
+            }
+
+            return Enumerable.Empty<string>();
+        }
+
         public IEnumerable<string> GetRegex(string nameRegex, string valueRegex)
         {
-            if (Dictionary.TryGetValue(nameRegex, out IList<string> values))
+            foreach (string key in Dictionary.Keys)
             {
-                return values.Where(x => Regex.IsMatch(x, valueRegex));
+                if (Regex.IsMatch(key, nameRegex))
+                {
+                    return Dictionary[key].Where(x => Regex.IsMatch(x, valueRegex));
+                }
             }
 
             return Enumerable.Empty<string>();

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         /// <param name="key"></param>
         public string this[string key]
         {
-            get => TryGetValue(key, out string value) ? value : null;
-            set => SetValue(key, value);
+            get => TryGet(key, out string value) ? value : null;
+            set => Set(key, value);
         }
 
         #region IGitConfiguration
@@ -45,7 +45,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             }
         }
 
-        public bool TryGetValue(string name, out string value)
+        public bool TryGet(string name, out string value)
         {
             if (Dictionary.TryGetValue(name, out var values))
             {
@@ -66,7 +66,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             return false;
         }
 
-        public void SetValue(string name, string value)
+        public void Set(string name, string value)
         {
             if (!Dictionary.TryGetValue(name, out IList<string> values))
             {

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
                 return true;
             }
 
-            if (GitConfiguration?.TryGetValue(section, property, out value) ?? false)
+            if (GitConfiguration?.TryGet(section, property, out value) ?? false)
             {
                 return true;
             }

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -17,12 +17,12 @@
 
 #if InstallTarget == "user"
   #define GcmAppId "{{aa76d31d-432c-42ee-844c-bc0bc801cef3}}"
-  #define GcmLongName "Git Credential Manager Manager Core (User)"
+  #define GcmLongName "Git Credential Manager Core (User)"
   #define GcmSetupExe "gcmcoreuser"
   #define GcmConfigureCmdArgs "--user"
 #elif InstallTarget == "system"
   #define GcmAppId "{{fdfae50a-1bc1-4ead-9228-1e1c275e8d12}}"
-  #define GcmLongName "Git Credential Manager Manager Core"
+  #define GcmLongName "Git Credential Manager Core"
   #define GcmSetupExe "gcmcore"
   #define GcmConfigureCmdArgs "--system"
 #else


### PR DESCRIPTION
Rather than set the helper to be _only_ GCM Core in the system configuration when called with `(un)configure --system`, we do what we are already doing in the user-case.
We only append an empty ("") reset entry, and then the GCM full path entry. This means on uninstall of the standalone GCM (be that the system or user install), we restore the previous entry, always.

Catch more existing config cases such as when another 'empty' entry is _after_ GCM. We will now see this case and reconfigure ourselves to be exclusively 'in front'.

Also we are not that meta.. "Git Credential Manager ~Manager~ Core". Whoops.