### PR TITLE
Fix winget tag specification

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -21,7 +21,11 @@ jobs:
           Publisher: Microsoft Corporation
           Moniker: git-credential-manager-core
           PackageUrl: https://aka.ms/gcmcore
-          Tags: [ gcm, gcmcore, git, credential ]
+          Tags:
+          - gcm
+          - gcmcore
+          - git
+          - credential 
           License: Copyright (C) Microsoft Corporation
           ShortDescription: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
           Installers:


### PR DESCRIPTION
According to a [recent PR](https://github.com/microsoft/winget-pkgs/pull/18410), the recommended format for winget tags has changed. Updating our manifest according to the new specification.