### PR TITLE
Fix multiple gitHubAuthModes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,7 +164,7 @@ _(unset)_|Automatically detect modes
 #### Example
 
 ```shell
-git config --global credential.gitHubAuthModes "oauth basic"
+git config --global credential.gitHubAuthModes "oauth,basic"
 ```
 
 **Also see: [GCM_GITHUB_AUTHMODES](environment.md#GCM_GITHUB_AUTHMODES)**


### PR DESCRIPTION
List must be comma separated.

Before:
```
$ GCM_TRACE=1 git fetch
22:22:08.037216 ...\Application.cs:69   trace: [RunInternalAsync] Git Credential Manager version 2.0.318-beta+44acfafa98 (Windows, .NET Framework 4.0.30319.42000) 'get'
22:22:08.040208 ...\Command.cs:63       trace: [ExecuteAsync] Start 'get' command...
22:22:08.046193 ...\Command.cs:74       trace: [ExecuteAsync] Detecting host provider for input:
22:22:08.047214 ...\Command.cs:75       trace: [ExecuteAsync]   protocol=https
22:22:08.047214 ...\Command.cs:75       trace: [ExecuteAsync]   host=***
22:22:08.206763 ...viderRegistry.cs:129 trace: [GetProvider] Performing auto-detection of host provider.
22:22:08.208757 ...\Command.cs:77       trace: [ExecuteAsync] Host provider 'GitHub' was selected.
22:22:08.211749 ...\HostProvider.cs:115 trace: [GetCredentialAsync] Looking for existing credential in store with service=https://*** account=...
22:22:08.214770 ...\HostProvider.cs:120 trace: [GetCredentialAsync] No existing credentials found.
22:22:08.214770 ...\HostProvider.cs:123 trace: [GetCredentialAsync] Creating new credential...
22:22:08.266604 ...bHostProvider.cs:227 trace: [GetSupportedAuthenticationModesAsync] Invalid value for supported authentication modes override setting: 'OAuth Basic'
```

After:
```
$ GCM_TRACE=1 git fetch
22:22:32.792872 ...\Application.cs:69   trace: [RunInternalAsync] Git Credential Manager version 2.0.318-beta+44acfafa98 (Windows, .NET Framework 4.0.30319.42000) 'get'
22:22:32.796891 ...\Command.cs:63       trace: [ExecuteAsync] Start 'get' command...
22:22:32.801849 ...\Command.cs:74       trace: [ExecuteAsync] Detecting host provider for input:
22:22:32.802847 ...\Command.cs:75       trace: [ExecuteAsync]   protocol=https
22:22:32.802847 ...\Command.cs:75       trace: [ExecuteAsync]   host=***
22:22:32.945493 ...viderRegistry.cs:129 trace: [GetProvider] Performing auto-detection of host provider.
22:22:32.947488 ...\Command.cs:77       trace: [ExecuteAsync] Host provider 'GitHub' was selected.
22:22:32.949455 ...\HostProvider.cs:115 trace: [GetCredentialAsync] Looking for existing credential in store with service=https://*** account=...
22:22:32.951449 ...\HostProvider.cs:120 trace: [GetCredentialAsync] No existing credentials found.
22:22:32.951449 ...\HostProvider.cs:123 trace: [GetCredentialAsync] Creating new credential...
22:22:32.991343 ...bHostProvider.cs:222 trace: [GetSupportedAuthenticationModesAsync] Supported authentication modes override present: Basic, OAuth
```