### PR TITLE
Mark GHES 3.2 as supporting GCM Core OAuth

### DIFF
--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -27,10 +27,9 @@ namespace GitHub
         public const string GitHubOptHeader = "X-GitHub-OTP";
 
         /// <summary>
-        /// Minimum GitHub Enterprise version that supports OAuth authentication with GCM Core.
+        /// Minimum GitHub Enterprise Server version that supports OAuth authentication with GCM Core.
         /// </summary>
-        // TODO: update this with a real version number once the GCM OAuth application has been deployed to GHE
-        public static readonly Version MinimumEnterpriseOAuthVersion = new Version("99.99.99");
+        public static readonly Version MinimumOnPremOAuthVersion = new Version("3.2");
 
         /// <summary>
         /// The version string returned from the meta API endpoint for GitHub AE instances.

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -269,7 +269,7 @@ namespace GitHub
                     // Assume all GHAE instances have the GCM OAuth application deployed
                     modes |= AuthenticationModes.OAuth;
                 }
-                else if (Version.TryParse(metaInfo.InstalledVersion, out var version) && version >= GitHubConstants.MinimumEnterpriseOAuthVersion)
+                else if (Version.TryParse(metaInfo.InstalledVersion, out var version) && version >= GitHubConstants.MinimumOnPremOAuthVersion)
                 {
                     // Only GHES versions beyond the minimum version have the GCM OAuth application deployed
                     modes |= AuthenticationModes.OAuth;


### PR DESCRIPTION
Mark GitHub Enterprise Server (GHES; on-prem server) version 3.2 as supporting the OAuth authentication mechanism.

Fixes #235 