### PR TITLE
Fix the .NET SDK used in release builds

### DIFF
--- a/.azure-pipelines/templates/linux/compile.yml
+++ b/.azure-pipelines/templates/linux/compile.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.x
+    displayName: Use .NET SDK 5.0.203
     inputs:
       packageType: sdk
-      version: 5.0.x
+      version: 5.0.203
 
   - task: DotNetCoreCLI@2
     displayName: Compile common code

--- a/.azure-pipelines/templates/osx/compile.yml
+++ b/.azure-pipelines/templates/osx/compile.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.x
+    displayName: Use .NET SDK 5.0.203
     inputs:
       packageType: sdk
-      version: 5.0.x
+      version: 5.0.203
 
   - task: DotNetCoreCLI@2
     displayName: Compile common code and macOS Helpers

--- a/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
@@ -7,10 +7,10 @@ steps:
       downloadPath: '$(Build.StagingDirectory)/payload'
 
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.x
+    displayName: Use .NET SDK 5.0.203
     inputs:
       packageType: sdk
-      version: 5.0.x
+      version: 5.0.203
 
   - script: dotnet tool install --global nbgv
     displayName: Install Nerdbank.GitVersioning tool

--- a/.azure-pipelines/templates/windows/compile.signed.yml
+++ b/.azure-pipelines/templates/windows/compile.signed.yml
@@ -6,10 +6,10 @@ steps:
       signType: '$(SignType)'
 
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.x
+    displayName: Use .NET SDK 5.0.203
     inputs:
       packageType: sdk
-      version: 5.0.x
+      version: 5.0.203
 
   - task: NuGetToolInstaller@0
     displayName: Install NuGet tool >=4.3.0

--- a/.azure-pipelines/templates/windows/compile.yml
+++ b/.azure-pipelines/templates/windows/compile.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.x
+    displayName: Use .NET SDK 5.0.203
     inputs:
       packageType: sdk
-      version: 5.0.x
+      version: 5.0.203
 
   - task: DotNetCoreCLI@2
     displayName: Restore packages


### PR DESCRIPTION
Fix the .NET SDK version used on Mac and Linux to build release builds in Azure Pipelines.

The release build started to hang since .NET SDK 5.0.300 was available.
Others have reported issues with new SDK patches:
https://github.com/dotnet/sdk/issues/16204

The last successful release build used .NET SDK 5.0.203, so let's fix to that version.

Last success:
https://mseng.visualstudio.com/AzureDevOps/_build/results?buildId=15246465

Current failure:
https://mseng.visualstudio.com/AzureDevOps/_build/results?buildId=15390460