### PR TITLE
Fix documentation links for Windows Broker settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,7 +299,7 @@ Value|Description
 git config --global credential.msauthUseBroker true
 ```
 
-**Also see: [GCM_MSAUTH_USEBROKER](environment.md#GCM_MSAUTH_USEBROKER)**
+**Also see: [GCM_MSAUTH_USEBROKER](environment.md#GCM_MSAUTH_USEBROKER-experimental)**
 
 ---
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -457,7 +457,7 @@ SET GCM_MSAUTH_USEBROKER="true"
 export GCM_MSAUTH_USEBROKER="false"
 ```
 
-**Also see: [credential.msauthUseBroker](configuration.md#credentialmsauthusebroker)**
+**Also see: [credential.msauthUseBroker](configuration.md#credentialmsauthusebroker-experimental)**
 
 ---
 


### PR DESCRIPTION
When we added the "(experimental)" suffix to the headings of the Windows Broker settings, we broke the cross-links between environment.md and configuration.md.