### PR TITLE
Integrate with the shared Microsoft developer tools AAD token cache on macOS

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Git.CredentialManager
         public const string ProviderIdAuto  = "auto";
         public const string AuthorityIdAuto = "auto";
 
-        public const string GcmConfigDirectoryName = ".gcm";
+        public const string GcmDataDirectoryName = ".gcm";
 
         public static class RegexPatterns
         {

--- a/src/shared/Microsoft.Git.CredentialManager/FileSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/FileSystem.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -10,6 +11,16 @@ namespace Microsoft.Git.CredentialManager
     /// </summary>
     public interface IFileSystem
     {
+        /// <summary>
+        /// Get the path to the user's home profile directory (Unix: $HOME, Windows: %USERPROFILE%).
+        /// </summary>
+        string UserHomePath { get; }
+
+        /// <summary>
+        /// Get the path the the user's Git Credential Manager data directory.
+        /// </summary>
+        string UserDataDirectoryPath { get; }
+
         /// <summary>
         /// Check if two paths are the same for the current platform and file system. Symbolic links are not followed.
         /// </summary>
@@ -82,6 +93,10 @@ namespace Microsoft.Git.CredentialManager
     /// </summary>
     public abstract class FileSystem : IFileSystem
     {
+        public string UserHomePath => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        public string UserDataDirectoryPath => Path.Combine(UserHomePath, Constants.GcmDataDirectoryName);
+
         public abstract bool IsSamePath(string a, string b);
 
         public bool FileExists(string path) => File.Exists(path);

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxCredentialStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxCredentialStore.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Linux
                 out storeRoot))
             {
                 // Use default store root at ~/.gcm/store
-                storeRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), Constants.GcmConfigDirectoryName, "store");
+                storeRoot = Path.Combine(_fileSystem.UserDataDirectoryPath, "store");
             }
         }
     }

--- a/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
+++ b/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.1.0-preview" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.25.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.16.8" />
   </ItemGroup>
 
 </Project>

--- a/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
+++ b/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
@@ -9,10 +9,19 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestFileSystem : IFileSystem
     {
+        public string UserHomePath { get; set; }
+        public string UserDataDirectoryPath { get; set; }
         public IDictionary<string, byte[]> Files { get; set; } = new Dictionary<string, byte[]>();
         public ISet<string> Directories { get; set; } = new HashSet<string>();
         public string CurrentDirectory { get; set; } = Path.GetTempPath();
         public bool IsCaseSensitive { get; set; } = false;
+
+        public TestFileSystem()
+        {
+            var gcmTestRoot = Path.Combine(Path.GetTempPath(), $"gcmtest-{Guid.NewGuid():N}");
+            UserHomePath = Path.Combine(gcmTestRoot, "HOME");
+            UserDataDirectoryPath = Path.Combine(UserHomePath, ".gcm");
+        }
 
         #region IFileSystem
 


### PR DESCRIPTION
Various Microsoft developer tools share a token cache used by the MSAL library on macOS. This includes Visual Studio for Mac, and Azure CLI amongst others. This allows us to share refresh tokens those applications.