### PR TITLE
Avoid extra restore in macOS installer creation (fix CI hangs)

### DIFF
--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -74,6 +74,7 @@ cp "$INSTALLER_SRC/uninstall.sh" "$PAYLOAD" || exit 1
 # Publish core application executables
 echo "Publishing core application..."
 dotnet publish "$GCM_SRC" \
+	--no-restore \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -81,6 +82,7 @@ dotnet publish "$GCM_SRC" \
 
 echo "Publishing Bitbucket UI helper..."
 dotnet publish "$BITBUCKET_UI_SRC" \
+	--no-restore \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -88,6 +90,7 @@ dotnet publish "$BITBUCKET_UI_SRC" \
 
 echo "Publishing GitHub UI helper..."
 dotnet publish "$GITHUB_UI_SRC" \
+	--no-restore \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \

--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -75,6 +75,7 @@ cp "$INSTALLER_SRC/uninstall.sh" "$PAYLOAD" || exit 1
 echo "Publishing core application..."
 dotnet publish "$GCM_SRC" \
 	--no-restore \
+	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -83,6 +84,7 @@ dotnet publish "$GCM_SRC" \
 echo "Publishing Bitbucket UI helper..."
 dotnet publish "$BITBUCKET_UI_SRC" \
 	--no-restore \
+	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -91,6 +93,7 @@ dotnet publish "$BITBUCKET_UI_SRC" \
 echo "Publishing GitHub UI helper..."
 dotnet publish "$GITHUB_UI_SRC" \
 	--no-restore \
+	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \


### PR DESCRIPTION
Avoid an extra `dotnet restore` during the `dotnet publish` commands in `layout.sh` when building the macOS installer.
For some reason, the CI machines (and sometimes locally) hang during this step with:

```
Building Installer.Mac
Copying uninstall script...
Microsoft (R) Build Engine version 16.10.0-preview-21181-07+073022eb4 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...

```

Avoiding the restore during publish should be OK since the hosting `Installer.Mac.csproj` project will have already built (and restored) packages for the dependent projects.

Issues noticed for example in #373