### PR TITLE
Add explicit PAT authentication mode for the GitHub Provider

### DIFF
--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -50,7 +50,7 @@ namespace Atlassian.Bitbucket
                 var cmdArgs = new StringBuilder("userpass");
                 if (!string.IsNullOrWhiteSpace(userName))
                 {
-                    cmdArgs.AppendFormat(" --username {0}", userName);
+                    cmdArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
                 }
 
                 IDictionary<string, string> output = await InvokeHelperAsync(helperPath, cmdArgs.ToString());

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -221,7 +221,8 @@ namespace GitHub.Tests
 
             var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
             ghAuthMock.Setup(x => x.GetAuthenticationAsync(expectedTargetUri, null, It.IsAny<AuthenticationModes>()))
-                      .ReturnsAsync(new AuthenticationPromptResult(new GitCredential(expectedUserName, expectedPassword)));
+                      .ReturnsAsync(new AuthenticationPromptResult(
+                          AuthenticationModes.Basic, new GitCredential(expectedUserName, expectedPassword)));
 
             var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
             ghApiMock.Setup(x => x.CreatePersonalAccessTokenAsync(expectedTargetUri, expectedUserName, expectedPassword, null, It.IsAny<IEnumerable<string>>()))
@@ -270,7 +271,8 @@ namespace GitHub.Tests
 
             var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
             ghAuthMock.Setup(x => x.GetAuthenticationAsync(expectedTargetUri, null, It.IsAny<AuthenticationModes>()))
-                      .ReturnsAsync(new AuthenticationPromptResult(new GitCredential(expectedUserName, expectedPassword)));
+                      .ReturnsAsync(new AuthenticationPromptResult(
+                          AuthenticationModes.Basic, new GitCredential(expectedUserName, expectedPassword)));
             ghAuthMock.Setup(x => x.GetTwoFactorCodeAsync(expectedTargetUri, false))
                       .ReturnsAsync(expectedAuthCode);
 

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -82,8 +82,8 @@ namespace GitHub
                     if ((modes & AuthenticationModes.OAuth) != 0) promptArgs.Append(" --oauth");
                     if ((modes & AuthenticationModes.Pat)   != 0) promptArgs.Append(" --pat");
                 }
-                if (!GitHubHostProvider.IsGitHubDotCom(targetUri)) promptArgs.AppendFormat(" --enterprise-url \"{0}\"", targetUri);
-                if (!string.IsNullOrWhiteSpace(userName)) promptArgs.AppendFormat(" --username \"{0}\"", userName);
+                if (!GitHubHostProvider.IsGitHubDotCom(targetUri)) promptArgs.AppendFormat(" --enterprise-url {0}", QuoteCmdArg(targetUri.ToString()));
+                if (!string.IsNullOrWhiteSpace(userName)) promptArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
 
                 IDictionary<string, string> resultDict = await InvokeHelperAsync(helperPath, promptArgs.ToString(), null);
 

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -35,7 +35,11 @@ namespace GitHub
         /// <summary>
         /// Supported authentication modes for GitHub.com.
         /// </summary>
