### PR TITLE
Fix missing space in username input

### DIFF
--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -72,7 +72,7 @@ namespace GitHub
                 if ((modes & AuthenticationModes.Basic) != 0) promptArgs.Append(" --basic");
                 if ((modes & AuthenticationModes.OAuth) != 0) promptArgs.Append(" --oauth");
                 if (!GitHubHostProvider.IsGitHubDotCom(targetUri)) promptArgs.AppendFormat(" --enterprise-url {0}", targetUri);
-                if (!string.IsNullOrWhiteSpace(userName)) promptArgs.AppendFormat("--username {0}", userName);
+                if (!string.IsNullOrWhiteSpace(userName)) promptArgs.AppendFormat(" --username {0}", userName);
 
                 IDictionary<string, string> resultDict = await InvokeHelperAsync(helperPath, promptArgs.ToString(), null);
 


### PR DESCRIPTION
This caused the preceding argument to fail due to lack of separation between args