### PR TITLE
Allow user to override which interactive authentication flow used for MS auth

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,3 +226,46 @@ git config --global credential.plaintextStorePath /mnt/external-drive/credential
 ```
 
 **Also see: [GCM_PLAINTEXT_STORE_PATH](environment.md#GCM_PLAINTEXT_STORE_PATH)**
+
+---
+
+### credential.msauthFlow
+
+Specify which authentication flow should be used when performing Microsoft authentication and an interactive flow is required.
+
+Defaults to the value `auto`.
+
+**Note:** This setting will be ignored if a native authentication helper is configured and available. See [`credential.msauthHelper`](#credentialmsauthhelper) for more information.
+
+Value|Credential Store
+-|-
+`auto` _(default)_|Select the best option depending on the current environment and platform.
+`embedded`|Show a window with embedded web view control.
+`system`|Open the user's default web browser.
+`devicecode`|Show a device code.
+
+#### Example
+
+```shell
+git config --global credential.msauthFlow devicecode
+```
+
+**Also see: [GCM_MSAUTH_FLOW](environment.md#GCM_MSAUTH_FLOW)**
+
+---
+
+### credential.msauthHelper
+
+Full path to an external 'helper' tool to which Microsoft authentication should be delegated.
+
+On macOS this defaults to the included native `Microsoft.Authentication.Helper` tool. On all other platforms this is not set.
+
+**Note:** If a helper is set and available then all Microsoft authentication will be delegated to this helper and the [`credential.msauthFlow`](#credentialmsauthflow) setting will be ignored. Setting the value to the empty string (`""`) will unset any default helper.
+
+#### Example
+
+```shell
+git config --global credential.msauthHelper "C:\path\to\helper.exe"
+```
+
+**Also see: [GCM_MSAUTH_HELPER](environment.md#GCM_MSAUTH_HELPER)**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -373,3 +373,58 @@ export GCM_PLAINTEXT_STORE_PATH=/mnt/external-drive/credentials
 ```
 
 **Also see: [credential.plaintextStorePath](configuration.md#credentialplaintextstorepath)**
+
+---
+
+### GCM_MSAUTH_FLOW
+
+Specify which authentication flow should be used when performing Microsoft authentication and an interactive flow is required.
+
+Defaults to the value `auto`.
+
+**Note:** This setting will be ignored if a native authentication helper is configured and available. See [`GCM_MSAUTH_HELPER`](#gcm_msauth_helper) for more information.
+
+Value|Credential Store
+-|-
+`auto` _(default)_|Select the best option depending on the current environment and platform.
+`embedded`|Show a window with embedded web view control.
+`system`|Open the user's default web browser.
+`devicecode`|Show a device code.
+
+##### Windows
+
+```batch
+SET GCM_MSAUTH_FLOW="devicecode"
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_MSAUTH_FLOW="devicecode"
+```
+
+**Also see: [credential.msauthFlow](configuration.md#credentialmsauthflow)**
+
+---
+
+### GCM_MSAUTH_HELPER
+
+Full path to an external 'helper' tool to which Microsoft authentication should be delegated.
+
+On macOS this defaults to the included native `Microsoft.Authentication.Helper` tool. On all other platforms this is not set.
+
+**Note:** If a helper is set and available then all Microsoft authentication will be delegated to this helper and the [`GCM_MSAUTH_FLOW`](#gcm_msauth_flow) setting will be ignored. Setting the value to the empty string (`""`) will unset any default helper.
+
+##### Windows
+
+```batch
+SET GCM_MSAUTH_HELPER="C:\path\to\helper.exe"
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_MSAUTH_HELPER="/usr/local/bin/msauth-helper"
+```
+
+**Also see: [credential.msauthHelper](configuration.md#credentialmsauthhelper)**

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -13,9 +13,8 @@ namespace Microsoft.AzureRepos
         // We share this to be able to consume existing access tokens from the VS caches
         public const string AadClientId = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
 
-        // Standard redirect URI for native client 'v1 protocol' applications
-        // https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code#request-an-authorization-code
-        public static readonly Uri AadRedirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob");
+        // Redirect URI specified by the Visual Studio application configuration
+        public static readonly Uri AadRedirectUri = new Uri("http://localhost");
 
         public const string VstsHostSuffix = ".visualstudio.com";
         public const string AzureDevOpsHost = "dev.azure.com";

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
@@ -106,6 +106,13 @@ namespace Microsoft.Git.CredentialManager.Authentication
                 helperName = PlatformUtils.IsWindows() ? $"{defaultValue}.exe" : defaultValue;
             }
 
+            // If the user set the helper override to the empty string then they are signalling not to use a helper
+            if (string.IsNullOrEmpty(helperName))
+            {
+                path = null;
+                return false;
+            }
+
             if (Path.IsPathRooted(helperName))
             {
                 path = helperName;

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Git.CredentialManager
             public const string GitSslNoVerify        = "GIT_SSL_NO_VERIFY";
             public const string GcmInteractive        = "GCM_INTERACTIVE";
             public const string GcmParentWindow       = "GCM_MODAL_PARENTHWND";
+            public const string MsAuthFlow            = "GCM_MSAUTH_FLOW";
             public const string MsAuthHelper          = "GCM_MSAUTH_HELPER";
             public const string GcmCredNamespace      = "GCM_NAMESPACE";
             public const string GcmCredentialStore    = "GCM_CREDENTIAL_STORE";
@@ -80,6 +81,7 @@ namespace Microsoft.Git.CredentialManager
                 public const string HttpsProxy  = "httpsProxy";
                 public const string UseHttpPath = "useHttpPath";
                 public const string Interactive = "interactive";
+                public const string MsAuthFlow  = "msauthFlow";
                 public const string MsAuthHelper = "msauthHelper";
                 public const string CredNamespace = "namespace";
                 public const string CredentialStore = "credentialStore";


### PR DESCRIPTION
Allow the user to override which Microsoft authentication flow to use when interaction is required.

The options available are:
 - embedded web view
 - system web view
 - device code

Previously we always picked one of these flows (or used a native external helper) to use. In some instances it may be desirable for the user to force a particular flow, for instance to take advantage of browser sign-in state or OS integrations by using 'system'.

If no option is set, or `auto` is selected the existing behaviour is preserved (we pick for the user).

Fixes #210 