-        public const AuthenticationModes DotComAuthenticationModes = AuthenticationModes.OAuth;
+        /// <remarks>
+        /// As of 13th November 2020, GitHub.com does not support username/password (basic) authentication to the APIs.
+        /// See https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint for more information.
+        /// </remarks>
+        public const AuthenticationModes DotComAuthenticationModes = AuthenticationModes.OAuth | AuthenticationModes.Pat;
 
         public static class TokenScopes
         {

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/AuthenticationBaseTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/AuthenticationBaseTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.Git.CredentialManager.Authentication;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests.Authentication
+{
+    public class AuthenticationBaseTests
+    {
+        [Theory]
+        [InlineData("foo", "foo")]
+        [InlineData("foo bar", "\"foo bar\"")]
+        [InlineData("foo\nbar", "\"foo\nbar\"")]
+        [InlineData("foo\rbar", "\"foo\rbar\"")]
+        [InlineData("foo\tbar", "\"foo\tbar\"")]
+        [InlineData("foo\" bar", "\"foo\\\" bar\"")]
+        [InlineData("foo\"", "\"foo\\\"\"")]
+        [InlineData("\"foo", "\"\\\"foo\"")]
+        [InlineData("foo\\", "\"foo\\\\\"")]
+        [InlineData("foo\\\"", "\"foo\\\\\\\"\"")]
+        public void AuthenticationBase_QuoteCmdArg(string input, string expected)
+        {
+            string actual = AuthenticationBase.QuoteCmdArg(input);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/EnsureArgumentTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/EnsureArgumentTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class EnsureArgumentTests
+    {
+        [Theory]
+        [InlineData(5, 0, 10, true, true)]
+        [InlineData(0, 0, 10, true, true)]
+        [InlineData(10, 0, 10, true, true)]
+        [InlineData(0, -10, 0, true, true)]
+        [InlineData(-10, -10, 0, true, true)]
+        public void EnsureArgument_InRange_DoesNotThrow(int x, int lower, int upper, bool lowerInc, bool upperInc)
+        {
+            EnsureArgument.InRange(x, nameof(x), lower, upper, lowerInc, upperInc);
+        }
+
+        [Theory]
+        [InlineData(-3, 0, 10, true, true)]
+        [InlineData(13, 0, 10, true, true)]
+        [InlineData(10, 0, 10, true, false)]
+        [InlineData(0, 0, 10, false, true)]
+        [InlineData(-10, -10, 0, false, true)]
+        [InlineData(0, -10, 0, true, false)]
+        public void EnsureArgument_InRange_ThrowsException(int x, int lower, int upper, bool lowerInc, bool upperInc)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => EnsureArgument.InRange(x, nameof(x), lower, upper, lowerInc, upperInc)
+            );
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager.Authentication
@@ -136,6 +138,23 @@ namespace Microsoft.Git.CredentialManager.Authentication
             }
 
             return true;
+        }
+
+        public static string QuoteCmdArg(string str)
+        {
+            char[] needsQuoteChars = {'"', ' ', '\\', '\n', '\r', '\t'};
+            bool needsQuotes = str.Any(x => needsQuoteChars.Contains(x));
+
+            if (!needsQuotes)
+            {
+                return str;
+            }
+
+            // Replace all '\' characters with an escaped '\\', and all '"' with '\"'
+            string escapedStr = str.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+            // Bookend the escaped string with double-quotes '"'
+            return $"\"{escapedStr}\"";
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/EnsureArgument.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/EnsureArgument.cs
@@ -75,5 +75,28 @@ namespace Microsoft.Git.CredentialManager
                 throw new ArgumentOutOfRangeException(name, "Argument must be negative.");
             }
         }
+
+        public static void InRange(int arg, string name, int lower, int upper, bool lowerInclusive = true, bool upperInclusive = true)
+        {
+            if (lowerInclusive && arg < lower)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be greater than or equal to {lower}.");
+            }
+
+            if (!lowerInclusive && arg <= lower)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be strictly greater than {lower}.");
+            }
+
+            if (upperInclusive && arg > upper)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be less than or equal to {upper}.");
+            }
+
+            if (!upperInclusive && arg >= upper)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be strictly less than {upper}.");
+            }
+        }
     }
 }

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/CredentialsControl.xaml
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/CredentialsControl.xaml
@@ -21,7 +21,7 @@
 
     <DockPanel Margin="0,0,0,30" LastChildFill="True">
         <StackPanel DockPanel.Dock="Bottom">
-            <TextBlock HorizontalAlignment="Center" Margin="0,0,0,10">
+            <TextBlock HorizontalAlignment="Center" Margin="0,30,0,10">
                 <Hyperlink
                     Style="{StaticResource BlueHyperlink}"
                     ToolTip="{x:Static local:BitbucketResources.PasswordResetUrl}"

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/OAuthControl.xaml
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/OAuthControl.xaml
@@ -20,7 +20,7 @@
 
     <DockPanel Margin="0,0,0,30" LastChildFill="True">
         <StackPanel DockPanel.Dock="Bottom">
