### PR TITLE
Add suppressions for credscan false positives

### DIFF
--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -207,7 +207,7 @@ namespace GitHub.Tests
 
             var expectedTargetUri = new Uri("https://github.com/");
             var expectedUserName = "john.doe";
-            var expectedPassword = "letmein123";
+            var expectedPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             IEnumerable<string> expectedPatScopes = new[]
             {
                 GitHubConstants.TokenScopes.Gist,
@@ -254,7 +254,7 @@ namespace GitHub.Tests
 
             var expectedTargetUri = new Uri("https://github.com/");
             var expectedUserName = "john.doe";
-            var expectedPassword = "letmein123";
+            var expectedPassword = "letmein123";  // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             var expectedAuthCode = "123456";
             IEnumerable<string> expectedPatScopes = new[]
             {

--- a/src/shared/GitHub.Tests/GitHubRestApiTests.cs
+++ b/src/shared/GitHub.Tests/GitHubRestApiTests.cs
@@ -18,7 +18,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_NullUri_ThrowsException()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 
@@ -34,7 +34,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_NoNetwork_ThrowsException()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 
@@ -55,7 +55,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_ValidRequestOK_ReturnsToken()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 
@@ -95,7 +95,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_ValidRequestOKBadJson_ReturnsFailure()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 
@@ -132,7 +132,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_ValidRequestCreated_ReturnsToken()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 
@@ -172,7 +172,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_Valid1FANoAppAuthCode_ReturnsApp2FARequired()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             string[] testScopes = { "scope1", "scope2" };
 
             var context = new TestCommandContext();
@@ -204,7 +204,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_Valid1FANoSmsAuthCode_ReturnsSms2FARequired()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             string[] testScopes = { "scope1", "scope2" };
 
             var context = new TestCommandContext();
@@ -236,7 +236,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_ValidOAuthToken_ReturnsOAuthToken()
         {
             const string testUserName = "john.doe";
-            const string testOAuthToken = "TestOAuthToken";
+            const string testOAuthToken = "TestOAuthToken"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             string[] testScopes = { "scope1", "scope2" };
 
             var context = new TestCommandContext();
@@ -272,7 +272,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_Unauthorized_ReturnsFailure()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 
@@ -307,7 +307,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_Forbidden_ReturnsFailure()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 
@@ -342,7 +342,7 @@ namespace GitHub.Tests
         public async Task GitHubRestApi_AcquireTokenAsync_UnknownResponse_ReturnsFailure()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testAuthCode = "1234";
             string[] testScopes = { "scope1", "scope2" };
 

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -12,6 +12,8 @@ namespace GitHub
         public const string DefaultAuthenticationHelper = "GitHub.UI";
 
         public const string OAuthClientId = "0120e057bd645470c1ed";
+
+        // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="OAuth2 public client application 'secrets' are required and permitted to be public")]
         public const string OAuthClientSecret = "18867509d956965542b521a529a79bb883344c90";
         public static readonly Uri OAuthRedirectUri = new Uri("http://localhost/");
         public static readonly Uri OAuthAuthorizationEndpointRelativeUri = new Uri("/login/oauth/authorize", UriKind.Relative);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
@@ -24,10 +24,10 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
         {
             const string testResource = "https://example.com";
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             var context = new TestCommandContext {SessionManager = {IsDesktopSession = false}};
-            context.Terminal.SecretPrompts["Password"] = testPassword;
+            context.Terminal.SecretPrompts["Password"] = testPassword; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             var basicAuth = new BasicAuthentication(context);
 
@@ -42,11 +42,11 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
         {
             const string testResource = "https://example.com";
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             var context = new TestCommandContext {SessionManager = {IsDesktopSession = false}};
             context.Terminal.Prompts["Username"] = testUserName;
-            context.Terminal.SecretPrompts["Password"] = testPassword;
+            context.Terminal.SecretPrompts["Password"] = testPassword; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             var basicAuth = new BasicAuthentication(context);
 
@@ -77,7 +77,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
         {
             const string testResource = "https://example.com";
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             var context = new TestCommandContext
             {
@@ -108,7 +108,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
         {
             const string testResource = "https://example.com";
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             var context = new TestCommandContext
             {
@@ -140,7 +140,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
             const string testResource = "https://example.com";
             const string testUserName = "john.doe";
             const string newUserName  = "jane.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             var context = new TestCommandContext
             {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/OAuth2ClientTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/OAuth2ClientTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Authentication
     public class OAuth2ClientTests
     {
         private const string TestClientId = "9ffe7f11c8";
-        private const string TestClientSecret = "62adac63a4614d93833470942a38454f";
+        private const string TestClientSecret = "62adac63a4614d93833470942a38454f"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
         private static readonly Uri TestRedirectUri = new Uri("http://localhost/oauth-callback");
 
         [Fact]

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/EraseCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/EraseCommandTests.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
         public async Task EraseCommand_ExecuteAsync_CallsHostProvider()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             var stdin = $"username={testUserName}\npassword={testPassword}\n\n";
             var expectedInput = new InputArguments(new Dictionary<string, string>
             {
                 ["username"] = testUserName,
-                ["password"] = testPassword
+                ["password"] = testPassword // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             var providerMock = new Mock<IHostProvider>();

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GetCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GetCommandTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
         public async Task GetCommand_ExecuteAsync_CallsHostProviderAndWritesCredential()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             ICredential testCredential = new GitCredential(testUserName, testPassword);
             var expectedStdOutDict = new Dictionary<string, string>
             {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/StoreCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/StoreCommandTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
         public async Task StoreCommand_ExecuteAsync_CallsHostProvider()
         {
             const string testUserName = "john.doe";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             var stdin = $"username={testUserName}\npassword={testPassword}\n\n";
             var expectedInput = new InputArguments(new Dictionary<string, string>
             {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderTests.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Git.CredentialManager.Tests
         public async Task HostProvider_GetCredentialAsync_CredentialExists_ReturnsExistingCredential()
         {
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string service = "https://example.com";
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
                 ["host"] = "example.com",
                 ["username"] = userName,
-                ["password"] = password,
+                ["password"] = password, // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             var context = new TestCommandContext();
@@ -47,13 +47,13 @@ namespace Microsoft.Git.CredentialManager.Tests
         public async Task HostProvider_GetCredentialAsync_CredentialDoesNotExist_ReturnsNewGeneratedCredential()
         {
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
                 ["host"] = "example.com",
                 ["username"] = userName,
-                ["password"] = password,
+                ["password"] = password, // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             bool generateWasCalled = false;
@@ -84,13 +84,13 @@ namespace Microsoft.Git.CredentialManager.Tests
         public async Task HostProvider_StoreCredentialAsync_EmptyCredential_DoesNotStoreCredential()
         {
             const string emptyUserName = "";
-            const string emptyPassword = "";
+            const string emptyPassword = ""; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
                 ["host"] = "example.com",
                 ["username"] = emptyUserName,
-                ["password"] = emptyPassword,
+                ["password"] = emptyPassword, // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             var context = new TestCommandContext();
@@ -105,14 +105,14 @@ namespace Microsoft.Git.CredentialManager.Tests
         public async Task HostProvider_StoreCredentialAsync_NonEmptyCredential_StoresCredential()
         {
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string service = "https://example.com";
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
                 ["host"] = "example.com",
                 ["username"] = userName,
-                ["password"] = password,
+                ["password"] = password, // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             var context = new TestCommandContext();
@@ -130,15 +130,15 @@ namespace Microsoft.Git.CredentialManager.Tests
         public async Task HostProvider_StoreCredentialAsync_NonEmptyCredential_ExistingCredential_UpdatesCredential()
         {
             const string testUserName = "john.doe";
-            const string testPasswordOld = "letmein123-old";
-            const string testPasswordNew = "letmein123-new";
+            const string testPasswordOld = "letmein123-old"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
+            const string testPasswordNew = "letmein123-new"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string testService = "https://example.com";
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
                 ["host"] = "example.com",
                 ["username"] = testUserName,
-                ["password"] = testPasswordNew,
+                ["password"] = testPasswordNew, // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             var context = new TestCommandContext();
@@ -186,14 +186,14 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             const string userName1 = "john.doe";
             const string userName2 = "alice";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string service = "https://example.com";
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
                 ["host"] = "example.com",
                 ["username"] = userName1,
-                ["password"] = password,
+                ["password"] = password, // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             var context = new TestCommandContext();
@@ -210,14 +210,14 @@ namespace Microsoft.Git.CredentialManager.Tests
         public async Task HostProvider_EraseCredentialAsync_InputUser_CredentialExists_UserMatch_ErasesCredential()
         {
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             const string service = "https://example.com";
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
                 ["host"] = "example.com",
                 ["username"] = userName,
-                ["password"] = password,
+                ["password"] = password, // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
             });
 
             var context = new TestCommandContext();

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HttpRequestExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HttpRequestExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             const string expected = "aGVsbG8tbXlfbmFtZSBpczpqb2huLmRvZTp0aGlzIWlzQVA0U1NXMFJEOiB3aXRoPyBfbG90cyBvZi8gY2hhcnM=";
             const string testUserName = "hello-my_name is:john.doe";
-            const string testPassword = "this!isAP4SSW0RD: with? _lots of/ chars";
+            const string testPassword = "this!isAP4SSW0RD: with? _lots of/ chars"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             TestAddBasicAuthenticationHeader(testUserName, testPassword, expected);
         }
@@ -22,7 +22,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             const string expected = "OmxldG1laW4xMjM=";
             const string testUserName = "";
-            const string testPassword = "letmein123";
+            const string testPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             TestAddBasicAuthenticationHeader(testUserName, testPassword, expected);
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             const string expected = "am9obi5kb2U6";
             const string testUserName = "john.doe";
-            const string testPassword = "";
+            const string testPassword = ""; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             TestAddBasicAuthenticationHeader(testUserName, testPassword, expected);
         }
@@ -42,7 +42,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             const string expected = "Og==";
             const string testUserName = "";
-            const string testPassword = "";
+            const string testPassword = ""; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             TestAddBasicAuthenticationHeader(testUserName, testPassword, expected);
         }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Linux/SecretServiceCollectionTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Linux/SecretServiceCollectionTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Linux
             // Create a service that is guaranteed to be unique
             string service = $"https://example.com/{Guid.NewGuid():N}";
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             try
             {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/MacOS/MacOSKeychainTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/MacOS/MacOSKeychainTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.MacOS
             // Create a service that is guaranteed to be unique
             string service = $"https://example.com/{Guid.NewGuid():N}";
             const string account = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             try
             {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Posix
             string uniqueGuid = Guid.NewGuid().ToString("N");
             string service = $"https://example.com/{uniqueGuid}";
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             string expectedSlug = $"{TestNamespace}/https/example.com/{uniqueGuid}/{userName}.gpg";
             string expectedFilePath = Path.Combine(storeRoot, expectedSlug);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Windows
             string uniqueGuid = Guid.NewGuid().ToString("N");
             string service = $"https://example.com/{uniqueGuid}";
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             string expectedTargetName = $"{TestNamespace}:https://example.com/{uniqueGuid}";
 
@@ -55,7 +55,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Windows
             string uniqueGuid = Guid.NewGuid().ToString("N");
             string service = $"https://example.com/{uniqueGuid}";
             const string userName = "john.doe@auth.com";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             string expectedTargetName = $"{TestNamespace}:https://example.com/{uniqueGuid}";
 
@@ -116,8 +116,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Windows
             string service = $"https://example.com/{uniqueGuid}";
             const string userName1 = "john.doe";
             const string userName2 = "jane.doe";
-            const string password1 = "letmein123";
-            const string password2 = "password123";
+            const string password1 = "letmein123";  // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
+            const string password2 = "password123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             string expectedTargetName1 = $"{TestNamespace}:https://example.com/{uniqueGuid}";
             string expectedTargetName2 = $"{TestNamespace}:https://{userName2}@example.com/{uniqueGuid}";
@@ -167,8 +167,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Interop.Windows
             const string userName1 = "john.doe@auth.com";
             const string userName2 = "jane.doe@auth.com";
             const string escapedUserName2 = "jane.doe_auth.com";
-            const string password1 = "letmein123";
-            const string password2 = "password123";
+            const string password1 = "letmein123";  // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
+            const string password2 = "password123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             string expectedTargetName1 = $"{TestNamespace}:https://example.com/{uniqueGuid}";
             string expectedTargetName2 = $"{TestNamespace}:https://{escapedUserName2}@example.com/{uniqueGuid}";

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/PlaintextCredentialStoreTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/PlaintextCredentialStoreTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             string uniqueGuid = Guid.NewGuid().ToString("N");
             string service = $"https://example.com/{uniqueGuid}";
             const string userName = "john.doe";
-            const string password = "letmein123";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
 
             string expectedSlug = Path.Combine(
                 TestNamespace,


### PR DESCRIPTION
Add the required source suppressions for false positive identification of credentials, raised by the internal CredScan tool.

Most of the identified matches are fake credentials for unit tests. One match was the GitHub OAuth2 application client secret, which per issue #228 valid and an accepted & required 'secret' to be public.

Note to reviewers: yes, sadly the tool does indeed require the `[SuppressMessage...]` C# attribute be _in a comment_ to work... 🤦‍♂️ 