### PR TITLE
Fix bug in GitHub x-platform UI command line parsing/binding

### DIFF
--- a/src/shared/GitHub.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitHub.UI/Commands/CredentialsCommand.cs
@@ -39,11 +39,11 @@ namespace GitHub.UI.Commands
             Handler = CommandHandler.Create<string, string, bool, bool, bool>(ExecuteAsync);
         }
 
-        private async Task<int> ExecuteAsync(string enterpriseUrl, string userName, bool basic, bool browser, bool pat)
+        private async Task<int> ExecuteAsync(string enterpriseUrl, string userName, bool basic, bool oauth, bool pat)
         {
             var viewModel = new CredentialsViewModel(Context.Environment)
             {
-                ShowBrowserLogin = browser,
+                ShowBrowserLogin = oauth,
                 ShowTokenLogin   = pat,
                 ShowBasicLogin   = basic,
             };


### PR DESCRIPTION
The System.CommandLine command line binding requires the parameter names match the option names.

During the rebasing of the x-platform UI work, the argument name for the `--oauth` option was left as `browser` which means the OAuth browser flow is never shown, even though the base GCM program is passing the right argument/options.