### PR TITLE
GitHub: add PAT support

### DIFF
--- a/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml
+++ b/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml
@@ -123,7 +123,7 @@
                                                       Localization.Attributes="PromptText (Modifiable Readable Text)"/>
 
                         <sharedControls:SecurePasswordBox Password="{Binding Password, UpdateSourceTrigger=PropertyChanged, Delay=300, Mode=OneWayToSource}"
-                                                          PromptText="Password"
+                                                          PromptText="{Binding PasswordOrPatString}"
                                                           x:Uid="passwordBox"
                                                           x:Name="passwordBox"
                                                           Localization.Attributes="PromptText (Modifiable Readable Text)"/>

--- a/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml.cs
+++ b/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml.cs
@@ -31,6 +31,7 @@ namespace GitHub.UI.Login
                 return;
             }
 
+            // Set focus into first visible input box
             if (ViewModel.IsLoginUsingUsernameAndPasswordVisible)
             {
                 if (string.IsNullOrWhiteSpace(ViewModel.UsernameOrEmail))

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -29,30 +29,31 @@ namespace GitHub.UI
                     if (StringComparer.OrdinalIgnoreCase.Equals(args[0], "prompt"))
                     {
                         string enterpriseUrl = CommandLineUtils.GetParameter(args, "--enterprise-url");
-                        bool basic = CommandLineUtils.TryGetSwitch(args, "--basic");
-                        bool oauth = CommandLineUtils.TryGetSwitch(args, "--oauth");
+                        bool passwordLogin = CommandLineUtils.TryGetSwitch(args, "--password");
+                        bool patLogin = CommandLineUtils.TryGetSwitch(args, "--pat");
+                        bool oauthLogin = CommandLineUtils.TryGetSwitch(args, "--oauth");
                         string username = CommandLineUtils.GetParameter(args, "--username");
 
-                        if (!basic && !oauth)
+                        if (!passwordLogin && !patLogin && !oauthLogin)
                         {
                             throw new Exception("at least one authentication mode must be specified");
                         }
 
                         var result = prompts.ShowCredentialPrompt(
-                            enterpriseUrl, basic, oauth,
+                            enterpriseUrl, passwordLogin, patLogin, oauthLogin,
                             ref username,
                             out string password);
 
                         switch (result)
                         {
-                            case CredentialPromptResult.BasicAuthentication:
-                                resultDict["mode"] = "basic";
+                            case CredentialPromptResult.Basic:
+                            case CredentialPromptResult.Password:
+                            case CredentialPromptResult.PAT:
                                 resultDict["username"] = username;
                                 resultDict["password"] = password;
                                 break;
 
-                            case CredentialPromptResult.OAuthAuthentication:
-                                resultDict["mode"] = "oauth";
+                            case CredentialPromptResult.OAuth:
                                 break;
 
                             case CredentialPromptResult.Cancel:
@@ -61,6 +62,8 @@ namespace GitHub.UI
                             default:
                                 throw new ArgumentOutOfRangeException();
                         }
+
+                        resultDict["mode"] = result.ToString().ToLower();
                     }
                     else if (StringComparer.OrdinalIgnoreCase.Equals(args[0], "2fa"))
                     {

--- a/src/windows/GitHub.UI.Windows/Tester.xaml
+++ b/src/windows/GitHub.UI.Windows/Tester.xaml
@@ -10,9 +10,15 @@
         ResizeMode="NoResize"
         Title="GitHub Authentication Dialog Tester"
         Height="420"
-        Width="420">
-    <DockPanel>
-        <Button Content="Show Credentials Dialog" Padding="10" Click="ShowCredentials" />
+        Width="380">
+    <WrapPanel>
+        <Button Content="Show Credentials Dialog: Password" Padding="10" Click="ShowCredentials_Password" />
+        <Button Content="Show Credentials Dialog: Pat" Padding="10" Click="ShowCredentials_Pat" />
+        <Button Content="Show Credentials Dialog: Password and Pat" Padding="10" Click="ShowCredentials_Basic" />
+        <Button Content="Show Credentials Dialog: OAuth and Password" Padding="10" Click="ShowCredentials_OAuthPassword" />
+        <Button Content="Show Credentials Dialog: OAuth and Pat" Padding="10" Click="ShowCredentials_OAuthPat" />
+        <Button Content="Show Credentials Dialog: OAuth and Password and Pat" Padding="10" Click="ShowCredentials_OAuthBasic" />
+        <Button Content="Show Credentials Dialog: OAuth" Padding="10" Click="ShowCredentials_OAuth" />
         <Button Content="Show Authentication Code Dialog" Padding="10" Click="ShowAuthenticationCode" />
-    </DockPanel>
+    </WrapPanel>
 </Window>

--- a/src/windows/GitHub.UI.Windows/Tester.xaml.cs
+++ b/src/windows/GitHub.UI.Windows/Tester.xaml.cs
@@ -21,12 +21,41 @@ namespace GitHub.UI
 
         private IntPtr Handle => new WindowInteropHelper(this).Handle;
 
-        private void ShowCredentials(object sender, RoutedEventArgs e)
+        private void ShowLoginCredentialsView(string gitHubEnterpriseUrl, string usernameOrEmail, bool enablePasswordAuth, bool enablePatAuth, bool enableBrowserAuth)
         {
-            var model = new LoginCredentialsViewModel(true, true);
+            var model = new LoginCredentialsViewModel(gitHubEnterpriseUrl, usernameOrEmail, enablePasswordAuth, enablePatAuth, enableBrowserAuth);
             var view = new LoginCredentialsView();
             var window = new DialogWindow(model, view);
             Gui.ShowDialog(window, Handle);
+        }
+
+        private void ShowCredentials_Password(object sender, RoutedEventArgs e)
+        {
+            ShowLoginCredentialsView("", "", true, false, false);
+        }
+        private void ShowCredentials_Pat(object sender, RoutedEventArgs e)
+        {
+            ShowLoginCredentialsView("", "", false, true, false);
+        }
+        private void ShowCredentials_Basic(object sender, RoutedEventArgs e)
+        {
+            ShowLoginCredentialsView("", "", true, true, false);
+        }
+        private void ShowCredentials_OAuthPassword(object sender, RoutedEventArgs e)
+        {
+            ShowLoginCredentialsView("", "", true, false, true);
+        }
+        private void ShowCredentials_OAuthPat(object sender, RoutedEventArgs e)
+        {
+            ShowLoginCredentialsView("", "", false, true, true);
+        }
+        private void ShowCredentials_OAuthBasic(object sender, RoutedEventArgs e)
+        {
+            ShowLoginCredentialsView("", "", true, true, true);
+        }
+        private void ShowCredentials_OAuth(object sender, RoutedEventArgs e)
+        {
+            ShowLoginCredentialsView("", "", false, false, true);
         }
 
         private void ShowAuthenticationCode(object sender, RoutedEventArgs e)


### PR DESCRIPTION
As shown in #222 current GCM Core does not only not properly show PAT. It even doesn't work with PAT at all. This PR is supposed to fix both issues.
Minor points of #222 are not yet addressed like showing "What is a PAT?" and "Click here to generate a PAT".