### PR TITLE
Initial pass at GCM_VSTS_SCOPE

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,21 @@ git config --global credential.gitHubAuthModes "oauth,basic"
 
 ---
 
+### vstsScope
+
+Overrides GCM default scope request when generating a Personal Access Token from Azure DevOps.
+The supported format is one or more [scope values](https://docs.microsoft.com/en-us/vsts/integrate/get-started/authentication/oauth#scopes) separated by whitespace, commas, semi-colons, or pipe `'|'` characters.
+
+Defaults to `vso.code_write|vso.packaging`; Honored when host is 'dev.azure.com'.
+
+```shell
+git config --global credential.microsoft.visualstudio.com.vstsScope vso.code_write|vso.packaging_write|vso.test_write
+```
+
+See [GCM_VSTS_SCOPE](Environment.md#gcm_vsts_scope)
+
+---
+
 ### credential.namespace
 
 Use a custom namespace prefix for credentials read and written in the OS credential store.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -312,6 +312,29 @@ export GCM_GITHUB_AUTHMODES="oauth,basic"
 
 ---
 
+### GCM_VSTS_SCOPE
+
+Overrides GCM default scope request when generating a Personal Access Token from Azure DevOps.
+The supported format is one or more [scope values](https://docs.microsoft.com/en-us/vsts/integrate/get-started/authentication/oauth#scopes) separated by whitespace, commas, semi-colons, or pipe characters (`' '`, `','`, `';'`, `'|'`).
+
+Defaults to `vso.code_write|vso.packaging`; Honored when host is 'visualstudio.com'.
+
+##### Windows
+
+```batch
+SET GCM_VSTS_SCOPE="vso.code_write"
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_VSTS_SCOPE="vso.code_write"
+```
+
+**Also see: [credential.namespace](configuration.md#credentialnamespace)**
+
+---
+
 ### GCM_NAMESPACE
 
 Use a custom namespace prefix for credentials read and written in the OS credential store.

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -36,7 +36,8 @@ namespace Microsoft.AzureRepos
             public const string DevAadClientId = "GCM_DEV_AZREPOS_CLIENTID";
             public const string DevAadRedirectUri = "GCM_DEV_AZREPOS_REDIRECTURI";
             public const string DevAadAuthorityBaseUri = "GCM_DEV_AZREPOS_AUTHORITYBASEURI";
-            public const string GcmVstsScope          = "GCM_VSTS_SCOPE";
+            public const string GcmVstsScope = "GCM_VSTS_SCOPE";
+            public const string GcmDevOpsScope = "GCM_DEVOPS_SCOPE";
         }
 
         public static class GitConfiguration

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AzureRepos
         {
             public const string ReposWrite = "vso.code_write";
             public const string ArtifactsRead = "vso.packaging";
+            public static readonly string[] DefaultScopes = new string[] {ReposWrite, ArtifactsRead};
         }
 
         public static class EnvironmentVariables
@@ -35,6 +36,7 @@ namespace Microsoft.AzureRepos
             public const string DevAadClientId = "GCM_DEV_AZREPOS_CLIENTID";
             public const string DevAadRedirectUri = "GCM_DEV_AZREPOS_REDIRECTURI";
             public const string DevAadAuthorityBaseUri = "GCM_DEV_AZREPOS_AUTHORITYBASEURI";
+            public const string GcmVstsScope          = "GCM_VSTS_SCOPE";
         }
 
         public static class GitConfiguration
@@ -44,6 +46,8 @@ namespace Microsoft.AzureRepos
                 public const string DevAadClientId = "azreposDevClientId";
                 public const string DevAadRedirectUri = "azreposDevRedirectUri";
                 public const string DevAadAuthorityBaseUri = "azreposDevAuthorityBaseUri";
+                public const string DevOpsScope = "devopsScope";
+                public const string VstsScope = "vstsScope";
             }
         }
     }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -176,7 +176,7 @@ namespace Microsoft.AzureRepos
         {
             string @namespace;
             if (_context.Settings.TryGetSetting(
-                    AzureDevOpsConstants.EnvironmentVariables.GcmVstsScope,
+                    AzureDevOpsConstants.EnvironmentVariables.GcmDevOpsScope,
                     Constants.GitConfiguration.Credential.SectionName,
                     AzureDevOpsConstants.GitConfiguration.Credential.DevOpsScope,
                     out @namespace) 


### PR DESCRIPTION
Bit of an awkward timing as in many cases we are trying to move away from PATs, but for scenarios where we still need to use PATs, I'm thinking we want to centralize this across the various DevOps protocols.  For example, I would love to replace the guts of various Artifacts cred providers with a shell out to GCM.

Mostly copy/paste from the old repo :)