### PR TITLE
Add option to Azure Repos provider to stop using Personal Access Tokens

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,3 +249,25 @@ git config --global credential.msauthFlow devicecode
 ```
 
 **Also see: [GCM_MSAUTH_FLOW](environment.md#GCM_MSAUTH_FLOW)**
+
+---
+
+### credential.azreposPATMode
+
+Specify if the Azure Repos host provider should use Azure DevOps Personal Access Tokens
+as credentials, or use underlying Azure Active Directory/Microsoft Account access tokens instead.
+
+Defaults to the value `true`.
+
+Value|Description
+-|-
+`true` _(default)_|Use Azure DevOps Personal Access Tokens.
+`false`|Do not use Personal Access Tokens; use Azure access tokens directly.
+
+#### Example
+
+```shell
+git config --global credential.azreposPATMode false
+```
+
+**Also see: [GCM_AZREPOS_PATMODE](environment.md#GCM_AZREPOS_PATMODE)**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -402,3 +402,31 @@ export GCM_MSAUTH_FLOW="devicecode"
 ```
 
 **Also see: [credential.msauthFlow](configuration.md#credentialmsauthflow)**
+
+---
+
+### GCM_AZREPOS_PATMODE
+
+Specify if the Azure Repos host provider should use Azure DevOps Personal Access Tokens
+as credentials, or use underlying Azure Active Directory/Microsoft Account access tokens instead.
+
+Defaults to the value `true`.
+
+Value|Description
+-|-
+`true` _(default)_|Use Azure DevOps Personal Access Tokens.
+`false`|Do not use Personal Access Tokens; use Azure access tokens directly.
+
+##### Windows
+
+```batch
+SET GCM_AZREPOS_PATMODE="false"
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_AZREPOS_PATMODE="false"
+```
+
+**Also see: [credential.azreposPATMode](configuration.md#azrepospatmode)**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,4 +34,4 @@ Set your user-level Git configuration (`~/.gitconfig`) to use GCM Core. If you p
 ### azure-repos
 
 Interact with the Azure Repos host provider to bind/unbind user accounts to Azure DevOps
-organizations or specific remote URLs.
+organizations or specific remote URLs, and manage the authentication authority cache.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,3 +30,8 @@ Read the [Git manual](https://git-scm.com/docs/gitcredentials#_custom_helpers) a
 Set your user-level Git configuration (`~/.gitconfig`) to use GCM Core. If you pass
 `--system` to these commands, they act on the system-level Git configuration
 (`/etc/gitconfig`) instead.
+
+### azure-repos
+
+Interact with the Azure Repos host provider to bind/unbind user accounts to Azure DevOps
+organizations or specific remote URLs.

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposAuthorityCacheTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposAuthorityCacheTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Microsoft.AzureRepos.Tests
+{
+    public class AzureReposAuthorityCacheTests
+    {
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_Null_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.GetAuthority(null));
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_NoCachedAuthority_ReturnsNull()
+        {
+            const string key = "org.contoso.authority";
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            string authority = cache.GetAuthority(key);
+
+            Assert.Null(authority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_CachedAuthority_ReturnsAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = expectedAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            string actualAuthority = cache.GetAuthority(orgName);
+
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_GetAuthority_CachedAuthority_PersistedStoreChanged_ReturnsPersistedAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string oldAuthority = "https://old-login.contoso.com";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = oldAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            // Update persisted store after creation of the authority cache
+            store.PersistedStore[key] = expectedAuthority;
+            // The in-memory value should be stale
+            Assert.Equal(oldAuthority, store.MemoryStore[key]);
+
+            string actualAuthority = cache.GetAuthority(orgName);
+
+            // Should have reloaded from the persisted store
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_UpdateAuthority_NoCachedAuthority_SetsAuthorityInPersistedStore()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            cache.UpdateAuthority(orgName, expectedAuthority);
+
+            Assert.True(store.PersistedStore.TryGetValue(key, out string actualAuthority));
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_UpdateAuthority_CachedAuthority_UpdatesAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string oldAuthority = "https://old-login.contoso.com";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = oldAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            cache.UpdateAuthority(orgName, expectedAuthority);
+
+            Assert.True(store.PersistedStore.TryGetValue(key, out string actualAuthority));
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_UpdateAuthority_CachedAuthority_PersistedStoreChanged_OverwritesPersistedAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string otherAuthority = "https://alt-login.contoso.com";
+            const string expectedAuthority = "https://login.contoso.com";
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            // Persisted store is updated after the authority cache is created
+            store.PersistedStore[key] = otherAuthority;
+
+            cache.UpdateAuthority(orgName, expectedAuthority);
+
+            Assert.True(store.PersistedStore.TryGetValue(key, out string actualAuthority));
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_EraseAuthority_NoCachedAuthority_DoesNothing()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string otherKey = "org.fabrikam.authority";
+            const string otherAuthority = "https://fabrikam.com/login";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [otherKey] = otherAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            cache.EraseAuthority(orgName);
+
+            // Other entries should remain in the persisted store
+            Assert.False(store.PersistedStore.ContainsKey(key));
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(otherKey, out string actualOtherAuthority));
+            Assert.Equal(otherAuthority, actualOtherAuthority);
+        }
+
+        [Fact]
+        public void AzureReposAuthorityCache_EraseAuthority_CachedAuthority_RemovesAuthority()
+        {
+            const string orgName = "contoso";
+            const string key = "org.contoso.authority";
+            const string authority = "https://login.contoso.com";
+            const string otherKey = "org.fabrikam.authority";
+            const string otherAuthority = "https://fabrikam.com/login";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [key] = authority,
+                [otherKey] = otherAuthority
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureDevOpsAuthorityCache(trace, store);
+
+            cache.EraseAuthority(orgName);
+
+            // Only the other entries should remain in the persisted store
+            Assert.False(store.PersistedStore.ContainsKey(key));
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(otherKey, out string actualOtherAuthority));
+            Assert.Equal(otherAuthority, actualOtherAuthority);
+        }
+    }
+}

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -132,8 +132,9 @@ namespace Microsoft.AzureRepos.Tests
             var context = new TestCommandContext();
             var azDevOps = Mock.Of<IAzureDevOpsRestApi>();
             var msAuth = Mock.Of<IMicrosoftAuthentication>();
+            var authorityCache = Mock.Of<IAzureDevOpsAuthorityCache>();
 
-            var provider = new AzureReposHostProvider(context, azDevOps, msAuth);
+            var provider = new AzureReposHostProvider(context, azDevOps, msAuth, authorityCache);
 
             await Assert.ThrowsAsync<Exception>(() => provider.GetCredentialAsync(input));
         }
@@ -170,7 +171,11 @@ namespace Microsoft.AzureRepos.Tests
             msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null))
                       .ReturnsAsync(authResult);
 
-            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object);
+
+            var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>();
+            authorityCacheMock.Setup(x => x.GetAuthority("org")).Returns(authorityUrl);
+
+            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object);
 
             ICredential credential = await provider.GetCredentialAsync(input);
 

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -132,9 +132,10 @@ namespace Microsoft.AzureRepos.Tests
             var context = new TestCommandContext();
             var azDevOps = Mock.Of<IAzureDevOpsRestApi>();
             var msAuth = Mock.Of<IMicrosoftAuthentication>();
+            var userMgr = Mock.Of<IAzureReposUserManager>();
             var authorityCache = Mock.Of<IAzureDevOpsAuthorityCache>();
 
-            var provider = new AzureReposHostProvider(context, azDevOps, msAuth, authorityCache);
+            var provider = new AzureReposHostProvider(context, azDevOps, msAuth, authorityCache, userMgr);
 
             await Assert.ThrowsAsync<Exception>(() => provider.GetCredentialAsync(input));
         }
@@ -171,11 +172,12 @@ namespace Microsoft.AzureRepos.Tests
             msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null))
                       .ReturnsAsync(authResult);
 
+            var userMgr = Mock.Of<IAzureReposUserManager>();
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>();
             authorityCacheMock.Setup(x => x.GetAuthority("org")).Returns(authorityUrl);
 
