### PR TITLE
Update GitVersioning package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
   <ItemGroup>
     <!-- All projects should use Nerdbank.GitVersioning for consistent version numbers -->
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.2.7-beta</Version>
+      <Version>3.3.37</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Update the Nerdbank.GitVersioning package to the latest version (3.3.37) to consume a fix for the removal of the `set-env` command in GitHub Actions.

Previous versions of GitVersioning use the `set-env` command to set the cloud build number. The new version uses "environment files" which is the replacement for `set-env`.

See: https://github.com/dotnet/Nerdbank.GitVersioning/pull/516