### PR TITLE
Ensure we locate UI helpers correctly on Linux/published as a single file

### DIFF
--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Git.CredentialManager
         public static void Main(string[] args)
         {
             string appPath = GetApplicationPath();
-            using (var context = new CommandContext())
-            using (var app = new Application(context, appPath))
+            using (var context = new CommandContext(appPath))
+            using (var app = new Application(context))
             {
                 // Register all supported host providers at the normal priority.
                 // The generic provider should never win against a more specific one, so register it with low priority.

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
             await application.ConfigureAsync(ConfigurationTarget.User);
 
             Assert.Single(context.Git.Configuration.Global);
@@ -34,8 +34,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string> {executablePath};
 
@@ -55,8 +55,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {
@@ -80,8 +80,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {
@@ -106,8 +106,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {
@@ -133,8 +133,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {
@@ -160,8 +160,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {
@@ -186,8 +186,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
             await application.UnconfigureAsync(ConfigurationTarget.User);
 
             Assert.Empty(context.Git.Configuration.Global);
@@ -199,8 +199,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string> {executablePath};
 
@@ -216,8 +216,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string> {emptyHelper, executablePath};
 
@@ -234,8 +234,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {
@@ -258,8 +258,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {
@@ -284,8 +284,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager-core";
             string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
 
-            var context = new TestCommandContext();
-            IConfigurableComponent application = new Application(context, executablePath);
+            var context = new TestCommandContext {AppPath = executablePath};
+            IConfigurableComponent application = new Application(context);
 
             context.Git.Configuration.Global[key] = new List<string>
             {

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -17,27 +17,23 @@ namespace Microsoft.Git.CredentialManager
 {
     public class Application : ApplicationBase, IConfigurableComponent
     {
-        private readonly string _appPath;
         private readonly IHostProviderRegistry _providerRegistry;
         private readonly IConfigurationService _configurationService;
         private readonly IList<ProviderCommand> _providerCommands = new List<ProviderCommand>();
 
-        public Application(ICommandContext context, string appPath)
-            : this(context, new HostProviderRegistry(context), new ConfigurationService(context), appPath)
+        public Application(ICommandContext context)
+            : this(context, new HostProviderRegistry(context), new ConfigurationService(context))
         {
         }
 
         internal Application(ICommandContext context,
                              IHostProviderRegistry providerRegistry,
-                             IConfigurationService configurationService,
-                             string appPath)
+                             IConfigurationService configurationService)
             : base(context)
         {
             EnsureArgument.NotNull(providerRegistry, nameof(providerRegistry));
             EnsureArgument.NotNull(configurationService, nameof(configurationService));
-            EnsureArgument.NotNullOrWhiteSpace(appPath, nameof(appPath));
 
-            _appPath = appPath;
             _providerRegistry = providerRegistry;
             _configurationService = configurationService;
 
@@ -84,7 +80,7 @@ namespace Microsoft.Git.CredentialManager
             Context.Trace.WriteLine($"Version: {Constants.GcmVersion}");
             Context.Trace.WriteLine($"Runtime: {info.ClrVersion}");
             Context.Trace.WriteLine($"Platform: {info.OperatingSystemType} ({info.CpuArchitecture})");
-            Context.Trace.WriteLine($"AppPath: {_appPath}");
+            Context.Trace.WriteLine($"AppPath: {Context.ApplicationPath}");
             Context.Trace.WriteLine($"Arguments: {string.Join(" ", args)}");
 
             var parser = new CommandLineBuilder(rootCommand)
@@ -243,18 +239,18 @@ namespace Microsoft.Git.CredentialManager
         {
             const string gitCredentialPrefix = "git-credential-";
 
-            string appName = Path.GetFileNameWithoutExtension(_appPath);
+            string appName = Path.GetFileNameWithoutExtension(Context.ApplicationPath);
             if (appName != null && appName.StartsWith(gitCredentialPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return appName.Substring(gitCredentialPrefix.Length);
             }
 
-            return _appPath;
+            return Context.ApplicationPath;
         }
 
         private string GetGitConfigAppPath()
         {
-            string path = _appPath;
+            string path = Context.ApplicationPath;
 
             // On Windows we must use UNIX style path separators
             if (PlatformUtils.IsWindows())

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
             }
             else
             {
-                string executableDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string executableDirectory = Path.GetDirectoryName(Context.ApplicationPath);
                 path = Path.Combine(executableDirectory!, helperName);
             }
 

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Git.CredentialManager
     public interface ICommandContext : IDisposable
     {
         /// <summary>
+        /// Absolute path the application entry executable.
+        /// </summary>
+        string ApplicationPath { get; }
+
+        /// <summary>
         /// Settings and configuration for Git Credential Manager.
         /// </summary>
         ISettings Settings { get; }
@@ -75,8 +80,11 @@ namespace Microsoft.Git.CredentialManager
     /// </summary>
     public class CommandContext : DisposableObject, ICommandContext
     {
-        public CommandContext()
+        public CommandContext(string appPath)
         {
+            EnsureArgument.NotNullOrWhiteSpace(appPath, nameof (appPath));
+
+            ApplicationPath = appPath;
             Streams = new StandardStreams();
             Trace   = new Trace();
 
@@ -164,6 +172,8 @@ namespace Microsoft.Git.CredentialManager
         }
 
         #region ICommandContext
+
+        public string ApplicationPath { get; }
 
         public ISettings Settings { get; }
 

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
     {
         public TestCommandContext()
         {
+            AppPath = PlatformUtils.IsWindows()
+                ? @"C:\Program Files\Git Credential Manager Core\git-credential-manager-core.exe"
+                : "/usr/local/bin/git-credential-manager-core";
+
             Streams = new TestStandardStreams();
             Terminal = new TestTerminal();
             SessionManager = new TestSessionManager();
@@ -26,6 +30,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             Settings = new TestSettings {Environment = Environment, GitConfiguration = Git.Configuration};
         }
 
+        public string AppPath { get; set; }
         public TestSettings Settings { get; set; }
         public TestStandardStreams Streams { get; set; }
         public TestTerminal Terminal { get; set; }
@@ -39,6 +44,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         public TestSystemPrompts SystemPrompts { get; set; }
 
         #region ICommandContext
+
+        string ICommandContext.ApplicationPath => AppPath;
 
         IStandardStreams ICommandContext.Streams => Streams;
 


### PR DESCRIPTION
Ensure that we are using the correct entry executable directory when published as a single file application. When looking for UI helpers we were still using the Assembly::Location property, which is `null` for single file applications.

Move to pass the (correctly computed) application path to the `ICommandContext`, which is available everywhere.

Fixes #309