### PR TITLE
Remove use of box drawing characters in warning output

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Git.CredentialManager
             if (!_settings.IsCertificateVerificationEnabled)
             {
                 _trace.WriteLine("TLS certificate verification has been disabled.");
-                _streams.Error.WriteLine("warning: ┌──────────────── SECURITY WARNING ───────────────┐");
-                _streams.Error.WriteLine("warning: │ TLS certificate verification has been disabled! │");
-                _streams.Error.WriteLine("warning: └─────────────────────────────────────────────────┘");
+                _streams.Error.WriteLine("warning: ----------------- SECURITY WARNING ----------------");
+                _streams.Error.WriteLine("warning: | TLS certificate verification has been disabled! |");
+                _streams.Error.WriteLine("warning: ---------------------------------------------------");
                 _streams.Error.WriteLine($"warning: HTTPS connections may not be secure. See {Constants.HelpUrls.GcmTlsVerification} for more information.");
 
 #if NETFRAMEWORK

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -277,18 +277,18 @@ namespace Microsoft.Git.CredentialManager
                      * We've slightly changed the behaviour of this setting in GCM Core to essentially
                      * remove the 'always' option. The table below outlines the changes:
                      *
-                     * ┌──────────┬───────────────────────────┬────────────────────┐
-                     * │ Value(s) │ Old meaning               │ New meaning        │
-                     * ┝━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━┥
-                     * │ auto     │ Prompt if required        │ [unchanged]        │
-                     * ├──────────┼───────────────────────────┼────────────────────┤
-                     * │ never    │ Never prompt ─ fail if    │ [unchanged]        │
-                     * │ false    │ interaction is required   │                    │
-                     * ├──────────┼───────────────────────────┼────────────────────┤
-                     * │ always   │ Always prompt ─ don't use │ Prompt if required │
-                     * │ force    │ cached credentials        │                    │
-                     * │ true     │                           │                    │
-                     * └──────────┴───────────────────────────┴────────────────────┘
+                     * -------------------------------------------------------------
+                     * | Value(s) | Old meaning               | New meaning        |
+                     * |-----------------------------------------------------------|
+                     * | auto     | Prompt if required        | [unchanged]        |
+                     * |-----------------------------------------------------------|
+                     * | never    | Never prompt ─ fail if    | [unchanged]        |
+                     * | false    | interaction is required   |                    |
+                     * |-----------------------------------------------------------|
+                     * | always   | Always prompt ─ don't use | Prompt if required |
+                     * | force    | cached credentials        |                    |
+                     * | true     |                           |                    |
+                     * -------------------------------------------------------------
                      */
                     if (StringComparer.OrdinalIgnoreCase.Equals("never", value))
                     {


### PR DESCRIPTION
Remove the use of box drawing characters in the warning output messages for TLS verification being disabled. Some systems (looking at you Windows) struggle with such characters. Replace them with simpler characters.

Whilst we're at it, also remove box drawing characters from code comments. Even though these aren't a problem, let's just do it for consistency.