-            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object);
+            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object, userMgr);
 
             ICredential credential = await provider.GetCredentialAsync(input);
 

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposUserManagerTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposUserManagerTests.cs
@@ -1,0 +1,810 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Microsoft.AzureRepos.Tests
+{
+    public class AzureReposUserManagerTests
+    {
+        #region BindOrganization
+
+        [Fact]
+        public void AzureReposUserManager_BindOrganization_NullOrganization_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.BindOrganization(null, "user"));
+        }
+
+
+        [Fact]
+        public void AzureReposUserManager_BindOrganization_NoUser_SetsOrgKey()
+        {
+            const string expectedUser = "user1";
+            const string orgName = "org";
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.BindOrganization(orgName, expectedUser);
+
+            Assert.True(store.PersistedStore.TryGetValue(GetOrgUserKey(orgName), out string actualUser));
+            Assert.Equal(expectedUser, actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_BindOrganization_ExistingUser_SetsOrgKey()
+        {
+            const string expectedUser = "user1";
+            const string orgName = "org";
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            store.PersistedStore[GetOrgUserKey(orgName)] = "org-user";
+            store.PersistedStore[GetRemoteUserKey(remote)] = "remote-user";
+
+            cache.BindOrganization(orgName, expectedUser);
+
+            Assert.True(store.PersistedStore.TryGetValue(GetOrgUserKey(orgName), out string actualUser));
+            Assert.Equal(expectedUser, actualUser);
+        }
+
+        #endregion
+
+        #region BindRemote
+
+        [Fact]
+        public void AzureReposUserManager_BindRemote_NullUri_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.BindRemote(null, "user"));
+        }
+
+        [Fact]
+        public void AzureReposUserManager_BindRemote_NoUser_SetsRemoteKey()
+        {
+            const string expectedUser = "user1";
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.BindRemote(remote, expectedUser);
+
+            Assert.True(store.PersistedStore.TryGetValue(GetRemoteUserKey(remote), out string actualUser));
+            Assert.Equal(expectedUser, actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_BindRemote_ExistingUser_SetsRemoteKey()
+        {
+            const string expectedUser = "user1";
+            const string orgName = "org";
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            store.PersistedStore[GetOrgUserKey(orgName)] = "org-user";
+            store.PersistedStore[GetRemoteUserKey(remote)] = "remote-user";
+
+            cache.BindRemote(remote, expectedUser);
+
+            Assert.True(store.PersistedStore.TryGetValue(GetRemoteUserKey(remote), out string actualUser));
+            Assert.Equal(expectedUser, actualUser);
+        }
+
+        #endregion
+
+        #region UnbindOrganization
+
+        [Fact]
+        public void AzureReposUserManager_UnbindOrganization_NullOrganization_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.UnbindOrganization(null));
+        }
+        [Fact]
+        public void AzureReposUserManager_UnbindOrganization_NoUser_DoesNothing()
+        {
+            const string orgName = "org";
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.UnbindOrganization(orgName);
+
+            Assert.False(store.PersistedStore.TryGetValue(GetOrgUserKey(orgName), out string _));
+        }
+
+        [Fact]
+        public void AzureReposUserManager_UnbindOrganization_ExistingUser_RemovesOrgKey()
+        {
+            const string orgName = "org";
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            store.PersistedStore[GetOrgUserKey(orgName)] = "org-user";
+            store.PersistedStore[GetRemoteUserKey(remote)] = "remote-user";
+
+            cache.UnbindOrganization(orgName);
+
+            Assert.False(store.PersistedStore.TryGetValue(GetOrgUserKey(orgName), out string actualUser));
+        }
+
+        #endregion
+
+        #region UnbindRemote
+
+        [Fact]
+        public void AzureReposUserManager_UnbindRemote_NullUri_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.UnbindRemote(null));
+        }
+
+
+        [Fact]
+        public void AzureReposUserManager_UnbindRemote_NoUser_DoesNothing()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.UnbindRemote(remote);
+
+            Assert.False(store.PersistedStore.TryGetValue(GetRemoteUserKey(remote), out string _));
+        }
+
+        [Fact]
+        public void AzureReposUserManager_UnbindRemote_ExistingUser_RemovesRemoteKey()
+        {
+            const string orgName = "org";
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            store.PersistedStore[GetOrgUserKey(orgName)] = "org-user";
+            store.PersistedStore[GetRemoteUserKey(remote)] = "remote-user";
+
+            cache.UnbindRemote(remote);
+
+            Assert.False(store.PersistedStore.TryGetValue(GetRemoteUserKey(remote), out string actualUser));
+        }
+
+        [Fact]
+        public void AzureReposUserManager_UnbindRemote_Explicit_ExistingUser_SetsRemoteKeyEmptyString()
+        {
+            const string orgName = "org";
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            store.PersistedStore[GetOrgUserKey(orgName)] = "org-user";
+            store.PersistedStore[GetRemoteUserKey(remote)] = "remote-user";
+
+            cache.UnbindRemote(remote, isExplicit: true);
+
+            Assert.True(store.PersistedStore.TryGetValue(GetRemoteUserKey(remote), out string actualUser));
+            Assert.Equal(string.Empty, actualUser);
+        }
+
+        #endregion
+
+        #region GetUser
+
+        [Fact]
+        public void AzureReposUserManager_GetUser_Null_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.GetUser(null));
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetUser_NoUser_ReturnsNull()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            string authority = cache.GetUser(remote);
+
+            Assert.Null(authority);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetUser_OrgUser_ReturnsOrgUser()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string orgUser = "john.doe";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = orgUser
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            string actualUser = cache.GetUser(remote);
+
+            Assert.Equal(orgUser, actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetUser_RemoteUser_ReturnsRemoteUser()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string remoteKey = GetRemoteUserKey(remote);
+            string remoteUser = "john.doe";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [remoteKey] = remoteUser
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            string actualUser = cache.GetUser(remote);
+
+            Assert.Equal(remoteUser, actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetUser_OrgAndRemoteUser_ReturnsRemoteUser()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string orgUser = "john.doe";
+            string remoteKey = GetRemoteUserKey(remote);
+            string remoteUser = "joe.bloggs";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = orgUser,
+                [remoteKey] = remoteUser,
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            string actualUser = cache.GetUser(remote);
+
+            Assert.Equal(remoteUser, actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetUser_OrgAndNoInheritRemoteUser_ReturnsNull()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string orgUser = "john.doe";
+            string remoteKey = GetRemoteUserKey(remote);
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = orgUser,
+                [remoteKey] = null,
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            string actualUser = cache.GetUser(remote);
+
+            Assert.Null(actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetUser_OrgUser_PersistedStoreChanged_ReturnsPersistedOrgUser()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string orgUser = "john.doe";
+            const string oldOrgUser = "joe.bloggs";
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = oldOrgUser
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            // Update persisted store after creation of the authority cache
+            store.PersistedStore[orgKey] = orgUser;
+            // The in-memory value should be stale
+            Assert.Equal(oldOrgUser, store.MemoryStore[orgKey]);
+
+            string actualUser = cache.GetUser(remote);
+
+            // Should have reloaded from the persisted store
+            Assert.Equal(orgUser, actualUser);
+        }
+
+        #endregion
+
+        #region Bind
+
+        [Fact]
+        public void AzureReposUserManager_Bind_Null_ThrowException()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.Bind(null, "user"));
+            Assert.Throws<ArgumentNullException>(() => cache.Bind(remote, null));
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Bind_NoOrgUser_SignsInOrg()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            const string user = "john.doe";
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Bind(remote, user);
+
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualUser));
+            Assert.Equal(user, actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Bind_SameOrgUser_DoesNothing()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            const string user = "john.doe";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = user
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Bind(remote, user);
+
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualUser));
+            Assert.Equal(user, actualUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Bind_DifferentOrgUser_SignsInRemote()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+            const string otherUser = "joe.bloggs";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = otherUser
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Bind(remote, user);
+
+            Assert.Equal(2, store.PersistedStore.Count);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(otherUser, actualOrgUser);
+            Assert.True(store.PersistedStore.TryGetValue(remoteKey, out string actualRemoteUser));
+            Assert.Equal(user, actualRemoteUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Bind_OrgAndRemoteUser_SignsInRemote()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+            const string otherUser1 = "joe.bloggs";
+            const string otherUser2 = "jane.doe";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = otherUser1,
+                [remoteKey] = otherUser2
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Bind(remote, user);
+
+            Assert.Equal(2, store.PersistedStore.Count);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(otherUser1, actualOrgUser);
+            Assert.True(store.PersistedStore.TryGetValue(remoteKey, out string actualRemoteUser));
+            Assert.Equal(user, actualRemoteUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Bind_OrgAndSignedOutRemoteUser_SignsInRemote()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+            const string otherUser = "joe.bloggs";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = otherUser,
+                [remoteKey] = null
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Bind(remote, user);
+
+            Assert.Equal(2, store.PersistedStore.Count);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(otherUser, actualOrgUser);
+            Assert.True(store.PersistedStore.TryGetValue(remoteKey, out string actualRemoteUser));
+            Assert.Equal(user, actualRemoteUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Bind_SameRemoteUserOnly_SignsInOrgRemovesRemote()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [remoteKey] = user
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Bind(remote, user);
+
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(user, actualOrgUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Bind_DifferentRemoteUserOnly_SignsInOrgRemovesRemote()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+            const string otherUser = "joe.bloggs";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [remoteKey] = otherUser
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Bind(remote, user);
+
+            Assert.Single(store.PersistedStore);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(user, actualOrgUser);
+        }
+
+        // TODO: persisted change test
+
+        #endregion
+
+        #region Unbind
+
+        [Fact]
+        public void AzureReposUserManager_Unbind_Null_ThrowException()
+        {
+            var dict  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            Assert.Throws<ArgumentNullException>(() => cache.Unbind(null));
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Unbind_NoOrgUserNoRemoteUser_DoesNothing()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string remoteKey = GetRemoteUserKey(remote);
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Unbind(remote);
+
+            Assert.Empty(store.PersistedStore);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Unbind_OrgUser_RemoteExplicitlySignedOut()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = user
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Unbind(remote);
+
+            Assert.Equal(2, store.PersistedStore.Count);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(user, actualOrgUser);
+            Assert.True(store.PersistedStore.TryGetValue(remoteKey, out string actualRemoteUser));
+            Assert.Null(actualRemoteUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Unbind_OrgAndRemoteUser_RemoteExplicitlySignedOut()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+            const string otherUser = "joe.bloggs";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = user,
+                [remoteKey] = otherUser,
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Unbind(remote);
+
+            Assert.Equal(2, store.PersistedStore.Count);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(user, actualOrgUser);
+            Assert.True(store.PersistedStore.TryGetValue(remoteKey, out string actualRemoteUser));
+            Assert.Null(actualRemoteUser);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Unbind_RemoteUser_RemovesRemoteUser()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [remoteKey] = user,
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Unbind(remote);
+
+            Assert.Empty(store.PersistedStore);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_Unbind_OrgAndSignedOutRemoteUser_DoesNothing()
+        {
+            var remote = new Uri("https://dev.azure.com/org/_git/repo");
+            string orgKey = GetOrgUserKey("org");
+            string remoteKey = GetRemoteUserKey(remote);
+            const string user = "john.doe";
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [orgKey] = user,
+                [remoteKey] = null
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(dict);
+            var cache = new AzureReposUserManager(trace, store);
+
+            cache.Unbind(remote);
+
+            Assert.Equal(2, store.PersistedStore.Count);
+            Assert.True(store.PersistedStore.TryGetValue(orgKey, out string actualOrgUser));
+            Assert.Equal(user, actualOrgUser);
+            Assert.True(store.PersistedStore.TryGetValue(remoteKey, out string actualRemoteUser));
+            Assert.Null(actualRemoteUser);
+        }
+
+        #endregion
+
+        #region GetBindings
+
+        [Fact]
+        public void AzureReposUserManager_GetRemoteBindings_NoUsers_ReturnsEmpty()
+        {
+            var expected = new Dictionary<Uri, string>();
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            IDictionary<Uri, string> actual = cache.GetRemoteBindings();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetOrganizationBindings_NoUsers_ReturnsEmpty()
+        {
+            var expected = new Dictionary<string, string>();
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            IDictionary<string, string> actual = cache.GetOrganizationBindings();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetRemoteBindings_Users_ReturnsRemoteUsers()
+        {
+            const string org1 = "org1";
+            const string org2 = "org2";
+            var remote1 = new Uri("https://dev.azure.com/org/_git/repo1");
+            var remote2 = new Uri("https://dev.azure.com/org/_git/repo2");
+
+            var expected = new Dictionary<Uri, string>
+            {
+                [remote1] = "user1",
+                [remote2] = "user2",
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            store.PersistedStore[GetRemoteUserKey(remote1)] = "user1";
+            store.PersistedStore[GetRemoteUserKey(remote2)] = "user2";
+            store.PersistedStore[GetOrgUserKey(org1)] = "user3";
+            store.PersistedStore[GetOrgUserKey(org2)] = "user4";
+
+            IDictionary<Uri, string> actual = cache.GetRemoteBindings();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void AzureReposUserManager_GetOrganizationBindings_Users_ReturnsOrgUsers()
+        {
+            const string org1 = "org1";
+            const string org2 = "org2";
+            var remote1 = new Uri("https://dev.azure.com/org/_git/repo1");
+            var remote2 = new Uri("https://dev.azure.com/org/_git/repo2");
+
+            var expected = new Dictionary<string, string>
+            {
+                [org1] = "user3",
+                [org2] = "user4",
+            };
+
+            var trace = new NullTrace();
+            var store = new InMemoryIniStore(StringComparer.OrdinalIgnoreCase);
+            var cache = new AzureReposUserManager(trace, store);
+
+            store.PersistedStore[GetRemoteUserKey(remote1)] = "user1";
+            store.PersistedStore[GetRemoteUserKey(remote2)] = "user2";
+            store.PersistedStore[GetOrgUserKey(org1)] = "user3";
+            store.PersistedStore[GetOrgUserKey(org2)] = "user4";
+
+            IDictionary<string, string> actual = cache.GetOrganizationBindings();
+
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static string GetOrgUserKey(string orgName)
+        {
+            return $"org.{orgName}.user";
+        }
+
+        private static string GetRemoteUserKey(Uri uri)
+        {
+            return $"remote.{uri}.user";
+        }
+
+        #endregion
+    }
+}

--- a/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
@@ -76,159 +76,96 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public void UriHelpers_CreateOrganizationUri_Null_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => UriHelpers.CreateOrganizationUri(null));
-        }
-
-        [Fact]
-        public void UriHelpers_CreateOrganizationUri_InputArgsMissingProtocol_ThrowsException()
-        {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["host"] = "dev.azure.com"
-            });
-
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
-        }
-
-        [Fact]
-        public void UriHelpers_CreateOrganizationUri_InputArgsMissingHost_ThrowsException()
-        {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https"
-            });
-
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Throws<ArgumentNullException>(() => UriHelpers.CreateOrganizationUri(null, out _));
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_ReturnsCorrectUri()
         {
             var expected = new Uri("https://dev.azure.com/myorg");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com",
-                ["path"]     = "myorg/myproject/_git/myrepo"
-            });
+            var input =  new Uri("https://dev.azure.com/myorg/myproject/_git/myrepo");
+            const string expectedOrg = "myorg";
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actual = UriHelpers.CreateOrganizationUri(input, out string actualOrg);
 
             Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrg, actualOrg);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_WithPort_ReturnsCorrectUri()
         {
             var expected = new Uri("https://dev.azure.com:456/myorg");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com:456",
-                ["path"]     = "myorg/myproject/_git/myrepo"
-            });
+            var input = new Uri("https://dev.azure.com:456/myorg/myproject/_git/myrepo");
+            const string expectedOrg = "myorg";
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actual = UriHelpers.CreateOrganizationUri(input, out string actualOrg);
 
             Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void UriHelpers_CreateOrganizationUri_AzureHost_WithBadPort_ThrowsException()
-        {
-            var expected = new Uri("https://dev.azure.com:456/myorg");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com:not-a-port",
-                ["path"]     = "myorg/myproject/_git/myrepo"
-            });
-
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Equal(expectedOrg, actualOrg);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_OrgAlsoInUser_PrefersPathOrg()
         {
             var expected = new Uri("https://dev.azure.com/myorg-path");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com",
-                ["path"]     = "myorg-path",
-                ["username"] = "myorg-user"
-            });
+            var input = new Uri("https://myorg-user@dev.azure.com/myorg-path");
+            const string expectedOrg = "myorg-path";
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actual = UriHelpers.CreateOrganizationUri(input, out string actualOrg);
 
             Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrg, actualOrg);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_InputArgsMissingPath_HasUser_UsesUserOrg()
         {
             var expected = new Uri("https://dev.azure.com/myorg-user");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com",
-                ["username"] = "myorg-user"
-            });
+            var input = new Uri("https://myorg-user@dev.azure.com");
+            const string expectedOrg = "myorg-user";
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actual = UriHelpers.CreateOrganizationUri(input, out string actualOrg);
 
             Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrg, actualOrg);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_AzureHost_InputArgsMissingPathAndUser_ThrowsException()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "dev.azure.com"
