### PR TITLE
Fix computation of app path when published as a "single file"

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -76,8 +76,13 @@ namespace Microsoft.Git.CredentialManager
                 rootCommand.AddCommand(providerCommand);
             }
 
-            // Trace the current version and program arguments
-            Context.Trace.WriteLine($"{Constants.GetProgramHeader()} '{string.Join(" ", args)}'");
+            // Trace the current version, OS, runtime, and program arguments
+            PlatformInformation info = PlatformUtils.GetPlatformInformation();
+            Context.Trace.WriteLine($"Version: {Constants.GcmVersion}");
+            Context.Trace.WriteLine($"Runtime: {info.ClrVersion}");
+            Context.Trace.WriteLine($"Platform: {info.OperatingSystemType} ({info.CpuArchitecture})");
+            Context.Trace.WriteLine($"AppPath: {_appPath}");
+            Context.Trace.WriteLine($"Arguments: {string.Join(" ", args)}");
 
             try
             {

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System.Diagnostics;
+using System;
 using System.Reflection;
 
 namespace Microsoft.Git.CredentialManager
@@ -105,33 +105,33 @@ namespace Microsoft.Git.CredentialManager
             public const string GcmLinuxCredStores     = "https://aka.ms/gcmcore-linuxcredstores";
         }
 
-        private static string _gcmVersion;
+        private static Version _gcmVersion;
 
-        /// <summary>
-        /// The current version of Git Credential Manager.
-        /// </summary>
-        public static string GcmVersion
+        public static Version GcmVersion
         {
             get
             {
                 if (_gcmVersion is null)
                 {
-                    _gcmVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+                    var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+                    var attr = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+                    if (attr is null)
+                    {
+                        _gcmVersion = assembly.GetName().Version;
+                    }
+                    else if (Version.TryParse(attr.Version, out Version asmVersion))
+                    {
+                        _gcmVersion = asmVersion;
+                    }
+                    else
+                    {
+                        // Unknown version!
+                        _gcmVersion = new Version(0, 0);
+                    }
                 }
 
                 return _gcmVersion;
             }
-        }
-
-        /// <summary>
-        /// Get standard program header title for Git Credential Manager, including the current version and OS information.
-        /// </summary>
-        /// <returns>Standard program header.</returns>
-        public static string GetProgramHeader()
-        {
-            PlatformInformation info = PlatformUtils.GetPlatformInformation();
-
-            return $"Git Credential Manager version {GcmVersion} ({info.OperatingSystemType}, {info.ClrVersion})";
         }
 
         /// <summary>


### PR DESCRIPTION
When publishing GCM as a 'single file' application, the computed path to the entry executable is no longer correct.
    
On .NET Core 3.1, using `Assembly.Location` resolves to the temporary extracted DLL file path. On .NET 5 `Assembly.Location` always returns the empty string.
    
Since .NET 5, published single-file apps no longer use the self-extraction model, and are real single file with all assemblies and native libraries statically linked/bundled.

We now use the `Environment.GetCommandLineArgs()` method to get the raw underlying "argv" arguments, which argv[0] is the absolute file path to the entry executable.
    
We also change how we get the application version number to look for the assembly attribute, rather than extract if from the file on disk.
    
At app startup, also change the way we trace system information to be more readable.

Fixes #229
Fixes #252