### PR TITLE
Create apt-get release pipeline

### DIFF
--- a/.github/configure_repoclient.py
+++ b/.github/configure_repoclient.py
@@ -2,9 +2,9 @@ from os import enviorn as env
 
 
 def check_var(name:str) -> bool:
-    if not env[name]:
+    if name not in env:
         print(f"Required env var {name} is missing!")
-
+        exit(1)
 
 for var in ['APT_REPO_ID', 'AZURE_AAD_ID', 'AAD_CLIENT_SECRET']:
     check_var(var)

--- a/.github/configure_repoclient.py
+++ b/.github/configure_repoclient.py
@@ -1,4 +1,4 @@
-from os import enviorn as env
+from os import environ as env
 
 
 def check_var(name:str) -> bool:

--- a/.github/configure_repoclient.py
+++ b/.github/configure_repoclient.py
@@ -1,5 +1,5 @@
 from os import environ as env
-
+import json
 
 def check_var(name:str) -> bool:
     if name not in env:

--- a/.github/fetch_release.py
+++ b/.github/fetch_release.py
@@ -1,0 +1,38 @@
+from os import environ as env
+import requests
+import time
+
+if 'RELEASE' not in env or not env['RELEASE']:
+    print("Require env var RELEASE is missing!")
+    exit(1)
+
+release = env['RELEASE']
+
+release_arg = "latest" if release == "latest" else f"tags/{release}"
+release_url = f"https://api.github.com/repos/microsoft/git-credential-manager-core/releases/{release_arg}"
+
+try:
+    r = requests.get(release_url)
+
+    # if at first you don't succeed...
+    if r.status_code != 200:
+        time.sleep(2)
+        r = requests.get(release_url)
+
+    if r.status_code != 200:
+        raise Error(f"Failed to fetch release info from {release_url}")
+
+    asset = [a for a in r.json()['assets'] if a['name'].endswith(".deb")][0]
+    asset_url = asset['browser_download_url']
+    asset_name = asset['name']
+
+    print(f"Found asset {asset_name}")
+    print(f"Writing asset URL: {asset_url} to asset_url.txt")
+    
+    with open('asset_url.txt', 'w') as f:
+        f.write(asset_url)
+
+except RuntimeError as ex:
+    print("Oh dear...")
+    print(ex)
+    exit(1)

--- a/.github/fetch_release.py
+++ b/.github/fetch_release.py
@@ -1,21 +1,30 @@
 from os import environ as env
 import requests
 import time
+import json
 
 release = env['RELEASE'] if 'RELEASE' in env else "latest"
 release_arg = "latest" if release == "latest" else f"tags/{release}"
+
+print(f"release_arg set to {release_arg}")
+
 release_url = f"https://api.github.com/repos/microsoft/git-credential-manager-core/releases/{release_arg}"
 
 try:
+    print(f"Fetching release {release_url}")
     r = requests.get(release_url)
 
     # if at first you don't succeed...
     if r.status_code != 200:
+        print(f"Trying again, initial status {r.status_code}")
         time.sleep(2)
         r = requests.get(release_url)
 
+    print("Response:")
+    print(json.dumps(r.json(), indent=4))
+
     if r.status_code != 200:
-        raise Error(f"Failed to fetch release info from {release_url}")
+        raise ValueError(f"Failed to fetch release info from {release_url}")
 
     asset = [a for a in r.json()['assets'] if a['name'].endswith(".deb")][0]
     asset_url = asset['browser_download_url']

--- a/.github/fetch_release.py
+++ b/.github/fetch_release.py
@@ -2,12 +2,7 @@ from os import environ as env
 import requests
 import time
 
-if 'RELEASE' not in env or not env['RELEASE']:
-    print("Require env var RELEASE is missing!")
-    exit(1)
-
-release = env['RELEASE']
-
+release = env['RELEASE'] if 'RELEASE' in env else "latest"
 release_arg = "latest" if release == "latest" else f"tags/{release}"
 release_url = f"https://api.github.com/repos/microsoft/git-credential-manager-core/releases/{release_arg}"
 
@@ -28,7 +23,7 @@ try:
 
     print(f"Found asset {asset_name}")
     print(f"Writing asset URL: {asset_url} to asset_url.txt")
-    
+
     with open('asset_url.txt', 'w') as f:
         f.write(asset_url)
 

