### PR TITLE
documented behavior under `credential.useHttpPath`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,3 +249,58 @@ git config --global credential.msauthFlow devicecode
 ```
 
 **Also see: [GCM_MSAUTH_FLOW](environment.md#GCM_MSAUTH_FLOW)**
+
+---
+
+### credential.useHttpPath
+
+Tells Git to pass the entire repository URL, rather than just the hostname, when calling out to a credential provider. (This setting [comes from Git itself](https://git-scm.com/docs/gitcredentials/#Documentation/gitcredentials.txt-useHttpPath), not GCM Core.)
+
+Defaults to `false`.
+
+Value|Authentication Flow
+-|-
+`false` _(default)_|Git will use only `user` and `hostname` to look up credentials.
+`true`|Git will use the full repository URL to look up credentials.
+
+#### Example
+
+For a user whose login is `alice`, and with `credential.useHttpPath` set to `false` (or not set), the following remote URLs will use the same credentials:
+
+```text
+Credential: "git:https://github.com" (user = alice) 
+
+   https://github.com/foo/bar
+   https://github.com/contoso/widgets
+   https://alice@github.com/contoso/widgets
+```
+```text
+Credential: "git:https://bob@github.com" (user = bob)
+
+   https://bob@github.com/foo/bar
+   https://bob@github.com/example/myrepo
+```
+
+Under the same user but with `credential.useHttpPath` set to `true`, these credentials would be used:
+
+```text
+Credential: "git:https://github.com/foo/bar" (user = alice)
+
+   https://github.com/foo/bar
+```
+```text
+Credential: "git:https://github.com/contoso/widgets" (user = alice)
+
+   https://github.com/contoso/widgets
+   https://alice@github.com/contoso/widgets
+```
+```text
+Credential: "git:https://bob@github.com/foo/bar" (user = bob)
+
+   https://bob@github.com/foo/bar
+```
+```text
+Credential: "git:https://bob@github.com/example/myrepo" (user = bob)
+
+   https://bob@github.com/example/myrepo
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,12 @@ Tells Git to pass the entire repository URL, rather than just the hostname, when
 
 Defaults to `false`.
 
+**Note:** GCM Core sets this value to `true` for `dev.azure.com` (Azure Repos) hosts after installation by default.
+
+This is because `dev.azure.com` alone is not enough information to determine the correct Azure authentication authority - we require a part of the path. The fallout of this is that for `dev.azure.com` remote URLs we do not support storing credentials against the full-path. We always store against the `dev.azure.com/org-name` stub.
+
+In order to use Azure Repos and store credentials against a full-path URL, you must use the `org-name.visualstudio.com` remote URL format instead.
+
 Value|Git Behavior
 -|-
 `false` _(default)_|Git will use only `user` and `hostname` to look up credentials.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,7 +258,7 @@ Tells Git to pass the entire repository URL, rather than just the hostname, when
 
 Defaults to `false`.
 
-Value|Authentication Flow
+Value|Git Behavior
 -|-
 `false` _(default)_|Git will use only `user` and `hostname` to look up credentials.
 `true`|Git will use the full repository URL to look up credentials.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,7 +271,7 @@ Value|Git Behavior
 
 #### Example
 
-For a user whose login is `alice`, and with `credential.useHttpPath` set to `false` (or not set), the following remote URLs will use the same credentials:
+On Windows using GitHub, for a user whose login is `alice`, and with `credential.useHttpPath` set to `false` (or not set), the following remote URLs will use the same credentials:
 
 ```text
 Credential: "git:https://github.com" (user = alice) 


### PR DESCRIPTION
fixes https://github.com/microsoft/Git-Credential-Manager-Core/issues/253