### PR TITLE
Add WAM workaround for elevated processes

### DIFF
--- a/docs/wam.md
+++ b/docs/wam.md
@@ -1,0 +1,41 @@
+# Web Account Manager integration
+
+## Running as administrator
+
+The Windows broker ("WAM") makes heavy use of
+[COM](https://docs.microsoft.com/en-us/windows/win32/com/the-component-object-model),
+an IPC and RPC technology built-in to the Windows operating system. In order to
+integrate with WAM, Git Credential Manager and the underlying
+[Microsoft Authentication Library (MSAL)](https://aka.ms/msal-net)
+must use COM interfaces and remote procedure calls (RPC).
+
+When you run Git Credential Manager as an elevated process, such as when you run
+a `git` command from an Administrator command-prompt or perform Git operations
+from Visual Studio running as Administrator, some of the calls made between GCM
+and WAM may fail due to differing process security levels.
+
+If you have enabled using the broker and GCM detects it is running in an
+elevated process, it will automatically attempt to modify the COM security
+settings for the running process so that GCM and WAM can work together.
+
+However, this automatic process security change is not guaranteed to succeed
+depending on various external factors like registry or system-wide COM settings.
+If GCM fails to modify the process COM security settings, a warning message is
+printed and use of the broker is disabled for this invocation of GCM:
+
+```text
+warning: broker initialization failed
+Failed to set COM process security to allow Windows broker from an elevated process (0x80010119).
+See https://aka.ms/gcmcore-wamadmin for more information.
+```
+
+### Possible solutions
+
+In order to fix the problem there are a few options:
+
+1. Do not run Git or Git Credential Manager as elevated processes.
+2. Disable the broker by setting the
+   [`GCM_MSAUTH_USEBROKER`](environment.md#gcm_msauth_usebroker)
+   environment variable or the
+   [`credential.msauthUseBroker`](configuration.md#credentialmsauthusebroker)
+   Git configuration setting to `false`.

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -20,7 +20,11 @@ namespace Microsoft.Git.CredentialManager
             {
                 // Workaround for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2560
                 if (MicrosoftAuthentication.CanUseBroker(context))
-                    try { MicrosoftAuthentication.InitializeBroker(); }
+                {
+                    try
+                    {
+                        MicrosoftAuthentication.InitializeBroker();
+                    }
                     catch (Exception ex)
                     {
                         context.Streams.Error.WriteLine(
@@ -28,6 +32,7 @@ namespace Microsoft.Git.CredentialManager
                             Environment.NewLine, ex.Message
                         );
                     }
+                }
 
                 // Register all supported host providers at the normal priority.
                 // The generic provider should never win against a more specific one, so register it with low priority.

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -49,15 +49,24 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
         public static void InitializeBroker()
         {
-            if (IsBrokerInitialized) return;
+            if (IsBrokerInitialized)
+            {
+                return;
+            }
 
             IsBrokerInitialized = true;
 
             // Broker is only supported on Windows 10
-            if (!PlatformUtils.IsWindows10()) return;
+            if (!PlatformUtils.IsWindows10())
+            {
+                return;
+            }
 
             // Nothing to do when not an elevated user
-            if (!PlatformUtils.IsElevatedUser()) return;
+            if (!PlatformUtils.IsElevatedUser())
+            {
+                return;
+            }
 
             // Lower COM security so that MSAL can make the calls to WAM
             int result = Interop.Windows.Native.Ole32.CoInitializeSecurity(

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Git.CredentialManager
             public const string GcmHttpProxyGuide      = "https://aka.ms/gcmcore-httpproxy";
             public const string GcmTlsVerification     = "https://aka.ms/gcmcore-tlsverify";
             public const string GcmLinuxCredStores     = "https://aka.ms/gcmcore-linuxcredstores";
+            public const string GcmWamComSecurity      = "https://aka.ms/gcmcore-wamadmin";
         }
 
         private static Version _gcmVersion;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Unistd.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Unistd.cs
@@ -21,5 +21,8 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix.Native
 
         [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         public static extern int getppid();
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int geteuid();
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Ole32.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Ole32.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Git.CredentialManager.Interop.Windows.Native
+{
+    public static class Ole32
+    {
+        private const string LibraryName = "ole32.dll";
+
+        public const uint RPC_E_TOO_LATE = 0x80010119;
+
+        [DllImport(LibraryName)]
+        public static extern int CoInitializeSecurity(
+            IntPtr pVoid,
+            int cAuthSvc,
+            IntPtr asAuthSvc,
+            IntPtr pReserved1,
+            RpcAuthnLevel level,
+            RpcImpLevel impers,
+            IntPtr pAuthList,
+            EoAuthnCap dwCapabilities,
+            IntPtr pReserved3);
+
+        public enum RpcAuthnLevel
+        {
+            Default = 0,
+            None = 1,
+            Connect = 2,
+            Call = 3,
+            Pkt = 4,
+            PktIntegrity = 5,
+            PktPrivacy = 6
+        }
+
+        public enum RpcImpLevel
+        {
+            Default = 0,
+            Anonymous = 1,
+            Identify = 2,
+            Impersonate = 3,
+            Delegate = 4
+        }
+
+        public enum EoAuthnCap
+        {
+            None = 0x00,
+            MutualAuth = 0x01,
+            StaticCloaking = 0x20,
+            DynamicCloaking = 0x40,
+            AnyAuthority = 0x80,
+            MakeFullSIC = 0x100,
+            Default = 0x800,
+            SecureRefs = 0x02,
+            AccessControl = 0x04,
+            AppID = 0x08,
+            Dynamic = 0x10,
+            RequireFullSIC = 0x200,
+            AutoImpersonate = 0x400,
+            NoCustomMarshal = 0x2000,
+            DisableAAA = 0x1000
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Git.CredentialManager.Interop.Posix.Native;
 
 namespace Microsoft.Git.CredentialManager
 {
@@ -134,6 +135,24 @@ namespace Microsoft.Git.CredentialManager
             {
                 throw new PlatformNotSupportedException();
             }
+        }
+
+        public static bool IsElevatedUser()
+        {
+            if (IsWindows())
+            {
+#if NETFRAMEWORK
+                var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+                var principal = new System.Security.Principal.WindowsPrincipal(identity);
+                return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+#endif
+            }
+            else if (IsPosix())
+            {
+                return Unistd.geteuid() == 0;
+            }
+
+            return false;
         }
 
         #region Platform information helper methods


### PR DESCRIPTION
Add a workaround to a broker bug whereby the account control does not appear when running from an elevated process.

https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2560

The underlying issue is to do with COM and the OS account control not being able to call-back in to the elevated process.

The workaround is to set the process COM security to "none" iif we are on Windows 10, the process is elevated, and the user hasn't disabled the broker.

It is possible the call to `CoInitializeSecurity` may fail, as this can only be called once in the lifetime of a process, and must be called before any COM interactions occur. The CLR may perform some COM interop before we even get to the Main method(!)

We try our best here and call the `CoInitializeSecurity` function as soon as we reasonably can in the lifetime of our process.