### PR TITLE
Update CI for rename of default branch to main (and drop the "beta" moniker)

### DIFF
--- a/.azure-pipelines/continuous-integration.yml
+++ b/.azure-pipelines/continuous-integration.yml
@@ -1,5 +1,5 @@
 trigger:
-  - master
+  - main
 
 variables:
   configuration: Release

--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -1,5 +1,5 @@
 pr:
-  - master
+  - main
   - release
 
 variables:

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -3,9 +3,9 @@ name: Build-Installers
 on:
   workflow_dispatch:
   push:
-    branches: [ master, release ]
+    branches: [ main, release ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   linux:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,9 +3,9 @@ name: GCM-Core
 on:
   workflow_dispatch:
   push:
-    branches: [ master, linux ]
+    branches: [ main, linux ]
   pull_request:
-    branches: [ master, linux ]
+    branches: [ main, linux ]
 
 jobs:
   validate_gcm:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Git Credential Manager Core
 
-Branch|Status
--|-
-master|[![Build Status](https://mseng.visualstudio.com/AzureDevOps/_apis/build/status/Teams/VCDesktop/Git-Credential-Manager-Core/GCM-CI?branchName=master)](https://mseng.visualstudio.com/AzureDevOps/_build/latest?definitionId=7861&branchName=master)
+[![Build Status](https://github.com/microsoft/Git-Credential-Manager-Core/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/microsoft/Git-Credential-Manager-Core/actions/workflows/continuous-integration.yml)
 
 ---
 

--- a/docs/azrepos-users-and-tokens.md
+++ b/docs/azrepos-users-and-tokens.md
@@ -8,8 +8,8 @@ The Azure Repos host provider supports creating multiple types of credential:
 - Microsoft identity OAuth tokens (experimental)
 
 To select which type of credential the Azure Repos host provider will create
-and use, you can set the [`credential.azreposCredentialType`](https://github.com/microsoft/Git-Credential-Manager-Core/blob/master/docs/configuration.md#credentialazreposcredentialtype-experimental)
-configuration entry (or [`GCM_AZREPOS_CREDENTIALTYPE`](https://github.com/microsoft/Git-Credential-Manager-Core/blob/master/docs/environment.md#GCM_AZREPOS_CREDENTIALTYPE-experimental)
+and use, you can set the [`credential.azreposCredentialType`](configuration.md#credentialazreposcredentialtype-experimental)
+configuration entry (or [`GCM_AZREPOS_CREDENTIALTYPE`](environment.md#GCM_AZREPOS_CREDENTIALTYPE-experimental)
 environment variable).
 
 ### Azure DevOps personal access tokens

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -35,7 +35,7 @@
 #define GcmPublisherUrl "https://www.microsoft.com"
 #define GcmCopyright "Copyright (c) Microsoft 2020"
 #define GcmUrl "https://aka.ms/gcmcore"
-#define GcmReadme "https://github.com/microsoft/Git-Credential-Manager-Core/blob/master/README.md"
+#define GcmReadme "https://github.com/microsoft/Git-Credential-Manager-Core/blob/main/README.md"
 #define GcmRepoRoot "..\..\.."
 #define GcmAssets GcmRepoRoot + "\assets"
 #define GcmExe "git-credential-manager-core.exe"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0-beta",
+  "version": "2.0",
   "publicReleaseRefSpec": [
     "^refs/heads/release$"
   ],


### PR DESCRIPTION
Update CI for the rename from `master` to `main`, and drop the "beta" moniker for the project now that the other Git credential "manager" helpers have all been fully deprecated.