### PR TITLE
Auto-detect more (on-prem) providers using a simple HTTP query

### DIFF
--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication.OAuth;
@@ -53,7 +54,17 @@ namespace Atlassian.Bitbucket
             return (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http") ||
                     StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "https")) &&
                    hostName.EndsWith(BitbucketConstants.BitbucketBaseUrlHost, StringComparison.OrdinalIgnoreCase);
+        }
 
+        public bool IsSupported(HttpResponseMessage response)
+        {
+            if (response is null)
+            {
+                return false;
+            }
+
+            // TODO: identify Bitbucket on-prem instances from the HTTP response
+            return false;
         }
 
         public async Task<ICredential> GetCredentialAsync(InputArguments input)

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -17,13 +17,12 @@ namespace Microsoft.Git.CredentialManager
             using (var context = new CommandContext())
             using (var app = new Application(context, appPath))
             {
-                // Register all supported host providers
-                app.RegisterProviders(
-                    new AzureReposHostProvider(context),
-                    new BitbucketHostProvider(context),
-                    new GitHubHostProvider(context),
-                    new GenericHostProvider(context)
-                );
+                // Register all supported host providers at the normal priority.
+                // The generic provider should never win against a more specific one, so register it with low priority.
+                app.RegisterProvider(new AzureReposHostProvider(context), HostProviderPriority.Normal);
+                app.RegisterProvider(new BitbucketHostProvider(context),  HostProviderPriority.Normal);
+                app.RegisterProvider(new GitHubHostProvider(context),     HostProviderPriority.Normal);
+                app.RegisterProvider(new GenericHostProvider(context),    HostProviderPriority.Low);
 
                 // Run!
                 int exitCode = app.RunAsync(args)

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication.OAuth;
@@ -88,6 +89,17 @@ namespace GitHub
             }
 
             return false;
+        }
+
+        public override bool IsSupported(HttpResponseMessage response)
+        {
+            if (response is null)
+            {
+                return false;
+            }
+
+            // Look for a known GitHub.com/GHES header
+            return response.Headers.Contains("X-GitHub-Request-Id");
         }
 
         public override string GetServiceName(InputArguments input)

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication;
@@ -58,6 +59,12 @@ namespace Microsoft.AzureRepos
                    UriHelpers.IsAzureDevOpsHost(hostName);
         }
 
+        public bool IsSupported(HttpResponseMessage response)
+        {
+            // Azure DevOps Server (TFS) is handled by the generic provider, which supports basic auth, and WIA detection.
+            return false;
+        }
+
         public async Task<ICredential> GetCredentialAsync(InputArguments input)
         {
             string service = GetServiceName(input);
@@ -83,7 +90,7 @@ namespace Microsoft.AzureRepos
             return credential;
         }
 
-        public virtual Task StoreCredentialAsync(InputArguments input)
+        public Task StoreCredentialAsync(InputArguments input)
         {
             string service = GetServiceName(input);
 

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
             var mockProvider = new Mock<IHostProvider>();
             var mockHostRegistry = new Mock<IHostProviderRegistry>();
 
-            mockHostRegistry.Setup(x => x.GetProvider(It.IsAny<InputArguments>()))
-                .Returns(mockProvider.Object)
+            mockHostRegistry.Setup(x => x.GetProviderAsync(It.IsAny<InputArguments>()))
+                .ReturnsAsync(mockProvider.Object)
                 .Verifiable();
 
             mockProvider.Setup(x => x.IsSupported(It.IsAny<InputArguments>()))
@@ -58,8 +58,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
             var mockSettings = new Mock<ISettings>();
             var mockHostRegistry = new Mock<IHostProviderRegistry>();
 
-            mockHostRegistry.Setup(x => x.GetProvider(It.IsAny<InputArguments>()))
-                .Returns(mockProvider.Object);
+            mockHostRegistry.Setup(x => x.GetProviderAsync(It.IsAny<InputArguments>()))
+                .ReturnsAsync(mockProvider.Object);
 
             string standardIn = "protocol=test\nhost=example.com\npath=a/b/c\n\n";
             TextReader standardInReader = new StringReader(standardIn);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Tests.Objects;
 using Moq;
 using Xunit;
@@ -39,11 +40,11 @@ namespace Microsoft.Git.CredentialManager.Tests
             var registry = new HostProviderRegistry(context);
             var input = new InputArguments(new Dictionary<string, string>());
 
-            Assert.Throws<Exception>(() => registry.GetProvider(input));
+            Assert.ThrowsAsync<Exception>(() => registry.GetProviderAsync(input));
         }
 
         [Fact]