-            <TextBlock HorizontalAlignment="Center" Margin="0,0,0,10">
+            <TextBlock HorizontalAlignment="Center" Margin="0,30,0,10">
                 <Hyperlink
                     Style="{StaticResource BlueHyperlink}"
                     ToolTip="{x:Static local:BitbucketResources.PasswordResetUrl}"

--- a/src/windows/GitHub.UI.Windows/AuthenticationPrompts.cs
+++ b/src/windows/GitHub.UI.Windows/AuthenticationPrompts.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-
+using System;
 using GitHub.UI.Login;
 using Microsoft.Git.CredentialManager.UI;
-using Microsoft.Git.CredentialManager.UI.Controls;
 
 namespace GitHub.UI
 {
@@ -16,11 +15,14 @@ namespace GitHub.UI
 
         private readonly IGui _gui;
 
-        public CredentialPromptResult ShowCredentialPrompt(string enterpriseUrl, bool showBasic, bool showOAuth, ref string username, out string password)
+        public CredentialPromptResult ShowCredentialPrompt(
+            string enterpriseUrl, bool showBasic, bool showOAuth, bool showPat,
+            ref string username, out string password, out string token)
         {
             password = null;
+            token = null;
 
-            var viewModel = new LoginCredentialsViewModel(showBasic, showOAuth)
+            var viewModel = new LoginCredentialsViewModel(showBasic, showOAuth, showPat)
             {
                 GitHubEnterpriseUrl = enterpriseUrl,
                 UsernameOrEmail = username
@@ -28,16 +30,27 @@ namespace GitHub.UI
 
             bool valid = _gui.ShowDialogWindow(viewModel, () => new LoginCredentialsView());
 
-            if (viewModel.UseBrowserLogin)
+            switch (viewModel.SelectedAuthType)
             {
-                return CredentialPromptResult.OAuthAuthentication;
-            }
+                case CredentialPromptResult.BasicAuthentication:
+                    if (valid)
+                    {
+                        username = viewModel.UsernameOrEmail;
+                        password = viewModel.Password.ToUnsecureString();
+                        return CredentialPromptResult.BasicAuthentication;
+                    }
+                    break;
 
-            if (valid)
-            {
-                username = viewModel.UsernameOrEmail;
-                password = viewModel.Password.ToUnsecureString();
-                return CredentialPromptResult.BasicAuthentication;
+                case CredentialPromptResult.OAuthAuthentication:
+                    return CredentialPromptResult.OAuthAuthentication;
+
+                case CredentialPromptResult.PersonalAccessToken:
+                    if (valid)
+                    {
+                        token = viewModel.Token.ToUnsecureString();
+                        return CredentialPromptResult.PersonalAccessToken;
+                    }
+                    break;
             }
 
             return CredentialPromptResult.Cancel;
@@ -59,6 +72,7 @@ namespace GitHub.UI
     {
         BasicAuthentication,
         OAuthAuthentication,
+        PersonalAccessToken,
         Cancel,
     }
 }

--- a/src/windows/GitHub.UI.Windows/Controls/HorizontalShadowDivider.xaml
+++ b/src/windows/GitHub.UI.Windows/Controls/HorizontalShadowDivider.xaml
@@ -7,7 +7,7 @@
              d:DesignWidth="200"
              Width="200"
              Opacity=".6"
-             Height="23.75"
+             Height="13.75"
              Margin="0,0,0,25"
              IsHitTestVisible="False"
              VerticalAlignment="Top">

--- a/src/windows/GitHub.UI.Windows/Login/Login2FaView.xaml
+++ b/src/windows/GitHub.UI.Windows/Login/Login2FaView.xaml
@@ -45,7 +45,7 @@
 
         <StackPanel Orientation="Horizontal"
                     HorizontalAlignment="Center"
-                    Margin="0,40,0,60">
+                    Margin="0,40">
             <Button x:Name="okButton"
                     TabIndex="2"
                     IsDefault="True"

--- a/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml
+++ b/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml
@@ -10,7 +10,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d"
              d:DesignWidth="414"
-             d:DesignHeight="440">
+             d:DesignHeight="520">
 
     <Control.Resources>
         <ResourceDictionary>
@@ -30,7 +30,6 @@
                 <Setter Property="Margin" Value="0" />
             </Style>
             <Style TargetType="{x:Type Border}" x:Key="LoginButtonBorder">
-                <Setter Property="Margin" Value="0,0,0,15" />
                 <Setter Property="HorizontalAlignment" Value="Center" />
             </Style>
             <Style TargetType="{x:Type sharedControls:SecurePasswordBox}" BasedOn="{StaticResource {x:Type sharedControls:SecurePasswordBox}}">
@@ -53,7 +52,7 @@
         </StackPanel>
 
         <DockPanel Margin="30 0">
-            <StackPanel DockPanel.Dock="Top" Margin="0 15 0 0"
+            <StackPanel DockPanel.Dock="Top" Margin="0"
                         Visibility="{Binding GitHubEnterpriseUrl, Converter={StaticResource NonEmptyStringToVisibleConverter}}">
                 <TextBlock TextWrapping="Wrap"
                            HorizontalAlignment="Center"
@@ -65,7 +64,8 @@
                            Text="{Binding GitHubEnterpriseUrl, Mode=OneWay}" />
             </StackPanel>
 
-            <StackPanel DockPanel.Dock="Bottom" Margin="0"
+            <StackPanel DockPanel.Dock="Bottom"
+                        Margin="0 20 0 0"
                         Visibility="{Binding GitHubEnterpriseUrl, Converter={StaticResource NonEmptyStringToVisibleConverter}, ConverterParameter=Invert}">
                 <TextBlock TextWrapping="Wrap"
                                    HorizontalAlignment="Center"
@@ -79,66 +79,81 @@
                 </TextBlock>
             </StackPanel>
 
-            <StackPanel VerticalAlignment="Center" x:Name="dotComloginControlsPanel" Margin="0,0,0,30">
-                <StackPanel>
-                    <StackPanel Visibility="{Binding IsLoginUsingBrowserVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <Border Style="{StaticResource LoginButtonBorder}" Margin="0 16 0 0">
-                                <Button Command="{Binding LoginUsingBrowserCommand}"
-                                        x:Uid="loginLink"
-                                        x:Name="loginLink"
-                                        Style="{DynamicResource GitHubButton}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock>Sign in with your browser</TextBlock>
-                                        <octicons:OcticonImage Icon="link_external" Margin="5 0 0 0"/>
-                                    </StackPanel>
-                                </Button>
-                            </Border>
-                        </StackPanel>
-                    </StackPanel>
+            <StackPanel VerticalAlignment="Center" Margin="0 20 0 0">
+                <Grid>
+                    <Border Style="{StaticResource LoginButtonBorder}" VerticalAlignment="Center"
+                            Visibility="{Binding IsLoginUsingBrowserVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Button Command="{Binding LoginUsingBrowserCommand}"
+                                    x:Uid="loginLink"
+                                    x:Name="loginLink"
+                                    Style="{DynamicResource GitHubButton}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock>Sign in with your browser</TextBlock>
+                                <octicons:OcticonImage Icon="link_external" Margin="5 0 0 0"/>
+                            </StackPanel>
+                        </Button>
+                    </Border>
+                </Grid>
 
-                    <Grid Margin="0 8">
-                        <Grid.Visibility>
-                            <MultiBinding Converter="{StaticResource BooleanAndVisibilityConverter}">
-                                <Binding Path="IsLoginUsingUsernameAndPasswordVisible" />
-                                <Binding Path="IsLoginUsingBrowserVisible" />
-                            </MultiBinding>
-                        </Grid.Visibility>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Rectangle Grid.Column="0" Fill="#FFDDDDDD" Height="1"/>
-                        <TextBlock Grid.Column="1" Margin="8,0,8,4">or</TextBlock>
-                        <Rectangle Grid.Column="2" Fill="#FFDDDDDD" Height="1"/>
-                    </Grid>
+                <Grid Margin="0 14" Visibility="{Binding IsBrowserSeparatorVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Rectangle Grid.Column="0" Fill="#FFDDDDDD" Height="1"/>
+                    <TextBlock Grid.Column="1" Margin="8,0,8,4" VerticalAlignment="Center">or</TextBlock>
+                    <Rectangle Grid.Column="2" Fill="#FFDDDDDD" Height="1"/>
+                </Grid>
 
-                    <StackPanel Visibility="{Binding IsLoginUsingUsernameAndPasswordVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <sharedControls:PromptTextBox Text="{Binding UsernameOrEmail, UpdateSourceTrigger=PropertyChanged, Delay=300}"
+                <StackPanel Visibility="{Binding IsLoginUsingTokenVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <sharedControls:SecurePasswordBox Password="{Binding Token, UpdateSourceTrigger=PropertyChanged, Delay=300, Mode=OneWayToSource}"
+                                                          PromptText="Personal Access Token"
+                                                          x:Name="tokenBox"
+                                                          Localization.Attributes="PromptText (Modifiable Readable Text)"/>
+
+                    <Border Style="{StaticResource LoginButtonBorder}" Margin="0 16 0 0">
+                        <Button Content="Sign in"
+                                    IsDefault="True"
+                                    Command="{Binding LoginUsingTokenCommand}"
+                                    Style="{DynamicResource GitHubButton}"/>
+                    </Border>
+                </StackPanel>
+
+                <Grid Margin="0 14" Visibility="{Binding IsTokenSeparatorVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Rectangle Grid.Column="0" Fill="#FFDDDDDD" Height="1"/>
+                    <TextBlock Grid.Column="1" Margin="8,0,8,4" VerticalAlignment="Center">or</TextBlock>
+                    <Rectangle Grid.Column="2" Fill="#FFDDDDDD" Height="1"/>
+                </Grid>
+
+                <StackPanel Visibility="{Binding IsLoginUsingUsernameAndPasswordVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <sharedControls:PromptTextBox Text="{Binding UsernameOrEmail, UpdateSourceTrigger=PropertyChanged, Delay=300}"
                                                       PromptText="Username or email"
                                                       Margin="0,0,0,10"
                                                       x:Uid="loginBox"
                                                       x:Name="loginBox"
                                                       Localization.Attributes="PromptText (Modifiable Readable Text)"/>
 
-                        <sharedControls:SecurePasswordBox Password="{Binding Password, UpdateSourceTrigger=PropertyChanged, Delay=300, Mode=OneWayToSource}"
+                    <sharedControls:SecurePasswordBox Password="{Binding Password, UpdateSourceTrigger=PropertyChanged, Delay=300, Mode=OneWayToSource}"
                                                           PromptText="Password"
                                                           x:Uid="passwordBox"
                                                           x:Name="passwordBox"
                                                           Localization.Attributes="PromptText (Modifiable Readable Text)"/>
 
-                        <Border Style="{StaticResource LoginButtonBorder}" Margin="0 16 0 0">
-                            <Button Content="Sign in"
+                    <Border Style="{StaticResource LoginButtonBorder}" Margin="0 16 0 0">
+                        <Button Content="Sign in"
                                         IsDefault="True"
                                         Command="{Binding LoginUsingUsernameAndPasswordCommand}"
                                         x:Uid="dotComLogInButton"
                                         Style="{DynamicResource GitHubButton}"/>
-                        </Border>
-                    </StackPanel>
+                    </Border>
                 </StackPanel>
             </StackPanel>
         </DockPanel>
-
     </DockPanel>
 </UserControl>

--- a/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml.cs
+++ b/src/windows/GitHub.UI.Windows/Login/LoginCredentialsView.xaml.cs
@@ -31,7 +31,15 @@ namespace GitHub.UI.Login
                 return;
             }
 
-            if (ViewModel.IsLoginUsingUsernameAndPasswordVisible)
+            if (ViewModel.IsLoginUsingBrowserVisible)
+            {
+                loginLink.Focus();
+            }
+            else if (ViewModel.IsLoginUsingTokenVisible)
+            {
+                tokenBox.Focus();
+            }
+            else if (ViewModel.IsLoginUsingUsernameAndPasswordVisible)
             {
                 if (string.IsNullOrWhiteSpace(ViewModel.UsernameOrEmail))
                 {
@@ -41,10 +49,6 @@ namespace GitHub.UI.Login
                 {
                     passwordBox.Focus();
                 }
-            }
-            else if (ViewModel.IsLoginUsingBrowserVisible)
-            {
-                loginLink.Focus();
             }
         }
     }

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -29,19 +29,20 @@ namespace GitHub.UI
                     if (StringComparer.OrdinalIgnoreCase.Equals(args[0], "prompt"))
                     {
                         string enterpriseUrl = CommandLineUtils.GetParameter(args, "--enterprise-url");
-                        bool basic = CommandLineUtils.TryGetSwitch(args, "--basic");
-                        bool oauth = CommandLineUtils.TryGetSwitch(args, "--oauth");
+                        bool showAll    = CommandLineUtils.TryGetSwitch(args, "--all");
+                        bool showBasic  = CommandLineUtils.TryGetSwitch(args, "--basic") || showAll;
+                        bool showOAuth  = CommandLineUtils.TryGetSwitch(args, "--oauth") || showAll;
+                        bool showPat    = CommandLineUtils.TryGetSwitch(args, "--pat")   || showAll;
                         string username = CommandLineUtils.GetParameter(args, "--username");
 
-                        if (!basic && !oauth)
+                        if (!showBasic && !showOAuth && !showPat && !showAll)
                         {
                             throw new Exception("at least one authentication mode must be specified");
                         }
 
                         var result = prompts.ShowCredentialPrompt(
-                            enterpriseUrl, basic, oauth,
-                            ref username,
-                            out string password);
+                            enterpriseUrl, showBasic, showOAuth, showPat,
+                            ref username, out string password, out string token);
 
                         switch (result)
                         {
@@ -53,6 +54,11 @@ namespace GitHub.UI
 
                             case CredentialPromptResult.OAuthAuthentication:
                                 resultDict["mode"] = "oauth";
+                                break;
+
+                            case CredentialPromptResult.PersonalAccessToken:
+                                resultDict["mode"] = "pat";
+                                resultDict["pat"] = token;
                                 break;
 
                             case CredentialPromptResult.Cancel:

--- a/src/windows/GitHub.UI.Windows/Styles.xaml
+++ b/src/windows/GitHub.UI.Windows/Styles.xaml
@@ -13,7 +13,6 @@
 
     <Style x:Key="DialogContainerDockPanel" TargetType="DockPanel">
         <Setter Property="LastChildFill" Value="True" />
-        <Setter Property="Margin" Value="0,0,0,30" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FocusManager.IsFocusScope" Value="True" />
     </Style>

--- a/src/windows/GitHub.UI.Windows/Tester.xaml
+++ b/src/windows/GitHub.UI.Windows/Tester.xaml
@@ -9,10 +9,33 @@
         UseLayoutRounding="True"
         ResizeMode="NoResize"
         Title="GitHub Authentication Dialog Tester"
-        Height="420"
-        Width="420">
-    <DockPanel>
-        <Button Content="Show Credentials Dialog" Padding="10" Click="ShowCredentials" />
-        <Button Content="Show Authentication Code Dialog" Padding="10" Click="ShowAuthenticationCode" />
+        Height="230"
+        Width="580">
+    <DockPanel Margin="5">
+        <StackPanel DockPanel.Dock="Right" Margin="10 0 0 0">
+            <Button Content="Show Credentials Dialog" Padding="10" Click="ShowCredentials" />
+            <Button Content="Show Authentication Code Dialog" Padding="10" Click="ShowAuthenticationCode" />
+        </StackPanel>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Label Grid.Row="0" Grid.Column="0" Content="Enterprise URL"/>
+            <TextBox Grid.Row="0" Grid.Column="1" x:Name="enterpriseUrl"/>
+            <Label Grid.Row="1" Grid.Column="0" Content="Username"/>
+            <TextBox Grid.Row="1" Grid.Column="1" x:Name="username"/>
+            <Label Grid.Row="2" Grid.Column="0" Content="Auth Modes"/>
+            <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal"  VerticalAlignment="Center">
+                <CheckBox Content="OAuth" x:Name="useOAuth" Margin="0 0 10 0"/>
+                <CheckBox Content="Pat" x:Name="usePat" Margin="0 0 10 0"/>
+                <CheckBox Content="Basic" x:Name="useBasic"/>
+            </StackPanel>
+        </Grid>
     </DockPanel>
 </Window>

--- a/src/windows/GitHub.UI.Windows/Tester.xaml.cs
+++ b/src/windows/GitHub.UI.Windows/Tester.xaml.cs
@@ -23,7 +23,17 @@ namespace GitHub.UI
 
         private void ShowCredentials(object sender, RoutedEventArgs e)
         {
-            var model = new LoginCredentialsViewModel(true, true);
+            var model = new LoginCredentialsViewModel(useBasic.IsChecked ?? false, useOAuth.IsChecked ?? false, usePat.IsChecked ?? false);
+            if (!string.IsNullOrWhiteSpace(enterpriseUrl.Text))
+            {
+                model.GitHubEnterpriseUrl = enterpriseUrl.Text;
+            }
+
+            if (!string.IsNullOrWhiteSpace(username.Text))
+            {
+                model.UsernameOrEmail = username.Text;
+            }
+
             var view = new LoginCredentialsView();
             var window = new DialogWindow(model, view);
             Gui.ShowDialog(window, Handle);

--- a/src/windows/Shared.UI.Windows/Controls/DialogWindow.xaml
+++ b/src/windows/Shared.UI.Windows/Controls/DialogWindow.xaml
@@ -5,9 +5,10 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
         xmlns:viewModels="clr-namespace:Microsoft.Git.CredentialManager.UI.ViewModels"
         Width="414"
-        Height="460"
-        MinWidth="414"
-        MinHeight="460"
+        SizeToContent="Height"
+        MinHeight="320"
+        MaxWidth="414"
+        MaxHeight="520"
         Background="{DynamicResource WindowPanelBrush}"
         Foreground="{DynamicResource WindowPanelTextBrush}"
         FontFamily="Segoe UI"
@@ -120,7 +121,7 @@
 
             </DockPanel>
 
-            <ContentControl x:Name="ContentHolder" Margin="30,30,30,0"/>
+            <ContentControl x:Name="ContentHolder" Margin="30"/>
         </DockPanel>
     </Border>
 </Window>


### PR DESCRIPTION
Add an authentication mode to the GitHub provider whereby a Personal Access Token can be returned directly, as generated by a user manually. This mode is always supported on both GitHub.com and GHES, as it should always be possible to create a PAT manually for whatever access is required.

This functionality sort-of already exists, but requires a few things:
1. The users needs to enable basic auth for GHES, or force override the authentication modes to allow basic auth (`GCM_GITHUB_AUTHMODES=basic`)
2. Know to enter their username, and the PAT as the password in a basic auth prompt

We update the WPF-based Windows GUI for GitHub authentication prompts to support the third authentication mode "PAT". There are also make some changes to how the dialog window is sized to scale with the size of the content (mins and maxes included), which may now vary in the extreme from all three auth options, to just one.

![image](https://user-images.githubusercontent.com/5658207/100254635-760b6900-2f3a-11eb-96a3-0f933c428bd7.png)
_GitHub.com with OAuth and PAT options_

![image](https://user-images.githubusercontent.com/5658207/100254683-84f21b80-2f3a-11eb-85c0-e341c2e2ea0f.png)
_GHES with basic and PAT options_

![image](https://user-images.githubusercontent.com/5658207/100254708-8e7b8380-2f3a-11eb-965a-f7bf3e318a7c.png)
_GHES with the PAT option only_

![image](https://user-images.githubusercontent.com/5658207/100254735-9804eb80-2f3a-11eb-858d-9f07bb99d043.png)
_A scenario where all options are presented. Currently not possible due to GHES not supporting GCM Core via OAuth, and GitHub.com no longer supporting basic auth - showing to prove the case should this happen such as by user override, or in future development._

Fixes #222 