### PR TITLE
Drop the git config --show-scope option usage

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/GitConfigurationEntry.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfigurationEntry.cs
@@ -4,14 +4,12 @@ namespace Microsoft.Git.CredentialManager
 {
     public class GitConfigurationEntry
     {
-        public GitConfigurationEntry(GitConfigurationLevel level, string key, string value)
+        public GitConfigurationEntry(string key, string value)
         {
-            Level = level;
             Key = key;
             Value = value;
         }
 
-        public GitConfigurationLevel Level { get; }
         public string Key { get; }
         public string Value { get; }
     }

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
                 {
                     foreach (var value in kvp.Value)
                     {
-                        var entry = new GitConfigurationEntry(dictLevel, kvp.Key, value);
+                        var entry = new GitConfigurationEntry(kvp.Key, value);
                         if (!cb(entry))
                         {
                             break;


### PR DESCRIPTION
The Git config `--show-scope` option was only introduced in Git from
version 2.26 onwards. The latest version of Git available in some
distributions of Linux (or macOS) is often older.

We only needed to know the scope of configuration values in one
particular call site: reading all Azure Repos user bindinds.

Replace the single `IGitConfiguration::Enumerate` call with two calls to
`Enumerate`, one for the global scope, and one for the local one.

Drop the --show-scope option parsing.

Fixes: #313