-        public void HostProviderRegistry_GetProvider_Auto_HasProviders_ReturnsSupportedProvider()
+        public async Task HostProviderRegistry_GetProvider_Auto_HasProviders_ReturnsSupportedProvider()
         {
             var context = new TestCommandContext();
             var registry = new HostProviderRegistry(context);
@@ -58,13 +59,13 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
-            IHostProvider result = registry.GetProvider(input);
+            IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider2Mock.Object, result);
         }
 
         [Fact]
-        public void HostProviderRegistry_GetProvider_Auto_MultipleValidProviders_ReturnsFirstRegistered()
+        public async Task HostProviderRegistry_GetProvider_Auto_MultipleValidProviders_ReturnsFirstRegistered()
         {
             var context = new TestCommandContext();
             var registry = new HostProviderRegistry(context);
@@ -79,13 +80,13 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
-            IHostProvider result = registry.GetProvider(input);
+            IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider1Mock.Object, result);
         }
 
         [Fact]
-        public void HostProviderRegistry_GetProvider_ProviderSpecified_ReturnsProvider()
+        public async Task HostProviderRegistry_GetProvider_ProviderSpecified_ReturnsProvider()
         {
             var context = new TestCommandContext
             {
@@ -106,13 +107,13 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
-            IHostProvider result = registry.GetProvider(input);
+            IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider3Mock.Object, result);
         }
 
         [Fact]
-        public void HostProviderRegistry_GetProvider_AutoProviderSpecified_ReturnsFirstSupportedProvider()
+        public async Task HostProviderRegistry_GetProvider_AutoProviderSpecified_ReturnsFirstSupportedProvider()
         {
             var context = new TestCommandContext
             {
@@ -133,13 +134,13 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
-            IHostProvider result = registry.GetProvider(input);
+            IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider2Mock.Object, result);
         }
 
         [Fact]
-        public void HostProviderRegistry_GetProvider_UnknownProviderSpecified_ReturnsFirstSupportedProvider()
+        public async Task HostProviderRegistry_GetProvider_UnknownProviderSpecified_ReturnsFirstSupportedProvider()
         {
             var context = new TestCommandContext
             {
@@ -160,13 +161,13 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
-            IHostProvider result = registry.GetProvider(input);
+            IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider2Mock.Object, result);
         }
 
         [Fact]
-        public void HostProviderRegistry_GetProvider_LegacyAuthoritySpecified_ReturnsProvider()
+        public async Task HostProviderRegistry_GetProvider_LegacyAuthoritySpecified_ReturnsProvider()
         {
             var context = new TestCommandContext
             {
@@ -187,13 +188,13 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
-            IHostProvider result = registry.GetProvider(input);
+            IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider2Mock.Object, result);
         }
 
         [Fact]
-        public void HostProviderRegistry_GetProvider_AutoLegacyAuthoritySpecified_ReturnsFirstSupportedProvider()
+        public async Task HostProviderRegistry_GetProvider_AutoLegacyAuthoritySpecified_ReturnsFirstSupportedProvider()
         {
             var context = new TestCommandContext
             {
@@ -214,7 +215,7 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
-            IHostProvider result = registry.GetProvider(input);
+            IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider2Mock.Object, result);
         }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var provider = new Mock<IHostProvider>();
             provider.Setup(x => x.Id).Returns(Constants.ProviderIdAuto);
 
-            Assert.Throws<ArgumentException>(() => registry.Register(provider.Object));
+            Assert.Throws<ArgumentException>(() => registry.Register(provider.Object, HostProviderPriority.Normal));
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Microsoft.Git.CredentialManager.Tests
             var provider = new Mock<IHostProvider>();
             provider.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"foo", Constants.AuthorityIdAuto, "bar"});
 
