### PR TITLE
Add support for Windows broker (WAM)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -256,11 +256,12 @@ git config --global credential.plaintextStorePath /mnt/external-drive/credential
 
 Specify which authentication flow should be used when performing Microsoft authentication and an interactive flow is required.
 
-Defaults to the value `auto`.
+Defaults to `auto`.
 
 **Note:** If [`credential.msauthUseBroker`](#credentialmsauthusebroker) is set
 to `true` and the operating system authentication broker is available, all flows
-will be delegated to the broker; this setting has no effect.
+will be delegated to the broker. If both of those things are true, then the
+value of `credential.msauthFlow` has no effect.
 
 Value|Authentication Flow
 -|-
@@ -283,7 +284,7 @@ git config --global credential.msauthFlow devicecode
 
 Use the operating system account manager where available.
 
-Defaults to the value `true`.
+Defaults to `true`.
 
 Value|Description
 -|-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,17 +284,17 @@ git config --global credential.msauthFlow devicecode
 
 Use the operating system account manager where available.
 
-Defaults to `true`.
+Defaults to `false`. This default is subject to change in the future.
 
 Value|Description
 -|-
-`true` _(default)_|Use the operating system account manager as an authentication broker.
-`false`|Do not use the broker.
+`true`|Use the operating system account manager as an authentication broker.
+`false` _(default)_|Do not use the broker.
 
 #### Example
 
 ```shell
-git config --global credential.msauthUseBroker false
+git config --global credential.msauthUseBroker true
 ```
 
 **Also see: [GCM_MSAUTH_USEBROKER](environment.md#GCM_MSAUTH_USEBROKER)**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,10 @@ Specify which authentication flow should be used when performing Microsoft authe
 
 Defaults to the value `auto`.
 
+**Note:** If [`credential.msauthUseBroker`](#credentialmsauthusebroker) is set
+to `true` and the operating system authentication broker is available, all flows
+will be delegated to the broker; this setting has no effect.
+
 Value|Authentication Flow
 -|-
 `auto` _(default)_|Select the best option depending on the current environment and platform.
@@ -272,6 +276,27 @@ git config --global credential.msauthFlow devicecode
 ```
 
 **Also see: [GCM_MSAUTH_FLOW](environment.md#GCM_MSAUTH_FLOW)**
+
+---
+
+### credential.msauthUseBroker
+
+Use the operating system account manager where available.
+
+Defaults to the value `true`.
+
+Value|Description
+-|-
+`true` _(default)_|Use the operating system account manager as an authentication broker.
+`false`|Do not use the broker.
+
+#### Example
+
+```shell
+git config --global credential.msauthUseBroker false
+```
+
+**Also see: [GCM_MSAUTH_USEBROKER](environment.md#GCM_MSAUTH_USEBROKER)**
 
 ---
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -436,17 +436,17 @@ export GCM_MSAUTH_FLOW="devicecode"
 
 Use the operating system account manager where available.
 
-Defaults to `true`.
+Defaults to `false`. This default is subject to change in the future.
 
 Value|Description
 -|-
-`true` _(default)_|Use the operating system account manager as an authentication broker.
-`false`|Do not use the broker.
+`true`|Use the operating system account manager as an authentication broker.
+`false` _(default)_|Do not use the broker.
 
 ##### Windows
 
 ```batch
-SET GCM_MSAUTH_USEBROKER="false"
+SET GCM_MSAUTH_USEBROKER="true"
 ```
 
 ##### macOS/Linux

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -402,11 +402,12 @@ export GCM_PLAINTEXT_STORE_PATH=/mnt/external-drive/credentials
 
 Specify which authentication flow should be used when performing Microsoft authentication and an interactive flow is required.
 
-Defaults to the value `auto`.
+Defaults to `auto`.
 
 **Note:** If [`GCM_MSAUTH_USEBROKER`](#gcm_msauth_usebroker) is set to `true`
 and the operating system authentication broker is available, all flows will be
-delegated to the broker; this setting has no effect.
+delegated to the broker. If both of those things are true, then the value of
+`GCM_MSAUTH_FLOW` has no effect.
 
 Value|Authentication Flow
 -|-
@@ -435,7 +436,7 @@ export GCM_MSAUTH_FLOW="devicecode"
 
 Use the operating system account manager where available.
 
-Defaults to the value `true`.
+Defaults to `true`.
 
 Value|Description
 -|-

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -404,6 +404,10 @@ Specify which authentication flow should be used when performing Microsoft authe
 
 Defaults to the value `auto`.
 
+**Note:** If [`GCM_MSAUTH_USEBROKER`](#gcm_msauth_usebroker) is set to `true`
+and the operating system authentication broker is available, all flows will be
+delegated to the broker; this setting has no effect.
+
 Value|Authentication Flow
 -|-
 `auto` _(default)_|Select the best option depending on the current environment and platform.
@@ -424,6 +428,33 @@ export GCM_MSAUTH_FLOW="devicecode"
 ```
 
 **Also see: [credential.msauthFlow](configuration.md#credentialmsauthflow)**
+
+---
+
+### GCM_MSAUTH_USEBROKER
+
+Use the operating system account manager where available.
+
+Defaults to the value `true`.
+
+Value|Description
+-|-
+`true` _(default)_|Use the operating system account manager as an authentication broker.
+`false`|Do not use the broker.
+
+##### Windows
+
+```batch
+SET GCM_MSAUTH_USEBROKER="false"
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_MSAUTH_USEBROKER="false"
+```
+
+**Also see: [credential.msauthUseBroker](configuration.md#credentialmsauthusebroker)**
 
 ---
 

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -400,26 +400,29 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
         private bool CanUseBroker()
         {
-            // We only support the broker on Windows 10 and .NET Framework
 #if NETFRAMEWORK
-            if (Context.SessionManager.IsDesktopSession && PlatformUtils.IsWindows10())
+            // We only support the broker on Windows 10 and require an interactive session
+            if (!Context.SessionManager.IsDesktopSession || !PlatformUtils.IsWindows10())
             {
-                // Default to using the OS broker
-                const bool defaultValue = true;
+                return false;
+            }
 
-                if (Context.Settings.TryGetSetting(Constants.EnvironmentVariables.MsAuthUseBroker,
+            // Default to using the OS broker
+            const bool defaultValue = true;
+
+            if (Context.Settings.TryGetSetting(Constants.EnvironmentVariables.MsAuthUseBroker,
                     Constants.GitConfiguration.Credential.SectionName,
                     Constants.GitConfiguration.Credential.MsAuthUseBroker,
                     out string valueStr))
-                {
-                    return valueStr.ToBooleanyOrDefault(defaultValue);
-                }
-
-                return defaultValue;
+            {
+                return valueStr.ToBooleanyOrDefault(defaultValue);
             }
-#endif
 
+            return defaultValue;
+#else
+            // OS broker requires .NET Framework right now until we migrate to .NET 5.0 (net5.0-windows10.x.y.z)
             return false;
+#endif
         }
 
         private bool CanUseEmbeddedWebView()

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -267,14 +267,12 @@ namespace Microsoft.Git.CredentialManager.Authentication
                 return;
             }
 
-            string clientId = app.AppConfig.ClientId;
-
             // We use the MSAL extension library to provide us consistent cache file access semantics (synchronisation, etc)
             // as other Microsoft developer tools such as the Azure PowerShell CLI.
             MsalCacheHelper helper = null;
             try
             {
-                var storageProps = CreateTokenCacheProps(clientId, useLinuxFallback: false);
+                var storageProps = CreateTokenCacheProps(useLinuxFallback: false);
                 helper = await MsalCacheHelper.CreateAsync(storageProps);
 
                 // Test that cache access is working correctly
@@ -300,7 +298,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
                     // On Linux the SecretService/keyring might not be available so we must fall-back to a plaintext file.
                     Context.Streams.Error.WriteLine("warning: using plain-text fallback token cache");
                     Context.Trace.WriteLine("Using fall-back plaintext token cache on Linux.");
-                    var storageProps = CreateTokenCacheProps(clientId, useLinuxFallback: true);
+                    var storageProps = CreateTokenCacheProps(useLinuxFallback: true);
                     helper = await MsalCacheHelper.CreateAsync(storageProps);
                 }
             }
@@ -317,7 +315,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
             }
         }
 
-        private StorageCreationProperties CreateTokenCacheProps(string clientId, bool useLinuxFallback)
+        private StorageCreationProperties CreateTokenCacheProps(bool useLinuxFallback)
         {
             const string cacheFileName = "msal.cache";
             string cacheDirectory;
@@ -336,7 +334,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
             }
 
             // The keychain is used on macOS with the following service & account names
-            var builder = new StorageCreationPropertiesBuilder(cacheFileName, cacheDirectory, clientId)
+            var builder = new StorageCreationPropertiesBuilder(cacheFileName, cacheDirectory)
                 .WithMacKeyChain("Microsoft.Developer.IdentityService", "MSALCache");
 
             if (useLinuxFallback)

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
         Auto = 0,
         EmbeddedWebView = 1,
         SystemWebView = 2,
-        DeviceCode = 3,
+        DeviceCode = 3
     }
 
     public class MicrosoftAuthentication : AuthenticationBase, IMicrosoftAuthentication

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -405,8 +405,8 @@ namespace Microsoft.Git.CredentialManager.Authentication
                 return false;
             }
 
-            // Default to using the OS broker
-            const bool defaultValue = true;
+            // Default to not using the OS broker
+            const bool defaultValue = false;
 
             if (Context.Settings.TryGetSetting(Constants.EnvironmentVariables.MsAuthUseBroker,
                     Constants.GitConfiguration.Credential.SectionName,

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Git.CredentialManager
             public const string GcmInteractive        = "GCM_INTERACTIVE";
             public const string GcmParentWindow       = "GCM_MODAL_PARENTHWND";
             public const string MsAuthFlow            = "GCM_MSAUTH_FLOW";
+            public const string MsAuthUseBroker       = "GCM_MSAUTH_USEBROKER";
             public const string GcmCredNamespace      = "GCM_NAMESPACE";
             public const string GcmCredentialStore    = "GCM_CREDENTIAL_STORE";
             public const string GcmCredCacheOptions   = "GCM_CREDENTIAL_CACHE_OPTIONS";
@@ -83,6 +84,7 @@ namespace Microsoft.Git.CredentialManager
                 public const string UseHttpPath = "useHttpPath";
                 public const string Interactive = "interactive";
                 public const string MsAuthFlow  = "msauthFlow";
+                public const string MsAuthUseBroker = "msauthUseBroker";
                 public const string CredNamespace = "namespace";
                 public const string CredentialStore = "credentialStore";
                 public const string CredCacheOptions = "cacheOptions";

--- a/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
+++ b/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
@@ -13,12 +13,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.29.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.25.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.16.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.29.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 

--- a/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Git.CredentialManager
             // https://github.com/dotnet/runtime/blob/6578f257e3be2e2144a65769706e981961f0130c/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L110-L122
             //
             // Note that we cannot use Environment.OSVersion in .NET Framework (or Core versions less than 5.0) as
-            // The implementation in those versions "lies" about Windows versions > 8.1 if there is no application manifest.
+            // the implementation in those versions "lies" about Windows versions > 8.1 if there is no application manifest.
             if (RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) != 0)
             {
                 return false;

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -112,14 +112,19 @@ Source: "{#PayloadDir}\GitHub.UI.exe.config";                          DestDir: 
 Source: "{#PayloadDir}\Microsoft.AzureRepos.dll";                      DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Git.CredentialManager.dll";           DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Git.CredentialManager.UI.dll";        DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Identity.Client.Desktop.dll";         DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Identity.Client.dll";                 DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Identity.Client.Extensions.Msal.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Web.WebView2.Core.dll";               DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Web.WebView2.WinForms.dll";           DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Web.WebView2.Wpf.dll";                DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Newtonsoft.Json.dll";                           DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.Buffers.dll";                            DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.CommandLine.dll";                        DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.Memory.dll";                             DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.Numerics.Vectors.dll";                   DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.Runtime.CompilerServices.Unsafe.dll";    DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\WebView2Loader.dll";                            DestDir: "{app}"; Flags: ignoreversion
 
 [Code]
 // Don't allow installing conflicting architectures


### PR DESCRIPTION
Add support for broker-assisted authentication on Windows using "WAM" (Web Authentication Manager) as provided by the MSAL.Desktop library.

The `GCM_MSAUTH_USEBROKER` environment variable or the `credential.msauthUseBroker` configuration option will control if WAM is enabled or not. ~By default WAM _is_ enabled.~

This ended up being simpler then I expected. Looks like the VS AAD app registration has now been updated to have the required WAM redirect URI which was previously a technical blocker.

Fixes #211 

**Update:** WAM is now default _disabled_ due to concerns about the maturity of the UX and technology. cc: @bgavrilMS 