### PR TITLE
Bump MSAL library versions

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
+++ b/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
@@ -13,13 +13,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.29.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.31.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.29.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.31.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.4" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrade our MSAL libraries to the latest versions:

- MS.ID.Client 4.29.0 -> 4.31.0
- MS.ID.Client.Desktop 4.29.0 -> 4.31.0
- MS.ID.Client.Extensions.Msal 2.18.3 -> 2.18.4

This brings a number of fixes that help us, including:

- Fix WAM account picker parenting
- Fix WAM exceptions in console apps
- Fix encoding of params sent to WAM
- WebView2 fallback to WebView1
- Stop writing junk to standard out on Linux syswebview flows

Fixes #286