### PR TITLE
Updating release-winget according to manifest schema changes

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -12,13 +12,13 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
-      branch: master
       uses: mjcheetham/update-winget@v1.1
       with:
         id: Microsoft.GitCredentialManagerCore
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
         repo: ldennington/winget-playground
+        branch: master
         manifestText: |
           PackageIdentifier: {{id}}
           PackageVersion: {{version}}

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -9,11 +9,12 @@ jobs:
     steps:
     - id: update winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.1
+      uses: mjcheetham/update-winget@v1.2
       with:
         id: Microsoft.GitCredentialManagerCore
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
+        repo: ldennington/winget-playground
         manifestText: |
           PackageIdentifier: {{id}}
           PackageVersion: {{version}}
@@ -33,3 +34,5 @@ jobs:
           ManifestType: singleton
           ManifestVersion: 1.0.0
         alwaysUsePullRequest: true
+        releaseRepo: 'microsoft/Git-Credential-Manager-Core'
+        releaseTag: 'v2.0.194-beta'

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -2,6 +2,9 @@ name: "release-winget"
 on:
   release:
     types: [released]
+  push:
+    branches:
+      - ldennington/update-winget-deployments
 
 jobs:
   release:

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -15,7 +15,6 @@ jobs:
       uses: mjcheetham/update-winget@v1.1
       with:
         id: Microsoft.GitCredentialManagerCore
-        version: 2.0.194.40577
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
         repo: ldennington/winget-playground
@@ -31,9 +30,9 @@ jobs:
           ShortDescription: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
           Installers:
           - Arch: x86
-            Url: https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.194-beta/gcmcore-win-x86-2.0.194.40577.exe
+            Url: {{url}}
             InstallerType: Inno
-            Sha256: 26D3662F66E6AEC76C3BF155028D22D30ED8D1F1AFFA7C676F8DB0426939E8AD
+            Sha256: {{sha256}}
           PackageLocale: en-US
           ManifestType: singleton
           ManifestVersion: 1.0.0

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -19,7 +19,6 @@ jobs:
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
         repo: ldennington/winget-playground
-        branch: main
         manifestText: |
           PackageIdentifier: {{id}}
           PackageVersion: {{version}}
@@ -32,9 +31,9 @@ jobs:
           ShortDescription: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
           Installers:
           - Arch: x86
-            Url: {{url}}
+            Url: https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.194-beta/gcmcore-win-x86-2.0.194.40577.exe
             InstallerType: Inno
-            Sha256: {{sha256}}
+            Sha256: 26D3662F66E6AEC76C3BF155028D22D30ED8D1F1AFFA7C676F8DB0426939E8AD
           PackageLocale: en-US
           ManifestType: singleton
           ManifestVersion: 1.0.0

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -15,6 +15,7 @@ jobs:
       uses: mjcheetham/update-winget@v1.1
       with:
         id: Microsoft.GitCredentialManagerCore
+        version: 2.0.194.40577
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
         repo: ldennington/winget-playground

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -7,26 +7,29 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - name: Update winget repository
-      uses: mjcheetham/update-winget@v1.0
+    - id: update winget
+      name: Update winget repository
+      uses: mjcheetham/update-winget@v1.1
       with:
-        token: ${{ secrets.WINGET_TOKEN }}
-        repo: microsoft/winget-pkgs
         id: Microsoft.GitCredentialManagerCore
+        token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
         manifestText: |
-          Id: {{id}}
-          Version: {{version}}
-          Name: Git Credential Manager Core
+          PackageIdentifier: {{id}}
+          PackageVersion: {{version}}
+          PackageName: Git Credential Manager Core
           Publisher: Microsoft Corporation
-          AppMoniker: git-credential-manager-core
-          Homepage: https://aka.ms/gcmcore
+          Moniker: git-credential-manager-core
+          PackageUrl: https://aka.ms/gcmcore
           Tags: "gcm, gcmcore, git, credential"
           License: Copyright (C) Microsoft Corporation
-          Description: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
+          ShortDescription: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
           Installers:
-              - Arch: x86
-                Url: {{url}}
-                InstallerType: Inno
-                Sha256: {{sha256}}
+          - Arch: x86
+            Url: {{url}}
+            InstallerType: Inno
+            Sha256: {{sha256}}
+          PackageLocale: en-US
+          ManifestType: singleton
+          ManifestVersion: 1.0.0
         alwaysUsePullRequest: true

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - id: update winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.2
+      uses: mjcheetham/update-winget@v1.1
       with:
         id: Microsoft.GitCredentialManagerCore
         token: ${{ secrets.WINGET_TOKEN }}   

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -18,7 +18,7 @@ jobs:
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
         repo: ldennington/winget-playground
-        branch: master
+        branch: main
         manifestText: |
           PackageIdentifier: {{id}}
           PackageVersion: {{version}}

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - id: update winget
+    - id: update-winget
       name: Update winget repository
       uses: mjcheetham/update-winget@v1.1
       with:

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -25,14 +25,14 @@ jobs:
           Publisher: Microsoft Corporation
           Moniker: git-credential-manager-core
           PackageUrl: https://aka.ms/gcmcore
-          Tags: "gcm, gcmcore, git, credential"
+          Tags: [ gcm, gcmcore, git, credential ]
           License: Copyright (C) Microsoft Corporation
           ShortDescription: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
           Installers:
-          - Arch: x86
-            Url: {{url}}
-            InstallerType: Inno
-            Sha256: {{sha256}}
+          - Architecture: x86
+            InstallerUrl: {{url}}
+            InstallerType: inno
+            InstallerSha256: {{sha256}}
           PackageLocale: en-US
           ManifestType: singleton
           ManifestVersion: 1.0.0

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -2,9 +2,6 @@ name: "release-winget"
 on:
   release:
     types: [released]
-  push:
-    branches:
-      - ldennington/update-winget-deployments
 
 jobs:
   release:
@@ -12,7 +9,7 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.1
+      uses: mjcheetham/update-winget@v1.2
       with:
         id: Microsoft.GitCredentialManagerCore
         token: ${{ secrets.WINGET_TOKEN }}   
@@ -37,5 +34,3 @@ jobs:
           ManifestType: singleton
           ManifestVersion: 1.0.0
         alwaysUsePullRequest: true
-        releaseRepo: 'microsoft/Git-Credential-Manager-Core'
-        releaseTag: 'v2.0.194-beta'

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -14,7 +14,6 @@ jobs:
         id: Microsoft.GitCredentialManagerCore
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: gcmcore-win-x86-(.*)\.exe
-        repo: ldennington/winget-playground
         manifestText: |
           PackageIdentifier: {{id}}
           PackageVersion: {{version}}

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
+      branch: master
       uses: mjcheetham/update-winget@v1.1
       with:
         id: Microsoft.GitCredentialManagerCore


### PR DESCRIPTION
It appears that changes have been made to the winget schema since this workflow was created, so I've made the necessary updates here. Additionally, we've fixed a couple issues in the `mjcheetham/update-winget` task that had been causing this workflow to fail (see [this](https://github.com/mjcheetham/update-winget/pull/92) and [this](https://github.com/mjcheetham/update-winget/pull/94)). 

With these updates, we should be good to go to publish gcm core to winget automatically with the next release. Exciting times!

I validated this workflow locally by successfully opening a [PR](https://github.com/ldennington/winget-playground/pull/5) against my winget-playground repo and running `winget validate` to ensure the generated manifest adheres to winget's required schema. 