### PR TITLE
Ensure the /usr/local/bin directory exists on install

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/osx/Installer.Mac/scripts/postinstall
+++ b/src/osx/Installer.Mac/scripts/postinstall
@@ -27,6 +27,7 @@ then
 fi
 
 # Create symlink to GCM in /usr/local/bin
+mkdir -p /usr/local/bin
 /bin/ln -Fs "$INSTALL_DESTINATION/git-credential-manager-core" /usr/local/bin/git-credential-manager-core
 
 # Configure GCM for the current user


### PR DESCRIPTION
Ensure the /usr/local/bin directory exists on macOS installations before we create the symlink for GCM Core. The directory does not exist on freshly installed Macs.

Fixes #256