### PR TITLE
Add support for OAuth with GitHub AE

### DIFF
--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -33,6 +33,11 @@ namespace GitHub
         public static readonly Version MinimumEnterpriseOAuthVersion = new Version("99.99.99");
 
         /// <summary>
+        /// The version string returned from the meta API endpoint for GitHub AE instances.
+        /// </summary>
+        public const string GitHubAeVersionString = "GitHub AE";
+
+        /// <summary>
         /// Supported authentication modes for GitHub.com.
         /// </summary>
         /// <remarks>

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -263,8 +263,15 @@ namespace GitHub
                 {
                     modes |= AuthenticationModes.Basic;
                 }
-                if (Version.TryParse(metaInfo.InstalledVersion, out var version) && version >= GitHubConstants.MinimumEnterpriseOAuthVersion)
+
+                if (StringComparer.OrdinalIgnoreCase.Equals(metaInfo.InstalledVersion, GitHubConstants.GitHubAeVersionString))
                 {
+                    // Assume all GHAE instances have the GCM OAuth application deployed
+                    modes |= AuthenticationModes.OAuth;
+                }
+                else if (Version.TryParse(metaInfo.InstalledVersion, out var version) && version >= GitHubConstants.MinimumEnterpriseOAuthVersion)
+                {
+                    // Only GHES versions beyond the minimum version have the GCM OAuth application deployed
                     modes |= AuthenticationModes.OAuth;
                 }
 


### PR DESCRIPTION
Add support for detecting GitHub AE (GHAE) and enabling the OAuth authentication mode with the GitHub provider.

We assume that all instances of GHAE have the GCM OAuth application deployed.

https://docs.github.com/en/github-ae@latest/admin/overview/about-github-ae