-            });
+            var input = new Uri("https://dev.azure.com");
 
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input, out _));
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_VisualStudioHost_ReturnsCorrectUri()
         {
-            var expected = new Uri("https://myorg.visualstudio.com/");
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"]     = "myorg.visualstudio.com",
-            });
+            var expected = new Uri("https://myorg.visualstudio.com");
+            var input = new Uri("https://myorg.visualstudio.com");
+            const string expectedOrg = "myorg";
 
-            Uri actual = UriHelpers.CreateOrganizationUri(input);
+            Uri actual = UriHelpers.CreateOrganizationUri(input, out string actualOrg);
 
             Assert.Equal(expected, actual);
+            Assert.Equal(expectedOrg, actualOrg);
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_VisualStudioHost_MissingOrgInHost_ThrowsException()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "visualstudio.com",
-            });
+            var input = new Uri("https://visualstudio.com");
 
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input, out _));
         }
 
         [Fact]
         public void UriHelpers_CreateOrganizationUri_NonAzureDevOpsHost_ThrowsException()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "example.com",
-            });
+            var input = new Uri("https://example.com");
 
-            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input));
+            Assert.Throws<InvalidOperationException>(() => UriHelpers.CreateOrganizationUri(input, out _));
         }
     }
 }

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsAuthorityCache.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsAuthorityCache.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager;
+
+namespace Microsoft.AzureRepos
+{
+    public interface IAzureDevOpsAuthorityCache
+    {
+        /// <summary>
+        /// Lookup the cached authority for the specified Azure DevOps organization.
+        /// </summary>
+        /// <param name="orgName">Azure DevOps organization name.</param>
+        /// <returns>Authority for the organization, or null if not found.</returns>
+        string GetAuthority(string orgName);
+
+        /// <summary>
+        /// Updates the cached authority for the specified Azure DevOps organization.
+        /// </summary>
+        /// <param name="orgName">Azure DevOps organization name.</param>
+        /// <param name="authority">New authority value.</param>
+        void UpdateAuthority(string orgName, string authority);
+
+        /// <summary>
+        /// Erase the cached authority for the specified Azure DevOps organization.
+        /// </summary>
+        /// <param name="orgName">Azure DevOps organization name.</param>
+        void EraseAuthority(string orgName);
+
+        /// <summary>
+        /// Clear all cached authorities.
+        /// </summary>
+        void Clear();
+    }
+
+    public class AzureDevOpsAuthorityCache : IAzureDevOpsAuthorityCache
+    {
+        private readonly ITrace _trace;
+        private readonly IScopedTransactionalStore _iniStore;
+
+        public AzureDevOpsAuthorityCache(ICommandContext context)
+            : this(context.Trace, new IniFileStore(context.FileSystem, new IniSerializer(), Path.Combine(
+                context.FileSystem.UserDataDirectoryPath,
+                AzureDevOpsConstants.AzReposDataDirectoryName,
+                AzureDevOpsConstants.AzReposDataStoreName))) { }
+
+        public AzureDevOpsAuthorityCache(ITrace trace, IScopedTransactionalStore iniStore)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(iniStore, nameof(iniStore));
+
+            _trace = trace;
+            _iniStore = iniStore;
+        }
+
+        public string GetAuthority(string orgName)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+            _trace.WriteLine($"Looking up cached authority for organization '{orgName}'...");
+
+            _iniStore.Reload();
+            if (_iniStore.TryGetValue(GetAuthorityKey(orgName), out string authority))
+            {
+                return authority;
+            }
+
+            return null;
+        }
+
+        public void UpdateAuthority(string orgName, string authority)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+            _trace.WriteLine($"Updating cached authority for '{orgName}' to '{authority}'...");
+
+            _iniStore.Reload();
+            _iniStore.SetValue(GetAuthorityKey(orgName), authority);
+            _iniStore.Commit();
+        }
+
+        public void EraseAuthority(string orgName)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+            _trace.WriteLine($"Removing cached authority for '{orgName}'...");
+            _iniStore.Reload();
+            _iniStore.Remove(GetAuthorityKey(orgName));
+            _iniStore.Commit();
+        }
+
+        public void Clear()
+        {
+            _trace.WriteLine("Clearing all cached authorities...");
+            _iniStore.Reload();
+            IEnumerable<string> orgNames = _iniStore.GetSectionScopes("org");
+            foreach (string orgName in orgNames)
+            {
+                _iniStore.Remove(GetAuthorityKey(orgName));
+            }
+            _iniStore.Commit();
+        }
+
+        private static string GetAuthorityKey(string orgName)
+        {
+            return $"org.{orgName}.authority";
+        }
+    }
+}

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -6,6 +6,9 @@ namespace Microsoft.AzureRepos
 {
     internal static class AzureDevOpsConstants
     {
+        public const string AzReposDataDirectoryName = "azure-repos";
+        public const string AzReposDataStoreName = "store.ini";
+
         // AAD environment authority base URL
         public const string AadAuthorityBaseUrl = "https://login.microsoftonline.com";
 

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AzureRepos
             public const string DevAadClientId = "GCM_DEV_AZREPOS_CLIENTID";
             public const string DevAadRedirectUri = "GCM_DEV_AZREPOS_REDIRECTURI";
             public const string DevAadAuthorityBaseUri = "GCM_DEV_AZREPOS_AUTHORITYBASEURI";
+            public const string PatMode = "GCM_AZREPOS_PATMODE";
         }
 
         public static class GitConfiguration
@@ -44,6 +45,7 @@ namespace Microsoft.AzureRepos
                 public const string DevAadClientId = "azreposDevClientId";
                 public const string DevAadRedirectUri = "azreposDevRedirectUri";
                 public const string DevAadAuthorityBaseUri = "azreposDevAuthorityBaseUri";
+                public const string PatMode = "azreposPATMode";
             }
         }
     }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -423,6 +423,12 @@ namespace Microsoft.AzureRepos
 
         ProviderCommand ICommandProvider.CreateCommand()
         {
+            var clearCacheCmd = new Command("clear-cache")
+            {
+                Description = "Clear the authority cache",
+                Handler = CommandHandler.Create(ClearCacheCmd),
+            };
+
             var orgArg = new Argument("org")
             {
                 Arity = ArgumentArity.ExactlyOne,
@@ -486,9 +492,16 @@ namespace Microsoft.AzureRepos
             rootCmd.AddCommand(bindRemoteCmd);
             rootCmd.AddCommand(unbindOrgCmd);
             rootCmd.AddCommand(unbindRemoteCmd);
+            rootCmd.AddCommand(clearCacheCmd);
             return rootCmd;
         }
 
+        private int ClearCacheCmd()
+        {
+            _authorityCache.Clear();
+            _context.Streams.Out.WriteLine("Authority cache cleared");
+            return 0;
+        }
         private int ListBindingsCmd()
         {
             IDictionary<string, string> orgBinds = _userManager.GetOrganizationBindings();

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -141,8 +141,8 @@ namespace Microsoft.AzureRepos
                 throw new Exception("Unencrypted HTTP is not supported for Azure Repos. Ensure the repository remote URL is using HTTPS.");
             }
 
-            Uri orgUri = UriHelpers.CreateOrganizationUri(input);
             Uri remoteUri = input.GetRemoteUri();
+            Uri orgUri = UriHelpers.CreateOrganizationUri(remoteUri, out _);
 
             // Determine the MS authentication authority for this organization
             _context.Trace.WriteLine("Determining Microsoft Authentication Authority...");
@@ -231,13 +231,15 @@ namespace Microsoft.AzureRepos
                 throw new InvalidOperationException("Failed to parse host name and/or port");
             }
 
