### PR TITLE
Target .NET Framework 4.7.2 and fix missing binaries in Windows installers

### DIFF
--- a/.azure-pipelines/templates/windows/pack.yml
+++ b/.azure-pipelines/templates/windows/pack.yml
@@ -6,8 +6,8 @@ steps:
     displayName: Set version variables
 
   - script: |
-      xcopy "out\windows\Installer.Windows\bin\$(configuration)\net461"       "$(Build.StagingDirectory)\publish\"
-      xcopy "out\windows\Payload.Windows\bin\$(configuration)\net461\win-x86" "$(Build.StagingDirectory)\publish\payload\"
+      xcopy "out\windows\Installer.Windows\bin\$(configuration)\net472"       "$(Build.StagingDirectory)\publish\"
+      xcopy "out\windows\Payload.Windows\bin\$(configuration)\net472\win-x86" "$(Build.StagingDirectory)\publish\payload\"
       mkdir "$(Build.StagingDirectory)\publish\payload.sym\"
       move  "$(Build.StagingDirectory)\publish\payload\*.pdb"                 "$(Build.StagingDirectory)\publish\payload.sym\"
     displayName: Prepare final build artifacts

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,9 +35,9 @@ msbuild /t:restore /p:Configuration=WindowsDebug
 msbuild /p:Configuration=WindowsDebug
 ```
 
-You can find a copy of the installer .exe file in `out\windows\Installer.Windows\bin\Debug\net461`.
+You can find a copy of the installer .exe file in `out\windows\Installer.Windows\bin\Debug\net472`.
 
-The flat binaries can also be found in `out\windows\Payload.Windows\bin\Debug\net461\win-x86`.
+The flat binaries can also be found in `out\windows\Payload.Windows\bin\Debug\net472\win-x86`.
 
 ### Linux
 

--- a/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
+++ b/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
     <AssemblyName>Atlassian.Bitbucket</AssemblyName>
     <RootNamespace>Atlassian.Bitbucket</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Microsoft.Git.CredentialManager\Microsoft.Git.CredentialManager.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net472;netcoreapp3.1</TargetFrameworks>
     <RuntimeIdentifiers>win-x86;osx-x64;linux-x64</RuntimeIdentifiers>
     <PlatformTarget Condition="'$(OSPlatform)'=='windows'">x86</PlatformTarget>
     <AssemblyName>git-credential-manager-core</AssemblyName>

--- a/src/shared/GitHub/GitHub.csproj
+++ b/src/shared/GitHub/GitHub.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
     <AssemblyName>GitHub</AssemblyName>
     <RootNamespace>GitHub</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Microsoft.Git.CredentialManager\Microsoft.Git.CredentialManager.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
+++ b/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
     <AssemblyName>Microsoft.AzureRepos</AssemblyName>
     <RootNamespace>Microsoft.AzureRepos</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Microsoft.Git.CredentialManager\Microsoft.Git.CredentialManager.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
+++ b/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
     <AssemblyName>Microsoft.Git.CredentialManager</AssemblyName>
     <RootNamespace>Microsoft.Git.CredentialManager</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Atlassian.Bitbucket.UI.Windows.csproj
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Atlassian.Bitbucket.UI.Windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <UseWPF>true</UseWPF>
     <RootNamespace>Atlassian.Bitbucket.UI</RootNamespace>
     <AssemblyName>Atlassian.Bitbucket.UI</AssemblyName>

--- a/src/windows/GitHub.UI.Windows/GitHub.UI.Windows.csproj
+++ b/src/windows/GitHub.UI.Windows/GitHub.UI.Windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <UseWPF>true</UseWPF>
     <RootNamespace>GitHub.UI</RootNamespace>
     <AssemblyName>GitHub.UI</AssemblyName>

--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -3,9 +3,9 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <PayloadPath>$(PlatformOutPath)Payload.Windows\bin\$(Configuration)\net461\win-x86</PayloadPath>
+    <PayloadPath>$(PlatformOutPath)Payload.Windows\bin\$(Configuration)\net472\win-x86</PayloadPath>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -115,6 +115,11 @@ Source: "{#PayloadDir}\Microsoft.Git.CredentialManager.UI.dll";        DestDir: 
 Source: "{#PayloadDir}\Microsoft.Identity.Client.dll";                 DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Identity.Client.Extensions.Msal.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Newtonsoft.Json.dll";                           DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\System.Buffers.dll";                            DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\System.CommandLine.dll";                        DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\System.Memory.dll";                             DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\System.Numerics.Vectors.dll";                   DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\System.Runtime.CompilerServices.Unsafe.dll";    DestDir: "{app}"; Flags: ignoreversion
 
 [Code]
 // Don't allow installing conflicting architectures

--- a/src/windows/Payload.Windows/Payload.Windows.csproj
+++ b/src/windows/Payload.Windows/Payload.Windows.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/src/windows/Shared.UI.Windows/Shared.UI.Windows.csproj
+++ b/src/windows/Shared.UI.Windows/Shared.UI.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <UseWPF>true</UseWPF>
     <RootNamespace>Microsoft.Git.CredentialManager.UI</RootNamespace>
     <AssemblyName>Microsoft.Git.CredentialManager.UI</AssemblyName>


### PR DESCRIPTION
When we added support for `System.CommandLine` I neglected to add the extra binaries it brings to the party in the Windows installers. D'oh!

Given the `System.CommandLine` is a .NET Standard targeting library, and we're currently targeting .NET Framework 4.6.1 on Windows, this brings in _a lot_ of compatibility and shim/type forwarding binaries (since `net461` doesn't perfectly implement `netstandard2.0`.. go figure). [We've asked for them to consider targeting a downlevel net461 TFM](https://github.com/dotnet/command-line-api/issues/1194), but in reality we can also just as easily increase our TFM to `net472`, which doesn't require any of those shim binaries.

.NET Framework 4.7.2 is supported on Windows versions all the way back to Windows 7 SP1, so we won't be removing any users from the support matrix. Git for Windows supports Vista, but since GCM Core is already targeting `net461`, it doesn't run on Vista today(!) Vista only supports 4.6(.0) as the latest Framework version.

We could also drop the `System.CommandLine` usage, but I'd rather not. It's worth it IMO.