### PR TITLE
Detect github.my-company-server.com as GitHub

### DIFF
--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -39,6 +39,8 @@ namespace GitHub.Tests
         [InlineData("https://foogithub.com", false)] // No support of non github.com domains.
         [InlineData("https://api.github.com", false)] // No support of github.com subdomains.
         [InlineData("https://gist.github.com", true)] // Except gists.
+        [InlineData("https://GiST.GitHub.Com", true)]
+        [InlineData("https://GitHub.Com", true)]
 
         [InlineData("http://github.my-company-server.com", true)]
         [InlineData("http://gist.github.my-company-server.com", true)]
@@ -50,6 +52,8 @@ namespace GitHub.Tests
         [InlineData("https://foogithub.my-company-server.com", false)]
         [InlineData("https://api.github.my-company-server.com", false)]
         [InlineData("https://gist.github.my.company.server.com", true)]
+        [InlineData("https://GitHub.My-Company-Server.Com", true)]
+        [InlineData("https://GiST.GitHub.My-Company-Server.com", true)]
         public void GitHubHostProvider_IsSupported(string uriString, bool expected)
         {
             Uri uri = new Uri(uriString);
@@ -61,7 +65,7 @@ namespace GitHub.Tests
             });
 
             // Ensure nothing got lost during transformation
-            Assert.Equal(uriString, input.Protocol + "://" + input.Host);
+            Assert.Equal(uriString.ToLower(), input.Protocol + "://" + input.Host);
 
             var provider = new GitHubHostProvider(new TestCommandContext());
             Assert.Equal(expected, provider.IsSupported(input));
@@ -70,11 +74,17 @@ namespace GitHub.Tests
 
         [Theory]
         [InlineData("https://github.com", "https://github.com")]
+        [InlineData("https://GitHub.Com", "https://github.com")]
         [InlineData("https://gist.github.com", "https://github.com")]
+        [InlineData("https://GiST.GitHub.Com", "https://github.com")]
         [InlineData("https://github.my-company-server.com", "https://github.my-company-server.com")]
+        [InlineData("https://GitHub.My-Company-Server.Com", "https://github.my-company-server.com")]
         [InlineData("https://gist.github.my-company-server.com", "https://github.my-company-server.com")]
+        [InlineData("https://GiST.GitHub.My-Company-Server.Com", "https://github.my-company-server.com")]
         [InlineData("https://github.my.company.server.com", "https://github.my.company.server.com")]
+        [InlineData("https://GitHub.My.Company.Server.Com", "https://github.my.company.server.com")]
         [InlineData("https://gist.github.my.company.server.com", "https://github.my.company.server.com")]
+        [InlineData("https://GiST.GitHub.My.Company.Server.Com", "https://github.my.company.server.com")]
         public void GitHubHostProvider_GetCredentialServiceUrl(string uriString, string expectedService)
         {
             Uri uri = new Uri(uriString);
@@ -86,7 +96,7 @@ namespace GitHub.Tests
             });
 
             // Ensure nothing got lost during transformation
-            Assert.Equal(uriString, input.Protocol + "://" + input.Host);
+            Assert.Equal(uriString.ToLower(), input.Protocol + "://" + input.Host);
 
             var provider = new GitHubHostProvider(new TestCommandContext());
             Assert.Equal(expectedService, provider.GetServiceName(input));
@@ -96,8 +106,11 @@ namespace GitHub.Tests
         [Theory]
         [InlineData("https://example.com", "oauth", AuthenticationModes.OAuth)]
         [InlineData("https://github.com", "NOT-A-REAL-VALUE", GitHubConstants.DotComAuthenticationModes)]
+        [InlineData("https://GitHub.Com", "NOT-A-REAL-VALUE", GitHubConstants.DotComAuthenticationModes)]
         [InlineData("https://github.com", "none", GitHubConstants.DotComAuthenticationModes)]