+            Uri remoteUri = input.GetRemoteUri();
+
             // dev.azure.com
             if (UriHelpers.IsDevAzureComHost(hostName))
             {
                 // We can never store the new dev.azure.com-style URLs against the full path because
                 // we have forced the useHttpPath option to true to in order to retrieve the AzDevOps
                 // organization name from Git.
-                return UriHelpers.CreateOrganizationUri(input).AbsoluteUri.TrimEnd('/');
+                return UriHelpers.CreateOrganizationUri(remoteUri, out _).AbsoluteUri.TrimEnd('/');
             }
 
             // *.visualstudio.com
@@ -245,7 +247,7 @@ namespace Microsoft.AzureRepos
             {
                 // If we're given the full path for an older *.visualstudio.com-style URL then we should
                 // respect that in the service name.
-                return input.GetRemoteUri().AbsoluteUri.TrimEnd('/');
+                return remoteUri.AbsoluteUri.TrimEnd('/');
             }
 
             throw new InvalidOperationException("Host is not Azure DevOps.");

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -17,22 +17,26 @@ namespace Microsoft.AzureRepos
         private readonly ICommandContext _context;
         private readonly IAzureDevOpsRestApi _azDevOps;
         private readonly IMicrosoftAuthentication _msAuth;
+        private readonly IAzureDevOpsAuthorityCache _authorityCache;
 
         public AzureReposHostProvider(ICommandContext context)
-            : this(context, new AzureDevOpsRestApi(context), new MicrosoftAuthentication(context))
+            : this(context, new AzureDevOpsRestApi(context), new MicrosoftAuthentication(context),
+                new AzureDevOpsAuthorityCache(context))
         {
         }
 
         public AzureReposHostProvider(ICommandContext context, IAzureDevOpsRestApi azDevOps,
-            IMicrosoftAuthentication msAuth)
+            IMicrosoftAuthentication msAuth, IAzureDevOpsAuthorityCache authorityCache)
         {
             EnsureArgument.NotNull(context, nameof(context));
             EnsureArgument.NotNull(azDevOps, nameof(azDevOps));
             EnsureArgument.NotNull(msAuth, nameof(msAuth));
+            EnsureArgument.NotNull(authorityCache, nameof(authorityCache));
 
             _context = context;
             _azDevOps = azDevOps;
             _msAuth = msAuth;
+            _authorityCache = authorityCache;
         }
 
         #region IHostProvider