-            Assert.Throws<ArgumentException>(() => registry.Register(provider.Object));
+            Assert.Throws<ArgumentException>(() => registry.Register(provider.Object, HostProviderPriority.Normal));
         }
 
         [Fact]
@@ -57,7 +57,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
             provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
 
-            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+            registry.Register(provider1Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.Normal);
 
             IHostProvider result = await registry.GetProviderAsync(input);
 
@@ -78,11 +80,39 @@ namespace Microsoft.Git.CredentialManager.Tests
             provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
             provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
 
-            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+            registry.Register(provider1Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.Normal);
 
             IHostProvider result = await registry.GetProviderAsync(input);
 
             Assert.Same(provider1Mock.Object, result);
+        }
+
+        [Fact]
+        public async Task HostProviderRegistry_GetProvider_Auto_MultipleValidProvidersMultipleLevels_ReturnsFirstHighestRegistered()
+        {
+            var context = new TestCommandContext();
+            var registry = new HostProviderRegistry(context);
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            var provider4Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider4Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+
+            registry.Register(provider1Mock.Object, HostProviderPriority.Low);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.High);
+            registry.Register(provider4Mock.Object, HostProviderPriority.Low);
+
+            IHostProvider result = await registry.GetProviderAsync(input);
+
+            Assert.Same(provider3Mock.Object, result);
         }
 
         [Fact]
@@ -105,7 +135,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             provider3Mock.Setup(x => x.Id).Returns("provider3");
             provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
 
-            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+            registry.Register(provider1Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.Normal);
 
             IHostProvider result = await registry.GetProviderAsync(input);
 
@@ -132,7 +164,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             provider3Mock.Setup(x => x.Id).Returns("provider3");
             provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
 
-            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+            registry.Register(provider1Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.Normal);
 
             IHostProvider result = await registry.GetProviderAsync(input);
 
@@ -159,7 +193,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             provider3Mock.Setup(x => x.Id).Returns("provider3");
             provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
 
-            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+            registry.Register(provider1Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.Normal);
 
             IHostProvider result = await registry.GetProviderAsync(input);
 
@@ -186,7 +222,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             provider3Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityD"});
             provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
 
-            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+            registry.Register(provider1Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.Normal);
 
             IHostProvider result = await registry.GetProviderAsync(input);
 
@@ -213,7 +251,9 @@ namespace Microsoft.Git.CredentialManager.Tests
             provider3Mock.Setup(x => x.SupportedAuthorityIds).Returns(new[]{"authorityD"});
             provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
 
-            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
+            registry.Register(provider1Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider2Mock.Object, HostProviderPriority.Normal);
+            registry.Register(provider3Mock.Object, HostProviderPriority.Normal);
 
             IHostProvider result = await registry.GetProviderAsync(input);
 

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Git.CredentialManager
             _configurationService.AddComponent(this);
         }
 
-        public void RegisterProviders(params IHostProvider[] providers)
+        public void RegisterProvider(IHostProvider provider, HostProviderPriority priority)
         {
-            _providerRegistry.Register(providers);
+            _providerRegistry.Register(provider, priority);
 
-            // Add any providers that are also configurable components to the configuration service
-            foreach (IConfigurableComponent configurableProvider in providers.OfType<IConfigurableComponent>())
+            // If the provider is also a configurable component, add that to the configuration service
+            if (provider is IConfigurableComponent configurableProvider)
             {
                 _configurationService.AddComponent(configurableProvider);
             }

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Git.CredentialManager.Commands
             // Determine the host provider
             context.Trace.WriteLine("Detecting host provider for input:");
             context.Trace.WriteDictionarySecrets(inputDict, new []{ "password" }, StringComparer.OrdinalIgnoreCase);
-            IHostProvider provider = _hostProviderRegistry.GetProvider(input);
+            IHostProvider provider = await _hostProviderRegistry.GetProviderAsync(input);
             context.Trace.WriteLine($"Host provider '{provider.Name}' was selected.");
 
             await ExecuteInternalAsync(context, input, provider);

--- a/src/shared/Microsoft.Git.CredentialManager/EnumerableExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/EnumerableExtensions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -24,6 +25,12 @@ namespace Microsoft.Git.CredentialManager
             }
 
             return result;
