### PR TITLE
Fix app entry path computation on Windows

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
@@ -86,24 +86,31 @@ namespace Microsoft.Git.CredentialManager
 
         public static string GetEntryApplicationPath()
         {
-            // Assembly::Location always returns an empty string if the application was published as a single file
+#if NETFRAMEWORK
+            // Single file publishing does not exist with .NET Framework so
+            // we can just use reflection to get the entry assembly path.
+            return Assembly.GetEntryAssembly().Location;
+#else
+            // Assembly::Location always returns an empty string if the application
+            // was published as a single file
 #pragma warning disable IL3000
             bool isSingleFile = string.IsNullOrEmpty(Assembly.GetEntryAssembly()?.Location);
 #pragma warning restore IL3000
 
-            // Use "argv[0]" to get the full path to the entry executable - this is consistent across
-            // .NET Framework and .NET >= 5 when published as a single file.
+            // Use "argv[0]" to get the full path to the entry executable in
+            // .NET 5+ when published as a single file.
             string[] args = Environment.GetCommandLineArgs();
             string candidatePath = args[0];
 
-            // If we have not been published as a single file on .NET 5 then we must strip the ".dll" file extension
-            // to get the default AppHost/SuperHost name.
+            // If we have not been published as a single file then we must strip the
+            // ".dll" file extension to get the default AppHost/SuperHost name.
             if (!isSingleFile && Path.HasExtension(candidatePath))
             {
                 return Path.ChangeExtension(candidatePath, null);
             }
 
             return candidatePath;
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
The way we located the application (GCM) path was broken on .NET Framework (it worked OK for .NET Core/5.0+).