--- a/.github/fetch_release.py
+++ b/.github/fetch_release.py
@@ -36,6 +36,9 @@ try:
 
     print(f"Found asset {asset_name}")
     print(f"Writing asset URL: {asset_url} to asset_url.txt")
+    
+    with open('asset_name.txt', 'w') as f:
+        f.write(asset_name)
 
     with open('asset_url.txt', 'w') as f:
         f.write(asset_url)

--- a/.github/fetch_release.py
+++ b/.github/fetch_release.py
@@ -3,7 +3,11 @@ import requests
 import time
 import json
 
-release = env['RELEASE'] if 'RELEASE' in env else "latest"
+if 'RELEASE' in env and env['RELEASE']:
+    release = env['RELEASE'].strip()
+else:
+    release = "latest"
+
 release_arg = "latest" if release == "latest" else f"tags/{release}"
 
 print(f"release_arg set to {release_arg}")

--- a/.github/release-apt-get.py
+++ b/.github/release-apt-get.py
@@ -1,5 +1,18 @@
 from os import enviorn as env
 
+
+def check_var(name:str) -> bool:
+    if not env[name]:
+        print(f"Required env var {name} is missing!")
+
+
+for var in ['APT_REPO_ID', 'AZURE_AAD_ID', 'AAD_CLIENT_SECRET']:
+    check_var(var)
+
+repo_id = env['APT_REPO_ID']
+aad_id = env['AZURE_AAD_ID']
+password = env['AAD_CLIENT_SECRET']
+
 repo_config = {
     "AADResource": "https://microsoft.onmicrosoft.com/945999e9-da09-4b5b-878f-b66c414602c0",
     "AADTenant": "72f988bf-86f1-41af-91ab-2d7cd011db47",
@@ -7,9 +20,9 @@ repo_config = {
     "server": "azure-apt-cat.cloudapp.net",
     "port": "443",
 
-    "repositoryId": env['APT_REPO_ID'],
-    "AADClientId": env['AZURE_AAD_ID'],
-    "AADClientSecret": env['AAD_CLIENT_SECRET']
+    "repositoryId": repo_id,
+    "AADClientId": aad_id,
+    "AADClientSecret": password,
 }
 
 configs = [

--- a/.github/release-apt-get.py
+++ b/.github/release-apt-get.py
@@ -1,0 +1,22 @@
+from os import enviorn as env
+
+repo_config = {
+    "AADResource": "https://microsoft.onmicrosoft.com/945999e9-da09-4b5b-878f-b66c414602c0",
+    "AADTenant": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    "AADAuthorityUrl": "https://login.microsoftonline.com",
+    "server": "azure-apt-cat.cloudapp.net",
+    "port": "443",
+
+    "repositoryId": env['APT_REPO_ID'],
+    "AADClientId": env['AZURE_AAD_ID'],
+    "AADClientSecret": env['AAD_CLIENT_SECRET']
+}
+
+configs = [
+	("config.json", repo_config),
+]
+
+for filename, data in configs:
+	with open(filename, 'w') as fp:
+		json.dump(data, fp)
+

--- a/.github/workflows/build-signed-deb.yml
+++ b/.github/workflows/build-signed-deb.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         name: LinuxInstallers
 
-    - uses: Azure/login@v1.1
+    - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -2,6 +2,8 @@ name: "release-apt-get"
 on:
   release:
     types: [released]
+  pull_request:
+    branches: [master]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -37,5 +37,5 @@ jobs:
     - name: "Install Repo Client"
       shell: bash
       run: |
-        dpkg -i repoclient.deb
+        sudo dpkg -i repoclient.deb
         repoclient --version

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -34,7 +34,12 @@ jobs:
         az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repoclient.deb --auth-mode login
 
     - name: "Install Repo Client"
+      env:
+        APT_REPO_ID: ${{ secrets.APT_REPO_ID }}
+        AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
+        AAD_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
       run: |
         sudo apt-get install python3-adal --yes
         sudo dpkg -i repoclient.deb
-        repoclient -h
+        
+        python .github/release-apt-cat.py

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -32,8 +32,10 @@ jobs:
         AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
       run: |
         az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb --auth-mode login
+        ls
 
     - name: "Install Repo Client"
       run: |
+        ls
         sudo dpkg -i repoclient.deb
         repoclient --version

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
       run: |
-        az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb
+        az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb --auth-mode login
 
     - name: "Install Repo Client"
       run: |

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -51,4 +51,4 @@ jobs:
         pip install requests
         python .github/fetch_release.py
         wget "$(cat asset_url.txt)"
-        repoclient -v v3 package add --check --wait 300 "$(cat asset_name.txt)" 
+        repoclient -v v3 -c config.json package add --check --wait 300 "$(cat asset_name.txt)" 

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -35,5 +35,6 @@ jobs:
 
     - name: "Install Repo Client"
       run: |
+        sudo apt-get install python3-adal --yes
         sudo dpkg -i repoclient.deb
         repoclient --version

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -48,7 +48,6 @@ jobs:
         RELEASE: ${{ github.event.inputs.release }}
       run: |
         pip install requests
-        python .github/fetch-release.py
+        python .github/fetch_release.py
         wget "$(cat asset_url.txt)"
         ls
-        

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -42,6 +42,7 @@ jobs:
         sudo apt-get install python3-adal --yes
         sudo dpkg -i repoclient.deb
         python .github/configure_repoclient.py
+        rm repoclient.deb
 
     - name: "Publish to apt feed"
       env:

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -34,7 +34,6 @@ jobs:
         az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb
 
     - name: "Install Repo Client"
-      shell: bash
       run: |
         sudo dpkg -i repoclient.deb
         repoclient --version

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -2,8 +2,6 @@ name: "release-apt-get"
 on:
   release:
     types: [released]
-  pull_request:
-    branches: [master]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -37,4 +37,4 @@ jobs:
       run: |
         sudo apt-get install python3-adal --yes
         sudo dpkg -i repoclient.deb
-        repoclient --version
+        repoclient -h

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
       run: |
-        az storage blob download --subscription  "$env:AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb
+        az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb
 
     - name: "Install Repo Client"
       shell: bash

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -28,7 +28,6 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: 'Download Repo Client'
-      shell: pwsh
       env:
         AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
       run: |

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -31,11 +31,9 @@ jobs:
       env:
         AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
       run: |
-        az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb --auth-mode login
-        ls
+        az storage blob download --subscription  "$AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repoclient.deb --auth-mode login
 
     - name: "Install Repo Client"
       run: |
-        ls
         sudo dpkg -i repoclient.deb
         repoclient --version

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -51,4 +51,4 @@ jobs:
         pip install requests
         python .github/fetch_release.py
         wget "$(cat asset_url.txt)"
-        ls
+        repoclient -v v3 package add --wait --check "$(cat asset_name.txt)"

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -1,0 +1,39 @@
+name: "release-apt-get"
+on:
+  release:
+    types: [released]
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Release Tag'
+        required: true
+        default: 'latest'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/checkout@v2
+
+    - uses: Azure/login@v1.1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: 'Download Repo Client'
+      shell: pwsh
+      env:
+        AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
+      run: |
+        az storage blob download --subscription  "$env:AZ_SUB" --account-name gitcitoolstore -c tools -n azure-repoapi-client_2.0.1_amd64.deb -f repocli.deb
+
+    - name: "Install Repo Client"
+      shell: bash
+      run: |
+        dpkg -i repoclient.deb
+        repoclient --version

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -7,7 +7,7 @@ on:
 
   workflow_dispatch:
     inputs:
-      name:
+      release:
         description: 'Release Tag'
         required: true
         default: 'latest'
@@ -41,5 +41,14 @@ jobs:
       run: |
         sudo apt-get install python3-adal --yes
         sudo dpkg -i repoclient.deb
+        python .github/configure_repoclient.py
+
+    - name: "Publish to apt feed"
+      env:
+        RELEASE: ${{ github.event.inputs.release }}
+      run: |
+        pip install requests
+        python .github/fetch-release.py
+        wget "$(cat asset_url.txt)"
+        ls
         
-        python .github/release-apt-cat.py

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - uses: Azure/login@v1.1
+    - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -51,4 +51,4 @@ jobs:
         pip install requests
         python .github/fetch_release.py
         wget "$(cat asset_url.txt)"
-        repoclient -v v3 package add --wait --check "$(cat asset_name.txt)"
+        repoclient -v v3 package add --check --wait 300 "$(cat asset_name.txt)" 


### PR DESCRIPTION
Creating a new workflow to be triggered off full release to download the signed .deb asset and deploy it.

The workflow does not currently check if the .deb is actually signed, this is something the repo api _will do in the future_ similar to how it currently does for rpm packages.

Builds now failing because of https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ `set-env` usage in the GitVersioning tools :( 