### PR TITLE
Bumping mjcheetham/update-winget to v1.2.1

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.2
+      uses: mjcheetham/update-winget@v1.2.1
       with:
         id: Microsoft.GitCredentialManagerCore
         token: ${{ secrets.WINGET_TOKEN }}   


### PR DESCRIPTION
Bumping the version of our `mjcheetham/update-winget` task to version 1.2.1, which will publish our manifest to the correct path (i.e. with a new directory for each version), as evidenced in [this dummy PR](https://github.com/ldennington/winget-playground/pull/9/files).