### PR TITLE
Fix bug to ensure correct provider disposal

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Git.CredentialManager
             _httpClient?.Dispose();
 
             // Dispose of all registered providers to give them a chance to clean up and release any resources
-            foreach (IHostProvider provider in _hostProviders.Values)
+            foreach (IHostProvider provider in _hostProviders.Values.SelectMany(x => x))
             {
                 provider.Dispose();
             }


### PR DESCRIPTION
We are not correctly disposing of the host providers registered with the host provider registry. Fix this by actually calling `Dispose()` on the correct objects(!)