### PR TITLE
osx-sign: fix macOS release build sign/upload

### DIFF
--- a/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
@@ -18,8 +18,11 @@ steps:
   - script: nbgv cloud --common-vars
     displayName: Set version variables
 
-  - script: src/osx/Installer.Mac/pack.sh --payload='$(Build.StagingDirectory)/payload' --version='$(GitBuildVersion)' --output='$(Build.StagingDirectory)/pkg/gcmcore-osx-$(GitBuildVersion).pkg'
-    displayName: Pack installer payload
+  - script: src/osx/Installer.Mac/pack.sh --payload='$(Build.StagingDirectory)/payload' --version='$(GitBuildVersion)' --output='$(Build.StagingDirectory)/components/com.microsoft.gitcredentialmanager.component.pkg'
+    displayName: Create component package
+
+  - script: src/osx/Installer.Mac/dist.sh --package-path='$(Build.StagingDirectory)/components' --version='$(GitBuildVersion)' --output='$(Build.StagingDirectory)/pkg/gcmcore-osx-$(GitBuildVersion).pkg' || exit 1
+    displayName: Create product archive
 
   - task: PublishPipelineArtifact@0
     displayName: Upload unsigned package


### PR DESCRIPTION
Fix the macOS real-signed release build YAML files to also create the product archive (not just the component package), and upload and sign that instead.

This was missed as only the macOS release pipelines are completely separate from the normal one (due to needing to break the real signing process up into stages directly in Azure Pipelines).