### PR TITLE
Set MSAL embedded webview window title

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -183,6 +183,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
                             result = await app.AcquireTokenInteractive(scopes)
                                 .WithPrompt(Prompt.SelectAccount)
                                 .WithUseEmbeddedWebView(true)
+                                .WithEmbeddedWebViewOptions(GetEmbeddedWebViewOptions())
                                 .ExecuteAsync();
                             break;
 
@@ -407,6 +408,13 @@ namespace Microsoft.Git.CredentialManager.Authentication
             return builder.Build();
         }
 
+        private static EmbeddedWebViewOptions GetEmbeddedWebViewOptions()
+        {
+            return new EmbeddedWebViewOptions
+            {
+                Title = "Git Credential Manager"
+            };
+        }
 
         private static SystemWebViewOptions GetSystemWebViewOptions()
         {


### PR DESCRIPTION
Set the MSAL embedded webview window to "Git Credential Manager" to give some context to the user where this dialog came from.

Fixes #239 