### PR TITLE
Run postinstall and uninstall configure commands as current user

### DIFF
--- a/src/osx/Installer.Mac/scripts/postinstall
+++ b/src/osx/Installer.Mac/scripts/postinstall
@@ -30,7 +30,8 @@ fi
 mkdir -p /usr/local/bin
 /bin/ln -Fs "$INSTALL_DESTINATION/git-credential-manager-core" /usr/local/bin/git-credential-manager-core
 
-# Configure GCM for the current user
-"$INSTALL_DESTINATION/git-credential-manager-core" configure
+# Configure GCM for the current user (running as the current user to avoid root
+# from taking ownership of ~/.gitconfig)
+sudo -u ${USER} "$INSTALL_DESTINATION/git-credential-manager-core" configure
 
 exit 0

--- a/src/osx/Installer.Mac/uninstall.sh
+++ b/src/osx/Installer.Mac/uninstall.sh
@@ -10,9 +10,9 @@ then
 	exit $?
 fi
 
-# Unconfigure
+# Unconfigure (as the current user)
 echo "Unconfiguring credential helper..."
-"$GCMBIN" unconfigure
+sudo -u `/usr/bin/logname` "$GCMBIN" unconfigure
 
 # Remove symlink
 if [ -L /usr/local/bin/git-credential-manager-core ]


### PR DESCRIPTION
In the macOS installer postinstall script we run the `configure` command to get GCM to configure the current user's credential helper as GCM.

However, the postinstall script is often run as root (because that's how `installer` works out of the box), meaning although GCM will be writing to the ~/.gitconfig file, it will be doing so from a process running as root.

To avoid having root take ownership of ~/.gitconfig we run `sudo -u` to run the `configure` command as the real user (not root).

Also update the uninstall script to do the same thing (run `unconfigure` as the non-root user).

Fixes #186 