@@ -150,6 +154,11 @@ namespace Microsoft.AzureRepos
                 _context.Trace.WriteLine("Not using PATs - nothing to erase");
             }
 
+            // Clear the authority cache in case this was the reason for failure
+            Uri remoteUri = input.GetRemoteUri();
+            string orgName = UriHelpers.GetOrganizationName(remoteUri);
+            _authorityCache.EraseAuthority(orgName);
+
             return Task.CompletedTask;
         }
 
@@ -185,10 +194,17 @@ namespace Microsoft.AzureRepos
 
         private async Task<IMicrosoftAuthenticationResult> GetAzureAccessTokenAsync(Uri remoteUri)
         {
-            Uri orgUri = UriHelpers.CreateOrganizationUri(remoteUri, out _);
+            Uri orgUri = UriHelpers.CreateOrganizationUri(remoteUri, out string orgName);
 
-            _context.Trace.WriteLine("Determining Microsoft Authentication Authority...");
-            string authAuthority = await _azDevOps.GetAuthorityAsync(orgUri);
+            _context.Trace.WriteLine($"Determining Microsoft Authentication authority for Azure DevOps organization '{orgName}'...");
+            string authAuthority = _authorityCache.GetAuthority(orgName);
+            if (authAuthority is null)
+            {
+                // If there is no cached value we must query for it and cache it for future use
+                _context.Trace.WriteLine($"No cached authority value - querying {orgUri} for authority...");
+                authAuthority = await _azDevOps.GetAuthorityAsync(orgUri);
+                _authorityCache.UpdateAuthority(orgName, authAuthority);
+            }
             _context.Trace.WriteLine($"Authority is '{authAuthority}'.");
 
             _context.Trace.WriteLine("Getting Azure AD access token...");

--- a/src/shared/Microsoft.AzureRepos/AzureReposUserManager.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposUserManager.cs
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Git.CredentialManager;
+
+namespace Microsoft.AzureRepos
+{
+    /// <summary>
+    /// Manages association of users and Git remotes for Azure Repos.
+    /// </summary>
+    public interface IAzureReposUserManager
+    {
+        /// <summary>
+        /// Get the user for the given Azure DevOps organization or remote.
+        /// </summary>
+        /// <param name="remoteUri">Remote URI.</param>
+        /// <returns>Identifier of user bound to the remote, or null if no binding exists.</returns>
+        string GetUser(Uri remoteUri);
+
+        /// <summary>
+        /// Bind a user to an Azure DevOps organization or remote.
+        /// </summary>
+        /// <param name="remoteUri">Remote URI to bind.</param>
+        /// <param name="userName">User identifier to bind.</param>
+        void Bind(Uri remoteUri, string userName);
+
+        /// <summary>
+        /// Unbind an Azure DevOps organization or remote.
+        /// </summary>
+        /// <param name="remoteUri">Remote URL to unbind.</param>
+        void Unbind(Uri remoteUri);
+
+        /// <summary>
+        /// Get all users that have been bound at the organization level.
+        /// </summary>
+        /// <returns>Users bound by organization.</returns>
+        IDictionary<string, string> GetOrganizationBindings();
+
+        /// <summary>
+        /// Get all users that have been bound at the remote URL level.
+        /// </summary>
+        /// <returns>Users bound by remote URL.</returns>
+        IDictionary<Uri, string> GetRemoteBindings();
+
+        /// <summary>
+        /// Bind a user to the given organization.
+        /// </summary>
+        /// <param name="orgName">Organization to bind the user to.</param>
+        /// <param name="userName">User identifier to bind.</param>
+        void BindOrganization(string orgName, string userName);
+
+        /// <summary>
+        /// Bind a user to the given remote URI.
+        /// </summary>
+        /// <param name="remoteUri">Remote URI to bind the user to.</param>
+        /// <param name="userName">User identifier to bind.</param>
+        void BindRemote(Uri remoteUri, string userName);
+
+        /// <summary>
+        /// Unbind the given remote URI.
+        /// </summary>
+        /// <param name="orgName">Organization to unbind.</param>
+        void UnbindOrganization(string orgName);
+
+        /// <summary>
+        /// Unbind the given remote URI.
+        /// </summary>
+        /// <param name="remoteUri">Remote URI to unbind.</param>
+        /// <param name="isExplicit">Mark the remote as explicitly unbound.</param>
+        void UnbindRemote(Uri remoteUri, bool isExplicit = false);
+    }
+
+    public class AzureReposUserManager : IAzureReposUserManager
+    {
+        private readonly ITrace _trace;
+        private readonly IScopedTransactionalStore _iniStore;
+
+        public AzureReposUserManager(ICommandContext context)
+            : this(context.Trace, new IniFileStore(context.FileSystem, new IniSerializer(), Path.Combine(
+                context.FileSystem.UserDataDirectoryPath,
+                AzureDevOpsConstants.AzReposDataDirectoryName,
+                AzureDevOpsConstants.AzReposDataStoreName))) { }
+
+        public AzureReposUserManager(ITrace trace, IScopedTransactionalStore iniStore)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(iniStore, nameof(iniStore));
+
+            _trace = trace;
+            _iniStore = iniStore;
+        }
+
+        public string GetUser(Uri remoteUri)
+        {
+            EnsureArgument.AbsoluteUri(remoteUri, nameof(remoteUri));
+
+            string orgName = UriHelpers.GetOrganizationName(remoteUri);
+            string remoteKey = GetRemoteUserKey(remoteUri);
+            string orgKey = GetOrgUserKey(orgName);
+
+            /*
+             * Always prefer the remote bindings over the organization bindings
+             * If there is no remote binding this means 'inherit' the organization binding.
+             * If the remote binding has a value of "null" this means do not inherit the organization binding.
+             *
+             */
+
+            _iniStore.Reload();
+
+            // Look for a binding to the specific remote
+            _trace.WriteLine($"Looking up remote binding for '{remoteUri}'...");
+            if (_iniStore.TryGetValue(remoteKey, out string remoteUser))
+            {
+                return remoteUser;
+            }
+
+            // Try to find an organization binding for this remote
+            _trace.WriteLine($"Looking up organization binding for '{orgName}'...");
+            if (_iniStore.TryGetValue(orgKey, out string orgUser))
+            {
+                return orgUser;
+            }
+
+            // No bound user
+            return null;
+        }
+
+
+        public void Bind(Uri remoteUri, string userName)
+        {
+            EnsureArgument.AbsoluteUri(remoteUri, nameof(remoteUri));
+            EnsureArgument.NotNullOrWhiteSpace(userName, nameof(userName));
+
+            string orgName = UriHelpers.GetOrganizationName(remoteUri);
+            string remoteKey = GetRemoteUserKey(remoteUri);
+            string orgKey = GetOrgUserKey(orgName);
+
+            /*
+             *  State table change for binding user A
+             *
+             *     A = user being bound
+             *     B = another user
+             *     - = no binding
+             *
+             *   Current state   |    New state
+             *   Org  |  Remote  |  Org  |  Remote
+             * -------|----------|-------|----------
+             *    -   |    -     |   A   |    -
+             *    -   |    A     |   A   |    -
+             *    -   |    B     |   A   |    -
+             *    A   |    -     |   A   |    -
+             *    A   |    A     |   A   |    -
+             *    A   |    B     |   A   |    -
+             *    B   |    -     |   B   |    A
+             *    B   |    A     |   B   |    A
+             *    B   |    B     |   B   |    A
+             *
+             */
+
+            _iniStore.Reload();
+
+            bool hasOrgBinding = _iniStore.TryGetValue(orgKey, out string orgUser);
+            if (hasOrgBinding)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(userName, orgUser))
+                {
+                    // Org-level user is already correct; remove any remote-level binding
+                    _trace.WriteLine($"Organization '{orgName}' is already bound to user '{orgUser}'.");
+                    _trace.WriteLine($"Removing any explicit binding for remote '{remoteUri}'...");
+                    _iniStore.Remove(remoteKey);
+                }
+                else
+                {
+                    // Org-level user is different; bind at the remote-level
+                    _trace.WriteLine($"Organization '{orgName}' is bound to user '{orgUser}' which is different from '{userName}'.");
+                    _trace.WriteLine($"Binding explicit remote '{remoteUri}' to user '{userName}'...");
+                    _iniStore.SetValue(remoteKey, userName);
+                }
+            }
+            else
+            {
+                // Bind at the org-level and clean up any remote-level binding
+                _trace.WriteLine($"Binding organization '{orgName}' to user '{userName}'...");
+                _iniStore.SetValue(orgKey, userName);
+                _trace.WriteLine($"Removing any explicit binding for remote '{remoteUri}'...");
+                _iniStore.Remove(remoteKey);
+            }
+
+
+            _iniStore.Commit();
+        }
+
+        public void Unbind(Uri remoteUri)
+        {
+            EnsureArgument.AbsoluteUri(remoteUri, nameof(remoteUri));
+
+            string orgName = UriHelpers.GetOrganizationName(remoteUri);
+            string orgKey = GetOrgUserKey(orgName);
+            string remoteKey = GetRemoteUserKey(remoteUri);
+
+            _trace.WriteLine($"Explicitly clearing sign-in state for specific remote '{remoteUri}'...");
+
+            /*
+             *  Sign-out state table change for signing-out the remote
+             *
+             *     U = bound user
+             *     X = empty user (explicitly unbound/do not inherit)
+             *     - = no binding
+             *
+             *  Note: Org = X is not a valid state
+             *
+             *   Current state   |    New state
+             *   Org  |  Remote  |  Org  |  Remote
+             * -------|----------|-------|----------
+             *    -   |    -     |   -   |    -
+             *    -   |    X     |   -   |    -
+             *    -   |    U     |   -   |    -
+             *    U   |    -     |   U   |    X
+             *    U   |    X     |   U   |    X
+             *    U   |    U     |   U   |    X
+             *
+             */
+
+            _iniStore.Reload();
+
+            bool hasOrgUser = _iniStore.TryGetValue(orgKey, out _);
+
+            // If there is an org-level binding, set explicit remote binding
+            if (hasOrgUser)
+            {
+                // Use an empty value to mean 'do not inherit' vs the absence of an entry meaning 'inherit'
+                _iniStore.SetValue(remoteKey, null);
+            }
+            // If there is no org-level binding, just remove the remote binding
+            else
+            {
+                _iniStore.Remove(remoteKey);
+            }
+
+            _iniStore.Commit();
+        }
+
+        public IDictionary<string, string> GetOrganizationBindings()
+        {
+            var dict = new Dictionary<string, string>();
+
+            _iniStore.Reload();
+
+            IEnumerable<string> orgNames = _iniStore.GetSectionScopes("org");
+            foreach (string orgName in orgNames)
+            {
+                string orgUserKey = GetOrgUserKey(orgName);
+                if (_iniStore.TryGetValue(orgUserKey, out string orgUser))
+                {
+                    dict[orgName] = orgUser;
+                }
+            }
+
+            return dict;
+        }
+
+        public IDictionary<Uri, string> GetRemoteBindings()
+        {
+            var dict = new Dictionary<Uri, string>();
+
+            _iniStore.Reload();
+
+            IEnumerable<string> remotes = _iniStore.GetSectionScopes("remote");
+            foreach (string remoteUrl in remotes)
+            {
+                if (!Uri.TryCreate(remoteUrl, UriKind.Absolute, out Uri remoteUri))
+                {
+                    continue;
+                }
+
+                string orgUserKey = GetRemoteUserKey(remoteUri);
+                if (_iniStore.TryGetValue(orgUserKey, out string remoteUser))
+                {
+                    dict[remoteUri] = remoteUser;
+                }
+            }
+
+            return dict;
+        }
+
+        public void BindOrganization(string orgName, string userName)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+            EnsureArgument.NotNullOrWhiteSpace(userName, nameof(userName));
+
+            _iniStore.Reload();
+
+            string key = GetOrgUserKey(orgName);
+
+            _trace.WriteLine($"Binding user '{userName}' to organization '{orgName}'...");
+            _iniStore.SetValue(key, userName);
+
+            _iniStore.Commit();
+        }
+
+        public void BindRemote(Uri remoteUri, string userName)
+        {
+            EnsureArgument.AbsoluteUri(remoteUri, nameof(remoteUri));
+            EnsureArgument.NotNullOrWhiteSpace(userName, nameof(userName));
+
+            _iniStore.Reload();
+
+            string key = GetRemoteUserKey(remoteUri);
+
+            _trace.WriteLine($"Binding user '{userName}' to remote URL '{remoteUri}'...");
+            _iniStore.SetValue(key, userName);
+
+            _iniStore.Commit();
+        }
+
+        public void UnbindOrganization(string orgName)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+            _iniStore.Reload();
+
+            string key = GetOrgUserKey(orgName);
+
+            _trace.WriteLine($"Unbinding organization '{orgName}'...");
+            _iniStore.Remove(key);
+
+            _iniStore.Commit();
+        }
+
+        public void UnbindRemote(Uri remoteUri, bool isExplicit = false)
+        {
+            EnsureArgument.AbsoluteUri(remoteUri, nameof(remoteUri));
+
+            _iniStore.Reload();
+
+            string key = GetRemoteUserKey(remoteUri);
+
+            if (isExplicit)
+            {
+                // Use the empty string value to signal an explicitly signed-out user
+                _trace.WriteLine($"Explicitly unbinding remote URL '{remoteUri}'...");
+                _iniStore.SetValue(key, string.Empty);
+            }
+            else
+            {
+                _trace.WriteLine($"Unbinding remote URL '{remoteUri}'...");
+                _iniStore.Remove(key);
+            }
+
+            _iniStore.Commit();
+        }
+
+        private static string GetOrgUserKey(string orgName)
+        {
+            return $"org.{orgName}.user";
+        }
+
+        private static string GetRemoteUserKey(Uri uri)
+        {
+            return $"remote.{uri}.user";
+        }
+    }
+}

