### PR TITLE
Ensure the PAT option is always offered for GHES instances

### DIFF
--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -121,10 +121,10 @@ namespace GitHub.Tests
 
 
         [Theory]
-        [InlineData("https://example.com", null, "0.1", false, AuthenticationModes.None)]
-        [InlineData("https://example.com", null, "0.1", true, AuthenticationModes.Basic)]
-        [InlineData("https://example.com", null, "100.0", false, AuthenticationModes.OAuth)]
-        [InlineData("https://example.com", null, "100.0", true, AuthenticationModes.Basic | AuthenticationModes.OAuth)]
+        [InlineData("https://example.com", null, "0.1", false, AuthenticationModes.Pat)]
+        [InlineData("https://example.com", null, "0.1", true, AuthenticationModes.Basic | AuthenticationModes.Pat)]
+        [InlineData("https://example.com", null, "100.0", false, AuthenticationModes.OAuth | AuthenticationModes.Pat)]
+        [InlineData("https://example.com", null, "100.0", true, AuthenticationModes.All)]
         public async Task GitHubHostProvider_GetSupportedAuthenticationModes_WithMetadata(string uriString, string gitHubAuthModes,
             string installedVersion, bool verifiablePasswordAuthentication, AuthenticationModes expectedModes)
         {

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -243,7 +243,7 @@ namespace GitHub
             {
                 GitHubMetaInfo metaInfo = await _gitHubApi.GetMetaInfoAsync(targetUri);
 
-                var modes = AuthenticationModes.None;
+                var modes = AuthenticationModes.Pat;
                 if (metaInfo.VerifiablePasswordAuthentication)
                 {
                     modes |= AuthenticationModes.Basic;


### PR DESCRIPTION
Ensure the Personal Access Token authentication mode is always offered for GitHub Enterprise Server instances.