+        [InlineData("https://GitHub.Com", "none", GitHubConstants.DotComAuthenticationModes)]
         [InlineData("https://github.com", null, GitHubConstants.DotComAuthenticationModes)]
+        [InlineData("https://GitHub.Com", null, GitHubConstants.DotComAuthenticationModes)]
         public async Task GitHubHostProvider_GetSupportedAuthenticationModes(string uriString, string gitHubAuthModes, AuthenticationModes expectedModes)
         {
             var targetUri = new Uri(uriString);

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -30,10 +30,26 @@ namespace GitHub.Tests
         // show a helpful error message in the call to `GenerateCredentialAsync` instead.
         [InlineData("http://github.com", true)]
         [InlineData("http://gist.github.com", true)]
-        [InlineData("https://github.com", true)]
-        [InlineData("https://gist.github.com", true)]
         [InlineData("ssh://github.com", false)]
         [InlineData("https://example.com", false)]
+
+        [InlineData("https://github.com", true)]
+        [InlineData("https://github.con", false)] // No support of phony similar tld.
+        [InlineData("https://gist.github.con", false)] // No support of phony similar tld.
+        [InlineData("https://foogithub.com", false)] // No support of non github.com domains.
+        [InlineData("https://api.github.com", false)] // No support of github.com subdomains.
+        [InlineData("https://gist.github.com", true)] // Except gists.
+
+        [InlineData("http://github.my-company-server.com", true)]
+        [InlineData("http://gist.github.my-company-server.com", true)]
+        [InlineData("https://github.my-company-server.com", true)]
+        [InlineData("https://gist.github.my-company-server.com", true)]
+        [InlineData("https://gist.my-company-server.com", false)]
+        [InlineData("https://my-company-server.com", false)]
+        [InlineData("https://github.my.company.server.com", true)]
+        [InlineData("https://foogithub.my-company-server.com", false)]
+        [InlineData("https://api.github.my-company-server.com", false)]
+        [InlineData("https://gist.github.my.company.server.com", true)]
         public void GitHubHostProvider_IsSupported(string uriString, bool expected)
         {
             Uri uri = new Uri(uriString);
@@ -55,6 +71,10 @@ namespace GitHub.Tests
         [Theory]
         [InlineData("https://github.com", "https://github.com")]
         [InlineData("https://gist.github.com", "https://github.com")]
+        [InlineData("https://github.my-company-server.com", "https://github.my-company-server.com")]
+        [InlineData("https://gist.github.my-company-server.com", "https://github.my-company-server.com")]
+        [InlineData("https://github.my.company.server.com", "https://github.my.company.server.com")]
+        [InlineData("https://gist.github.my.company.server.com", "https://github.my.company.server.com")]
         public void GitHubHostProvider_GetCredentialServiceUrl(string uriString, string expectedService)
         {
             Uri uri = new Uri(uriString);

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -28,44 +28,39 @@ namespace GitHub.Tests
         [Theory]
         // We report that we support unencrypted HTTP here so that we can fail and
         // show a helpful error message in the call to `GenerateCredentialAsync` instead.
-        [InlineData("http://github.com", true)]
-        [InlineData("http://gist.github.com", true)]
-        [InlineData("ssh://github.com", false)]
-        [InlineData("https://example.com", false)]
+        [InlineData("http", "github.com", true)]
+        [InlineData("http", "gist.github.com", true)]
+        [InlineData("ssh", "github.com", false)]
+        [InlineData("https", "example.com", false)]
 
-        [InlineData("https://github.com", true)]
-        [InlineData("https://github.con", false)] // No support of phony similar tld.
-        [InlineData("https://gist.github.con", false)] // No support of phony similar tld.
-        [InlineData("https://foogithub.com", false)] // No support of non github.com domains.
-        [InlineData("https://api.github.com", false)] // No support of github.com subdomains.
-        [InlineData("https://gist.github.com", true)] // Except gists.
-        [InlineData("https://GiST.GitHub.Com", true)]
-        [InlineData("https://GitHub.Com", true)]
+        [InlineData("https", "github.com", true)]
+        [InlineData("https", "github.con", false)] // No support of phony similar tld.
+        [InlineData("https", "gist.github.con", false)] // No support of phony similar tld.
+        [InlineData("https", "foogithub.com", false)] // No support of non github.com domains.
+        [InlineData("https", "api.github.com", false)] // No support of github.com subdomains.
+        [InlineData("https", "gist.github.com", true)] // Except gists.
+        [InlineData("https", "GiST.GitHub.Com", true)]
+        [InlineData("https", "GitHub.Com", true)]
 
-        [InlineData("http://github.my-company-server.com", true)]
-        [InlineData("http://gist.github.my-company-server.com", true)]
-        [InlineData("https://github.my-company-server.com", true)]
-        [InlineData("https://gist.github.my-company-server.com", true)]
-        [InlineData("https://gist.my-company-server.com", false)]
-        [InlineData("https://my-company-server.com", false)]
-        [InlineData("https://github.my.company.server.com", true)]
-        [InlineData("https://foogithub.my-company-server.com", false)]
-        [InlineData("https://api.github.my-company-server.com", false)]
-        [InlineData("https://gist.github.my.company.server.com", true)]
-        [InlineData("https://GitHub.My-Company-Server.Com", true)]
-        [InlineData("https://GiST.GitHub.My-Company-Server.com", true)]
-        public void GitHubHostProvider_IsSupported(string uriString, bool expected)
+        [InlineData("http", "github.my-company-server.com", true)]
+        [InlineData("http", "gist.github.my-company-server.com", true)]
+        [InlineData("https", "github.my-company-server.com", true)]
+        [InlineData("https", "gist.github.my-company-server.com", true)]
+        [InlineData("https", "gist.my-company-server.com", false)]
+        [InlineData("https", "my-company-server.com", false)]
+        [InlineData("https", "github.my.company.server.com", true)]
+        [InlineData("https", "foogithub.my-company-server.com", false)]
+        [InlineData("https", "api.github.my-company-server.com", false)]
+        [InlineData("https", "gist.github.my.company.server.com", true)]
+        [InlineData("https", "GitHub.My-Company-Server.Com", true)]
+        [InlineData("https", "GiST.GitHub.My-Company-Server.com", true)]
+        public void GitHubHostProvider_IsSupported(string protocol, string host, bool expected)
         {
-            Uri uri = new Uri(uriString);
-
             var input = new InputArguments(new Dictionary<string, string>
             {
-                ["protocol"] = uri.Scheme,
-                ["host"] = uri.Host,
+                ["protocol"] = protocol,
+                ["host"] = host,
             });
-
-            // Ensure nothing got lost during transformation
-            Assert.Equal(uriString.ToLower(), input.Protocol + "://" + input.Host);
 
             var provider = new GitHubHostProvider(new TestCommandContext());
             Assert.Equal(expected, provider.IsSupported(input));
@@ -73,30 +68,25 @@ namespace GitHub.Tests
 
 
         [Theory]
-        [InlineData("https://github.com", "https://github.com")]
-        [InlineData("https://GitHub.Com", "https://github.com")]
-        [InlineData("https://gist.github.com", "https://github.com")]
-        [InlineData("https://GiST.GitHub.Com", "https://github.com")]
-        [InlineData("https://github.my-company-server.com", "https://github.my-company-server.com")]
-        [InlineData("https://GitHub.My-Company-Server.Com", "https://github.my-company-server.com")]
-        [InlineData("https://gist.github.my-company-server.com", "https://github.my-company-server.com")]
-        [InlineData("https://GiST.GitHub.My-Company-Server.Com", "https://github.my-company-server.com")]
-        [InlineData("https://github.my.company.server.com", "https://github.my.company.server.com")]
-        [InlineData("https://GitHub.My.Company.Server.Com", "https://github.my.company.server.com")]
-        [InlineData("https://gist.github.my.company.server.com", "https://github.my.company.server.com")]
-        [InlineData("https://GiST.GitHub.My.Company.Server.Com", "https://github.my.company.server.com")]
-        public void GitHubHostProvider_GetCredentialServiceUrl(string uriString, string expectedService)
+        [InlineData("https", "github.com", "https://github.com")]
+        [InlineData("https", "GitHub.Com", "https://github.com")]
+        [InlineData("https", "gist.github.com", "https://github.com")]
+        [InlineData("https", "GiST.GitHub.Com", "https://github.com")]
+        [InlineData("https", "github.my-company-server.com", "https://github.my-company-server.com")]
+        [InlineData("https", "GitHub.My-Company-Server.Com", "https://github.my-company-server.com")]
+        [InlineData("https", "gist.github.my-company-server.com", "https://github.my-company-server.com")]
+        [InlineData("https", "GiST.GitHub.My-Company-Server.Com", "https://github.my-company-server.com")]
+        [InlineData("https", "github.my.company.server.com", "https://github.my.company.server.com")]
+        [InlineData("https", "GitHub.My.Company.Server.Com", "https://github.my.company.server.com")]
+        [InlineData("https", "gist.github.my.company.server.com", "https://github.my.company.server.com")]
+        [InlineData("https", "GiST.GitHub.My.Company.Server.Com", "https://github.my.company.server.com")]
+        public void GitHubHostProvider_GetCredentialServiceUrl(string protocol, string host, string expectedService)
         {
-            Uri uri = new Uri(uriString);
-
             var input = new InputArguments(new Dictionary<string, string>
             {
-                ["protocol"] = uri.Scheme,
-                ["host"] = uri.Host,
+                ["protocol"] = protocol,
+                ["host"] = host,
             });
-
-            // Ensure nothing got lost during transformation
-            Assert.Equal(uriString.ToLower(), input.Protocol + "://" + input.Host);
 
             var provider = new GitHubHostProvider(new TestCommandContext());
             Assert.Equal(expectedService, provider.GetServiceName(input));

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -73,12 +73,19 @@ namespace GitHub
             string[] domains = hostName.Split(new char[] { '.' });
 
             // github[.subdomain].domain.tld
-            if (domains.Length >= 3 && domains[0] == "github")
+            if (domains.Length >= 3 &&
+                StringComparer.OrdinalIgnoreCase.Equals(domains[0], "github"))
+            {
                 return true;
+            }
 
             // gist.github[.subdomain].domain.tld
-            if (domains.Length >= 4 && domains[0] == "gist" && domains[1] == "github")
+            if (domains.Length >= 4 &&
+                StringComparer.OrdinalIgnoreCase.Equals(domains[0], "gist") &&
+                StringComparer.OrdinalIgnoreCase.Equals(domains[1], "github"))
+            {
                 return true;
+            }
 
             return false;
         }
@@ -286,7 +293,7 @@ namespace GitHub
             // Credentials for these repositories are the same as the one stored with "github.com".
             // Same for gist.github[.subdomain].domain.tld. The general form was already checked via IsSupported.
             int firstDot = uri.DnsSafeHost.IndexOf(".");
-            if (uri.DnsSafeHost.Substring(0, firstDot).Equals("gist", StringComparison.OrdinalIgnoreCase)) {
+            if (firstDot > -1 && uri.DnsSafeHost.Substring(0, firstDot).Equals("gist", StringComparison.OrdinalIgnoreCase)) {
                 return new Uri("https://" + uri.DnsSafeHost.Substring(firstDot+1));
             }
 


### PR DESCRIPTION
Detect github[.subdomain].domain.tld as GitHub in order to better support GitHub Enterprise Server.
Prior to this patch a manual configuration of https://github.com/microsoft/Git-Credential-Manager-Core/blob/master/docs/configuration.md#credentialprovider is required.
Closes #219 

Unfortunately it's unclear whether this will catch any significant portion of such setups as the urls are not known. But it does seem reasonable and it does catch my use case :-)