--- a/src/shared/Microsoft.AzureRepos/AzureReposUserManager.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposUserManager.cs
@@ -359,7 +359,8 @@ namespace Microsoft.AzureRepos
 
         private static string GetRemoteUserKey(Uri uri)
         {
-            return $"remote.{uri}.user";
+            // Trim any userinfo that may be present on the URI.. we only scope to the authority & path
+            return $"remote.{uri.WithoutUserInfo()}.user";
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/IniSerializerTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/IniSerializerTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class IniSerializerTests
+    {
+        [Fact]
+        public void IniSerializer_Deserialize()
+        {
+            const string iniText = "[foo \"this:\\ is-contoso/].com\"]\n" +
+                                   "\tuser = john.doe\n" +
+                                   "\n" +
+                                   "[bar]\n" +
+                                   "\tuser = jane.doe\n" +
+                                   "\n" +
+                                   "[misc]\n" +
+                                   "\tnull =\n" +
+                                   "\tempty =\n" +
+                                   "\tvalue = foo\n" +
+                                   "\n";
+
+            var serializer = new IniSerializer();
+            using (var reader = new StringReader(iniText))
+            {
+                IniFile iniFile = serializer.Deserialize(reader);
+
+                Assert.Equal(3, iniFile.Sections.Count);
+
+                Assert.Equal("foo", iniFile.Sections[0].Name);
+                Assert.Equal("this:\\ is-contoso/].com", iniFile.Sections[0].Scope);
+                Assert.Equal(1, iniFile.Sections[0].Properties.Count);
+                Assert.True(iniFile.Sections[0].Properties.ContainsKey("user"));
+                Assert.Equal("john.doe", iniFile.Sections[0].Properties["user"]);
+
+                Assert.Equal("bar", iniFile.Sections[1].Name);
+                Assert.Null(iniFile.Sections[1].Scope);
+                Assert.Equal(1, iniFile.Sections[1].Properties.Count);
+                Assert.True(iniFile.Sections[1].Properties.ContainsKey("user"));
+                Assert.Equal("jane.doe", iniFile.Sections[1].Properties["user"]);
+
+                Assert.Equal("misc", iniFile.Sections[2].Name);
+                Assert.Null(iniFile.Sections[2].Scope);
+                Assert.Equal(3, iniFile.Sections[2].Properties.Count);
+                Assert.True(iniFile.Sections[2].Properties.ContainsKey("null"));
+                Assert.True(iniFile.Sections[2].Properties.ContainsKey("empty"));
+                Assert.True(iniFile.Sections[2].Properties.ContainsKey("value"));
+                Assert.Null(iniFile.Sections[2].Properties["null"]);
+                Assert.Null(iniFile.Sections[2].Properties["empty"]);
+                Assert.Equal("foo", iniFile.Sections[2].Properties["value"]);
+            }
+        }
+
+        [Fact]
+        public void IniSerializer_Serialize()
+        {
+            const string expectedIniText = "[foo \"this:\\ is-contoso/].com\"]\n" +
+                                           "\tuser = john.doe\n" +
+                                           "\n" +
+                                           "[bar]\n" +
+                                           "\tuser = jane.doe\n" +
+                                           "\n" +
+                                           "[misc]\n" +
+                                           "\tnull =\n" +
+                                           "\tempty =\n" +
+                                           "\tvalue = foo\n" +
+                                           "\n";
+
+            var iniFile = new IniFile
+            {
+                Sections =
+                {
+                    new IniSection("foo", "this:\\ is-contoso/].com")
+                    {
+                        Properties = {["user"] = "john.doe"}
+                    },
+                    new IniSection("bar", null)
+                    {
+                        Properties = {["user"] = "jane.doe"}
+                    },
+                    new IniSection("misc", null)
+                    {
+                        Properties =
+                        {
+                            ["null"] = null,
+                            ["empty"] = "",
+                            ["value"] = "foo",
+                        },
+                    },
+                }
+            };
+
+            var serializer = new IniSerializer();
+
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb) {NewLine = "\n"})
+            {
+                serializer.Serialize(iniFile, writer);
+            }
+
+            string actualIniText = sb.ToString();
+
+            Assert.Equal(expectedIniText, actualIniText);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
@@ -141,6 +141,25 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public void InputArguments_GetRemoteUri_IncludeUserNoUser_Authority_ReturnsUriWithAuthority()
+        {
+            var expectedUri = new Uri("https://example.com/");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com",
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri(includeUser: true);
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
+        [Fact]
         public void InputArguments_GetRemoteUri_AuthorityAndPort_ReturnsUriWithAuthorityAndPort()
         {
             var expectedUri = new Uri("https://example.com:456/");

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
@@ -79,5 +79,22 @@ namespace Microsoft.Git.CredentialManager.Tests
             Assert.Equal(expectedUser, actualUser);
             Assert.Equal(expectedPass, actualPass);
         }
+
+        [Theory]
+        [InlineData("http://example.com", "http://example.com")]
+        [InlineData("http://john.doe:password123@example.com", "http://example.com")]
+        [InlineData("http://john.doe@example.com", "http://example.com")]
+        [InlineData("http://john.doe:@example.com", "http://example.com")]
+        [InlineData("http://:password123@example.com", "http://example.com")]
+        [InlineData("http://john.doe:::password123@example.com", "http://example.com")]
+        [InlineData("http://john%20doe:password%20123@example.com", "http://example.com")]
+        public void UriExtensions_WithoutUserInfo(string input, string expected)
+        {
+            var uri = new Uri(input);
+
+            Uri result = UriExtensions.WithoutUserInfo(uri);
+
+            Assert.Equal(expected, result.ToString().TrimEnd('/'));
+        }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/IScopedTransactionalStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IScopedTransactionalStore.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Represents a simple section-scoped property/value store that can accumulate changes before 'committing'
+    /// them to a persistent storage location, or be reloaded from that storage at will.
+    /// </summary>
+    public interface IScopedTransactionalStore
+    {
+        /// <summary>
+        /// Reload the store from persisted storage. Any uncommitted changes will be lost.
+        /// </summary>
+        Task Reload();
+
+        /// <summary>
+        /// Commit changes to persisted storage. Any changes made outside of the application will be overwritten.
+        /// </summary>
+        Task Commit();
+
+        /// <summary>
+        /// Get all scopes present for the given section name.
+        /// </summary>
+        /// <param name="sectionName">Name of section.</param>
+        /// <returns>All scopes present for the specified section name in the store.</returns>
+        IEnumerable<string> GetSectionScopes(string sectionName);
+
+        /// <summary>
+        /// Try to get the value of a property for the given key.
+        /// </summary>
+        /// <param name="key">Property key.</param>
+        /// <param name="value">Property value.</param>
+        /// <returns>True if a property with the specified key exists, false otherwise.</returns>
+        bool TryGetValue(string key, out string value);
+
+        /// <summary>
+        /// Set the value of a property for the given key. Existing values are overwritten.
+        /// </summary>
+        /// <param name="key">Property key.</param>
+        /// <param name="value">Property value.</param>
+        void SetValue(string key, string value);
+
+        /// <summary>
+        /// Delete a property identified by the given key if it exists.
+        /// </summary>
+        /// <param name="key">Property key.</param>
+        void Remove(string key);
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/IniFile.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IniFile.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Represents an INI based configuration file.
+    /// </summary>
+    public class IniFile
+    {
+        /// <summary>
+        /// All sections in this INI file.
+        /// </summary>
+        public IList<IniSection> Sections { get; } = new List<IniSection>();
+
+        /// <summary>
+        /// Attempt to find a section in this file with the given name and optional scope.
+        /// </summary>
+        /// <param name="name">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="section">Section with the specified name and scope.</param>
+        /// <returns>True if a section was found, false otherwise.</returns>
+        public bool TryGetSection(string name, string scope, out IniSection section)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(name, nameof(name));
+
+            foreach (IniSection s in Sections)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(name, s.Name) &&
+                    StringComparer.OrdinalIgnoreCase.Equals(scope, s.Scope))
+                {
+                    section = s;
+                    return true;
+                }
+            }
+
+            section = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get the value of a property in the INI file.
+        /// </summary>
+        /// <param name="section">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="property">Property name.</param>
+        /// <param name="value">Value of the property.</param>
+        /// <returns>True if the property was present and found, false otherwise.</returns>
+        /// <remarks>Null is a valid value.</remarks>
+        public bool TryGetValue(string section, string scope, string property, out string value)
+        {
+            value = null;
+            return TryGetSection(section, scope, out IniSection sectionObj) &&
+                   sectionObj.Properties.TryGetValue(property, out value);
+        }
+
+        /// <summary>
+        /// Set the value of a property in the INI file.
+        /// </summary>
+        /// <param name="section">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="property">Property name.</param>
+        /// <param name="value">Value of the property.</param>
+        /// <remarks>Null is a valid value. Use <see cref="UnsetValue"/> to remove the property.</remarks>
+        public void SetValue(string section, string scope, string property, string value)
+        {
+            if (!TryGetSection(section, scope, out IniSection sectionObj))
+            {
+                sectionObj = new IniSection(section, scope);
+                Sections.Add(sectionObj);
+            }
+
+            sectionObj.Properties[property] = value;
+        }
+
+        /// <summary>
+        /// Unset/remove a property from the INI file.
+        /// </summary>
+        /// <param name="section">Section name.</param>
+        /// <param name="scope">Optional section scope.</param>
+        /// <param name="property">Property name.</param>
+        public void UnsetValue(string section, string scope, string property)
+        {
+            if (TryGetSection(section, scope, out IniSection sectionObj))
+            {
+                sectionObj.Properties.Remove(property);
+            }
+        }
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class IniSection
+    {
+        public IniSection(string name, string scope)
+        {
+            Name = name;
+            Scope = scope;
+        }
+
+        /// <summary>
+        /// Name of the INI file section.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Optional scope of the INI file section.
+        /// </summary>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// All properties in this section.
+        /// </summary>
+        public IDictionary<string, string> Properties { get; } =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        private string DebuggerDisplay => Scope == null ? $"[{Name}]" : $"[{Name} \"{Scope}\"]";
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/IniFileStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IniFileStore.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Scoped transactional store that uses an INI file as the persistent storage.
+    /// </summary>
+    public class IniFileStore : IScopedTransactionalStore
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly IniSerializer _serializer;
+        private readonly string _filePath;
+        private readonly string _parentPath;
+        private readonly object _fileLock = new object();
+        private IniFile _iniFile;
+
+        public IniFileStore(IFileSystem fileSystem, IniSerializer serializer, string filePath)
+        {
+            _fileSystem = fileSystem;
+            _serializer = serializer;
+            _filePath = filePath;
+            _parentPath = Path.GetDirectoryName(_filePath);
+
+            Reload();
+        }
+
+        public Task Reload()
+        {
+            lock (_fileLock)
+            {
+                if (_fileSystem.FileExists(_filePath))
+                {
+                    using (Stream fs = _fileSystem.OpenFileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    using (var reader = new StreamReader(fs))
+                    {
+                        _iniFile = _serializer.Deserialize(reader);
+                    }
+                }
+                else
+                {
+                    // Create a new empty INI file object
+                    _iniFile = new IniFile();
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task Commit()
+        {
+            lock (_fileLock)
+            {
+                // Ensure parent directory exists
+                if (!_fileSystem.DirectoryExists(_parentPath))
+                {
+                    _fileSystem.CreateDirectory(_parentPath);
+                }
+
+                using (Stream fs = _fileSystem.OpenFileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.Write))
+                using (var writer = new StreamWriter(fs))
+                {
+                    _serializer.Serialize(_iniFile, writer);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public IEnumerable<string> GetSectionScopes(string sectionName)
+        {
+            lock (_fileLock)
+            {
+                IEnumerable<IniSection> sections = _iniFile.Sections
+                    .Where(x => StringComparer.OrdinalIgnoreCase.Equals(x.Name, sectionName));
+                foreach (var section in sections)
+                {
+                    yield return section.Scope;
+                }
+            }
+        }
+
+        public bool TryGetValue(string key, out string value)
+        {
+            lock (_fileLock)
+            {
+                value = null;
+
+                if (!TrySplitKey(key, out string section, out string scope, out string property))
+                {
+                    throw new ArgumentException($"Invalid key '{key}'.", nameof(key));
+                }
+
+                return _iniFile.TryGetValue(section, scope, property, out value);
+            }
+        }
+
+        public void SetValue(string key, string value)
+        {
+            lock (_fileLock)
+            {
+                if (!TrySplitKey(key, out string section, out string scope, out string property))
+                {
+                    throw new ArgumentException($"Invalid key '{key}'.", nameof(key));
+                }
+
+                _iniFile.SetValue(section, scope, property, value);
+            }
+        }
+
+        public void Remove(string key)
+        {
+            lock (_fileLock)
+            {
+                if (!TrySplitKey(key, out string section, out string scope, out string property))
+                {
+                    throw new ArgumentException($"Invalid key '{key}'.", nameof(key));
+                }
+
+                _iniFile.UnsetValue(section, scope, property);
+            }
+        }
+
+        private static bool TrySplitKey(string key, out string section, out string scope, out string property)
+        {
+            section = null;
+            scope = null;
+            property = null;
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            int first = key.IndexOf('.');
+            int last = key.LastIndexOf('.');
+
+            if (first < 0 || last < 0)
+            {
+                return false;
+            }
+
+            // section.property
+            if (first == last)
+            {
+                section = key.Substring(0, first);
+                property = key.Substring(last + 1);
+
+                return true;
+            }
+
+            // section.scope.maybe.with.periods.property
+            section = key.Substring(0, first);
+            scope = key.Substring(first + 1, last - first - 1);
+            property = key.Substring(last + 1);
+
+            return true;
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/IniSerializer.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/IniSerializer.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Git.CredentialManager
+{
+    /// <summary>
+    /// Performs serialization and deserialization of INI files <seealso cref="IniFile"/>.
+    /// </summary>
+    public class IniSerializer
+    {
+        private static readonly Regex SectionRegex = new Regex(@"\[\s*(?<name>.+?)(?:\s+\""(?<scope>.+)\"")?\s*\]", RegexOptions.Compiled);
+        private static readonly Regex PropertyRegex = new Regex(@"(?<name>\S+?)\s*\=\s*(?<value>.+)?", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Serialize the given INI file to a <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="file">INI file to serialize.</param>
+        /// <param name="writer"><see cref="TextWriter"/> to serialize the INI file to.</param>
+        public void Serialize(IniFile file, TextWriter writer)
+        {
+            foreach (IniSection section in file.Sections)
+            {
+                if (section.Properties.Any())
+                {
+                    WriteSectionHeader(writer, section);
+                    writer.WriteLine();
+
+                    foreach (var property in section.Properties)
+                    {
+                        WriteProperty(writer, property);
+                        writer.WriteLine();
+                    }
+
+                    writer.WriteLine();
+                    writer.Flush();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deserialize an INI file from a <see cref="TextReader"/>.
+        /// </summary>
+        /// <param name="reader"><see cref="TextReader"/> to deserialize the INI file from.</param>
+        /// <returns>INI file.</returns>
+        public IniFile Deserialize(TextReader reader)
+        {
+            var file = new IniFile();
+
+            IniSection currentSection = null;
+
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                if (TryParseSection(line, out IniSection newSection))
+                {
+                    if (file.TryGetSection(newSection.Name, newSection.Scope, out IniSection existingSection))
+                    {
+                        currentSection = existingSection;
+                    }
+                    else
+                    {
+                        currentSection = newSection;
+                        file.Sections.Add(newSection);
+                    }
+                }
+                else if (TryParseProperty(line, out string propertyName, out string propertyValue))
+                {
+                    if (currentSection is null)
+                    {
+                        throw new Exception("Invalid INI file. Properties must exist in a section.");
+                    }
+
+                    currentSection.Properties[propertyName] = propertyValue;
+                }
+                else
+                {
+                    // Invalid line
+                }
+            }
+
+            return file;
+        }
+
+        #region Writer Helpers
+
+        private void WriteProperty(TextWriter writer, KeyValuePair<string, string> property)
+        {
+            writer.Write('\t');
+            writer.Write(property.Key);
+            writer.Write(" =");
+            if (!string.IsNullOrWhiteSpace(property.Value))
+            {
+                writer.Write(' ');
+                writer.Write(property.Value);
+            }
+        }
+
+        private void WriteSectionHeader(TextWriter writer, IniSection section)
+        {
+            writer.Write('[');
+            writer.Write(section.Name);
+            if (section.Scope != null)
+            {
+                writer.Write(" \"{0}\"", section.Scope);
+            }
+
+            writer.Write(']');
+        }
+
+        #endregion
+
+        #region Parsing Helpers
+
+        private bool TryParseSection(string line, out IniSection section)
+        {
+            var match = SectionRegex.Match(line);
+            if (match.Success)
+            {
+                string name = match.Groups["name"].Value;
+                string scope = match.Groups["scope"].Success ? match.Groups["scope"].Value : null;
+
+                section = new IniSection(name, scope);
+                return true;
+            }
+
+            section = null;
+            return false;
+        }
+
+        private bool TryParseProperty(string line, out string propertyName, out string propertyValue)
+        {
+            var match = PropertyRegex.Match(line);
+            if (match.Success)
+            {
+                propertyName = match.Groups["name"].Value;
+                propertyValue = match.Groups["value"].Success ? match.Groups["value"].Value : null;
+
+                return true;
+            }
+
+            propertyName = null;
+            propertyValue = null;
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/InputArguments.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/InputArguments.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Git.CredentialManager
                     ub.Port = port;
                 }
 
-                if (includeUser)
+                if (includeUser && !string.IsNullOrEmpty(UserName))
                 {
                     ub.UserName = Uri.EscapeDataString(UserName);
                 }

--- a/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
@@ -74,6 +74,11 @@ namespace Microsoft.Git.CredentialManager
             return TryGetUserInfo(uri, out string userName, out _) ? userName : null;
         }
 
+        public static Uri WithoutUserInfo(this Uri uri)
+        {
+            return new UriBuilder(uri) {UserName = string.Empty, Password = string.Empty}.Uri;
+        }
+
         public static IEnumerable<string> GetGitConfigurationScopes(this Uri uri)
         {
             EnsureArgument.NotNull(uri, nameof(uri));

--- a/src/shared/TestInfrastructure/Objects/InMemoryIniStore.cs
+++ b/src/shared/TestInfrastructure/Objects/InMemoryIniStore.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager.Tests.Objects
+{
+    public class InMemoryIniStore : IScopedTransactionalStore
+    {
+        private readonly object _txLock = new object();
+
+        public IDictionary<string, string> PersistedStore { get; }
+
+        public IDictionary<string, string> MemoryStore { get; }
+
+        public InMemoryIniStore() : this(EqualityComparer<string>.Default) { }
+
+        public InMemoryIniStore(IEqualityComparer<string> comparer)
+            : this(new Dictionary<string, string>(comparer)) { }
+
+        public InMemoryIniStore(Dictionary<string, string> persistedStore)
+        {
+            PersistedStore = persistedStore;
+            MemoryStore = new Dictionary<string, string>(persistedStore.Comparer);
+
+            Reload();
+        }
+
+        public Task Reload()
+        {
+            // Copy state from persisted store -> memory store
+            lock (_txLock)
+            {
+                MemoryStore.Clear();
+                foreach (var kvp in PersistedStore)
+                {
+                    MemoryStore.Add(kvp);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task Commit()
+        {
+            // Copy state from memory store -> persisted store
+            lock (_txLock)
+            {
+                PersistedStore.Clear();
+                foreach (var kvp in MemoryStore)
+                {
+                    PersistedStore.Add(kvp);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public IEnumerable<string> GetSectionScopes(string sectionName)
+        {
+            var scopes = new HashSet<string>();
+
+            string prefix = $"{sectionName}.";
+            var cmp = StringComparison.OrdinalIgnoreCase;
+            foreach (string key in MemoryStore.Keys.Where(x => x.StartsWith(prefix, cmp)))
+            {
+                int sectionIndex = key.IndexOf(".", cmp);
+                int propertyIndex = key.LastIndexOf(".", cmp);
+
+                if (sectionIndex > -1 && propertyIndex > -1)
+                {
+                    string scope = key.Substring(sectionIndex + 1,
+                        propertyIndex - sectionIndex - 1);
+                    scopes.Add(scope);
+                }
+            }
+
+            return scopes;
+        }
+
+        public bool TryGetValue(string key, out string value)
+        {
+            return MemoryStore.TryGetValue(key, out value);
+        }
+
+        public void SetValue(string key, string value)
+        {
+            MemoryStore[key] = value;
+        }
+
+        public void Remove(string key)
+        {
+            MemoryStore.Remove(key);
+        }
+    }
+}


### PR DESCRIPTION
Add a new setting that enables the Azure Repos provider to return the Azure Active Directory/Microsoft Account access tokens to Git directly, rather than exchanging them for an Azure DevOps Personal Access Token.

The default mode is to continue using PATs at the moment. The disable PATs set the following config:

```sh
git config --global credential.azreposPATMode false
```

New sub-commands are added to the `git-credential-manager-core azure-repos` command to list and override the binding of user accounts to Azure DevOps organisations and/or remote URLs.