+        }
+
+        public static bool TryGetFirst<TSource>(this IEnumerable<TSource> collection, Func<TSource, bool> predicate, out TSource result)
+        {
+            result = collection.FirstOrDefault(predicate);
+            return !(result is null);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager
@@ -33,6 +34,13 @@ namespace Microsoft.Git.CredentialManager
         /// <param name="input">Input arguments of a Git credential query.</param>
         /// <returns>True if the provider supports the Git credential request, false otherwise.</returns>
         bool IsSupported(InputArguments input);
+
+        /// <summary>
+        /// Determine if the <see cref="HttpResponseMessage"/> identifies a recognized Git hosting provider.
+        /// </summary>
+        /// <param name="response">Response message of an endpoint query.</param>
+        /// <returns>True if the provider supports the host provider at the endpoint, false otherwise.</returns>
+        bool IsSupported(HttpResponseMessage response);
 
         /// <summary>
         /// Get a credential for accessing the remote Git repository on this hosting service.
@@ -77,6 +85,11 @@ namespace Microsoft.Git.CredentialManager
         public virtual IEnumerable<string> SupportedAuthorityIds => Enumerable.Empty<string>();
 
         public abstract bool IsSupported(InputArguments input);
+
+        public virtual bool IsSupported(HttpResponseMessage response)
+        {
+            return false;
+        }
 
         /// <summary>
         /// Return a string that uniquely identifies the service that a credential should be stored against.

--- a/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager
 {
@@ -28,7 +29,7 @@ namespace Microsoft.Git.CredentialManager
         /// </summary>
         /// <param name="input">Input arguments of a Git credential query.</param>
         /// <returns>A host provider that can service the given query.</returns>
-        IHostProvider GetProvider(InputArguments input);
+        Task<IHostProvider> GetProviderAsync(InputArguments input);
     }
 
     /// <summary>
@@ -72,7 +73,7 @@ namespace Microsoft.Git.CredentialManager
             _hostProviders.AddRange(hostProviders);
         }
 
-        public IHostProvider GetProvider(InputArguments input)
+        public Task<IHostProvider> GetProviderAsync(InputArguments input)
         {
             IHostProvider provider;
 
@@ -94,7 +95,7 @@ namespace Microsoft.Git.CredentialManager
                     }
                     else
                     {
-                        return provider;
+                        return Task.FromResult(provider);
                     }
                 }
             }
@@ -118,7 +119,7 @@ namespace Microsoft.Git.CredentialManager
                     }
                     else
                     {
-                        return provider;
+                        return Task.FromResult(provider);
                     }
                 }
             }
@@ -134,7 +135,7 @@ namespace Microsoft.Git.CredentialManager
                 throw new Exception("No host provider available to service this request.");
             }
 
-            return provider;
+            return Task.FromResult(provider);
         }
 
         public void Dispose()

--- a/src/shared/TestInfrastructure/Objects/TestHostProviderRegistry.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHostProviderRegistry.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System.Threading.Tasks;
+
 namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestHostProviderRegistry : IHostProviderRegistry
@@ -12,9 +14,9 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         {
         }
 
-        IHostProvider IHostProviderRegistry.GetProvider(InputArguments input)
+        Task<IHostProvider> IHostProviderRegistry.GetProviderAsync(InputArguments input)
         {
-            return Provider;
+            return Task.FromResult(Provider);
         }
 
         #endregion

--- a/src/shared/TestInfrastructure/Objects/TestHostProviderRegistry.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHostProviderRegistry.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         #region IHostProviderRegistry
 
-        void IHostProviderRegistry.Register(params IHostProvider[] hostProviders)
+        void IHostProviderRegistry.Register(IHostProvider hostProvider, HostProviderPriority priority)
         {
         }
 


### PR DESCRIPTION
Add the ability for host providers to inspect a HTTP response message in order to detect on-prem instances such as GitHub Enterprise.

The host provider registry is enhanced to enumerate providers first with the existing `InputArguments` to check for support, and then make an HTTP request to the remote URL and check against the response message.

Providers registered with high priority are checked first, followed by normal and then low priorities.

This allows the `GenericHostProvider` to be queried last, with the other customised providers (GitHub, AzDO, Bitbucket) queried first.

One one HTTP request is made for all providers, and then only if no providers match in the simple case by the `InputArguments`.