### PR TITLE
Add ability to override Microsoft Authentication parameters for Azure Repos

### DIFF
--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -6,7 +6,6 @@ namespace Microsoft.AzureRepos
 {
     internal static class AzureDevOpsConstants
     {
-
         // AAD environment authority base URL
         public const string AadAuthorityBaseUrl = "https://login.microsoftonline.com";
 
@@ -29,6 +28,23 @@ namespace Microsoft.AzureRepos
         {
             public const string ReposWrite = "vso.code_write";
             public const string ArtifactsRead = "vso.packaging";
+        }
+
+        public static class EnvironmentVariables
+        {
+            public const string DevAadClientId = "GCM_DEV_AZREPOS_CLIENTID";
+            public const string DevAadRedirectUri = "GCM_DEV_AZREPOS_REDIRECTURI";
+            public const string DevAadAuthorityBaseUri = "GCM_DEV_AZREPOS_AUTHORITYBASEURI";
+        }
+
+        public static class GitConfiguration
+        {
+            public static class Credential
+            {
+                public const string DevAadClientId = "azreposDevClientId";
+                public const string DevAadRedirectUri = "azreposDevRedirectUri";
+                public const string DevAadAuthorityBaseUri = "azreposDevAuthorityBaseUri";
+            }
         }
     }
 }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -153,8 +153,8 @@ namespace Microsoft.AzureRepos
             _context.Trace.WriteLine("Getting Azure AD access token...");
             IMicrosoftAuthenticationResult result = await _msAuth.GetTokenAsync(
                 authAuthority,
-                AzureDevOpsConstants.AadClientId,
-                AzureDevOpsConstants.AadRedirectUri,
+                GetClientId(),
+                GetRedirectUri(),
                 AzureDevOpsConstants.AzureDevOpsDefaultScopes,
                 null);
             _context.Trace.WriteLineSecrets(
@@ -174,6 +174,36 @@ namespace Microsoft.AzureRepos
             _context.Trace.WriteLineSecrets("PAT created. PAT='{0}'", new object[] {pat});
 
             return new GitCredential(result.AccountUpn, pat);
+        }
+
+        private string GetClientId()
+        {
+            // Check for developer override value
+            if (_context.Settings.TryGetSetting(
+                    AzureDevOpsConstants.EnvironmentVariables.DevAadClientId,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    AzureDevOpsConstants.GitConfiguration.Credential.DevAadClientId,
+                    out string clientId))
+            {
+                return clientId;
+            }
+
+            return AzureDevOpsConstants.AadClientId;
+        }
+
+        private Uri GetRedirectUri()
+        {
+            // Check for developer override value
+            if (_context.Settings.TryGetSetting(
+                    AzureDevOpsConstants.EnvironmentVariables.DevAadRedirectUri,
+                    Constants.GitConfiguration.Credential.SectionName, AzureDevOpsConstants.GitConfiguration.Credential.DevAadRedirectUri,
+                    out string redirectUriStr) &&
+                Uri.TryCreate(redirectUriStr, UriKind.Absolute, out Uri redirectUri))
+            {
+                return redirectUri;
+            }
+
+            return AzureDevOpsConstants.AadRedirectUri;
         }
 
         /// <remarks>


### PR DESCRIPTION
Add the ability to override the Microsoft authentication parameters in the Azure DevOps API and MSAuth components as used by the Azure Repos provider. This allows us to change the client ID, redirect URI, and the base authority at runtime as a developer (this is not documented or supported outside of development - the [same feature is available for the GitHub provider](https://github.com/microsoft/Git-Credential-Manager-Core/blob/66a573128898b28d46884a643eb6a446ab264562/src/shared/GitHub/GitHubOAuth2Client.cs#L28-L54)).