### PR TITLE
Issue 329 force bitbucket oauth

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,32 @@ git config --global credential.httpsProxy http://john.doe:password@proxy.contoso
 
 ---
 
+### credential.bitbucketAuthModes
+
+Override the available authentication modes presented during Bitbucket authentication.
+If this option is not set, then the available authentication modes will be automatically detected.
+
+
+**Note:** This setting only applies to Bitbucket.org not Server or DC instances.
+
+**Note:** This setting supports multiple values separated by commas.
+
+Value|Authentication Mode
+-|-
+_(unset)_|Automatically detect modes
+`oauth`|OAuth-based authentication
+`basic`|Basic/PAT-based authentication
+
+#### Example
+
+```shell
+git config --global credential.bitbucketAuthModes "oauth,basic"
+```
+
+**Also see: [GCM_BITBUCKET_AUTHMODES](environment.md#GCM_BITBUCKET_AUTHMODES)**
+
+---
+
 ### credential.gitHubAuthModes
 
 Override the available authentication modes presented during GitHub authentication.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -283,6 +283,37 @@ export GCM_HTTP_PROXY=http://john.doe:password@proxy.contoso.com
 
 ---
 
+### GCM_BITBUCKET_AUTHMODES
+
+Override the available authentication modes presented during Bitbucket authentication.
+If this option is not set, then the available authentication modes will be automatically detected.
+
+**Note:** This setting only applies to Bitbucket.org not Server or DC instances.
+
+**Note:** This setting supports multiple values separated by commas.
+
+Value|Authentication Mode
+-|-
+_(unset)_|Automatically detect modes
+`oauth`|OAuth-based authentication
+`basic`|Basic/PAT-based authentication
+
+##### Windows
+
+```batch
+SET GCM_BITBUCKET_AUTHMODES="oauth,basic"
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_BITBUCKET_AUTHMODES="oauth,basic"
+```
+
+**Also see: [credential.bitbucketAuthModes](configuration.md#credential.bitbucketAuthModes)**
+
+---
+
 ### GCM_GITHUB_AUTHMODES
 
 Override the available authentication modes presented during GitHub authentication.
@@ -308,7 +339,7 @@ SET GCM_GITHUB_AUTHMODES="oauth,basic"
 export GCM_GITHUB_AUTHMODES="oauth,basic"
 ```
 
-**Also see: [credential.gitHubAuthModes](configuration.md#credentialgitHubAuthModes)**
+**Also see: [credential.gitHubAuthModes](configuration.md#credential.gitHubAuthModes)**
 
 ---
 

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -1,17 +1,21 @@
 ﻿using Microsoft.Git.CredentialManager;
+using Microsoft.Git.CredentialManager.Authentication.OAuth;
 using Microsoft.Git.CredentialManager.Tests.Objects;
+using Moq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Atlassian.Bitbucket.Tests
 {
     public class BitbucketHostProviderTest
     {
+        private const string MOCK_ACCESS_TOKEN = "at-0987654321";
+        private const string MOCK_REFRESH_TOKEN = "rt-1234567809";
+        private Mock<IBitbucketAuthentication> bitbucketAuthentication = new Mock<IBitbucketAuthentication>(MockBehavior.Strict);
+        private Mock<IBitbucketRestApi> bitbucketApi = new Mock<IBitbucketRestApi>(MockBehavior.Strict);
+
         [Theory]
         // We report that we support unencrypted HTTP here so that we can fail and
         // show a helpful error message in the call to `GenerateCredentialAsync` instead.
@@ -55,6 +59,225 @@ namespace Atlassian.Bitbucket.Tests
 
             var provider = new BitbucketHostProvider(new TestCommandContext());
             Assert.Equal(expected, provider.IsSupported(input));
+        }
+
+
+        [Theory]
+        [InlineData("https", "bitbucket.org", "jsquire", "password", false, false, false)]
+        [InlineData("https", "bitbucket.org", "jsquire", "password", false, true, true)]
+        [InlineData("https", "bitbucket.org", "jsquire", "password", true, null, true)]
+        // Basic Auth works
+        public void BitbucketHostProvider_GetCredentialAsync_ForBasicAuth(string protocol, string host, string username,string password, bool storedAccount, bool? userEntersCredentials, bool expected)
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = protocol,
+                ["host"] = host,
+                ["username"] = username
+            });
+
+            var context = new TestCommandContext();
+
+            if (storedAccount)
+            {
+                MockStoredBasicAccount(context, input, password);
+            }
+
+            if (userEntersCredentials.HasValue && userEntersCredentials.Value)
+            {
+                MockUserEnteredBasicCredentials(bitbucketAuthentication, input, password);
+            }
+            else
+            {
+                MockUserDidNotEnteredBasicCredentials(bitbucketAuthentication);
+            }
+
+            MockValidRemoteAccount(bitbucketApi, input, password, false);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            if (userEntersCredentials.HasValue && !userEntersCredentials.Value)
+            {
+                Assert.ThrowsAsync<Exception>(async () => await provider.GetCredentialAsync(input));
+                return;
+            }
+
+            var credential = provider.GetCredentialAsync(input);
+
+            VerifyBasicAuthFlowRan(password, storedAccount, expected, input, credential);
+
+            VerifyOAuthFlowWasNotRun(password, storedAccount, expected, input, credential);
+        }
+
+        [Theory]
+        [InlineData("https", "bitbucket.org", "jsquire", "password", true, null, true)]
+        [InlineData("https", "bitbucket.org", "jsquire", "password", false, true, true)]
+        [InlineData("https", "bitbucket.org", "jsquire", "password", false, null, false)]
+        // Basic Auth works
+        public void BitbucketHostProvider_GetCredentialAsync_ForOAuth(string protocol, string host, string username, string password, bool storedAccount, bool? userEntersCredentials, bool expected)
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = protocol,
+                ["host"] = host,
+                ["username"] = username
+            });
+
+            var context = new TestCommandContext();
+
+            if (storedAccount)
+            {
+                MockStoredOAuthAccount(context, input);
+            }
+
+            if (userEntersCredentials.HasValue && userEntersCredentials.Value)
+            {
+                MockUserEnteredBasicCredentials(bitbucketAuthentication, input, password);
+            }
+            else
+            {
+                MockUserDidNotEnteredBasicCredentials(bitbucketAuthentication);
+            }
+
+            MockValidRemoteAccount(bitbucketApi, input, password, true);
+            MockRemoteValidRefreshToken();
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            if (userEntersCredentials.HasValue && !userEntersCredentials.Value)
+            {
+                Assert.ThrowsAsync<Exception>(async () => await provider.GetCredentialAsync(input));
+                return;
+            }
+
+            var credential = provider.GetCredentialAsync(input);
+
+            VerifyOAuthFlowRan(password, storedAccount, expected, input, credential);
+
+            VerifyBasicAuthFlowDidNotRun(password, storedAccount, expected, input, credential);
+        }
+
+        private void VerifyBasicAuthFlowRan(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            Assert.Equal(expected, credential != null);
+
+            var remoteUri = input.GetRemoteUri();
+
+            if (storedAccount)
+            {
+                // stored username/password so no need to prompt the user for them
+                bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Never);
+            }
+            else
+            {
+                // no username/password credentials so prompt the user for them
+                bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
+            }
+
+            // check username/password work
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(input.UserName, password, false), Times.Once);
+        }
+
+        private void VerifyBasicAuthFlowDidNotRun(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            Assert.Equal(expected, credential != null);
+
+            var remoteUri = input.GetRemoteUri();
+
+            // never prompt the user for basic credentials
+            bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), !storedAccount ? Times.Once : Times.Never);
+        }
+
+        private void VerifyOAuthFlowRan(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            Assert.Equal(expected, credential != null);
+
+            var remoteUri = input.GetRemoteUri();
+
+            if (storedAccount)
+            {
+                // use refresh token to get new access token and refresh token
+                bitbucketAuthentication.Verify(m => m.RefreshOAuthCredentialsAsync(MOCK_REFRESH_TOKEN), Times.Once);
+
+                // check access token works
+                bitbucketApi.Verify(m => m.GetUserInformationAsync(null, MOCK_ACCESS_TOKEN, true), Times.Once);
+            }
+            else
+            {
+                // prompt user for basic auth
+                bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
+
+                // check if entered Basic Auth credentials work
+                bitbucketApi.Verify(m => m.GetUserInformationAsync(input.UserName, password, false), Times.Once);
+
+                // Basic Auth 403-ed so push user through OAuth flow
+                bitbucketAuthentication.Verify(m => m.ShowOAuthRequiredPromptAsync(), Times.Once);
+            }
+        }
+
+        private void VerifyOAuthFlowWasNotRun(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            Assert.Equal(expected, credential != null);
+
+            var remoteUri = input.GetRemoteUri();
+
+            // never prompt user through OAuth flow
+            bitbucketAuthentication.Verify(m => m.ShowOAuthRequiredPromptAsync(), Times.Never);
+
+            // Never try to refresh Access Token
+            bitbucketAuthentication.Verify(m => m.RefreshOAuthCredentialsAsync(It.IsAny<string>()), Times.Never);
+
+            // never check access token works
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, MOCK_ACCESS_TOKEN, true), Times.Never);
+        }
+
+        private void MockStoredOAuthAccount(TestCommandContext context, InputArguments input)
+        {
+            // refresh token
+            context.CredentialStore.Add("https://bitbucket.org/refresh_token", new TestCredential(input.Host, input.UserName, MOCK_REFRESH_TOKEN));
+            // auth token
+            context.CredentialStore.Add("https://bitbucket.org", new TestCredential(input.Host, input.UserName, MOCK_ACCESS_TOKEN));
+        }
+
+        private void MockRemoteValidRefreshToken()
+        {
+            bitbucketAuthentication.Setup(m => m.RefreshOAuthCredentialsAsync(MOCK_REFRESH_TOKEN)).ReturnsAsync(new OAuth2TokenResult(MOCK_ACCESS_TOKEN, "access_token"));
+        }
+
+        private static void MockInvalidRemoteBasicAccount(Mock<IBitbucketRestApi> bitbucketApi, Mock<IBitbucketAuthentication> bitbucketAuthentication)
+        {
+            bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(It.IsAny<Uri>(), It.IsAny<String>())).ReturnsAsync((TestCredential)null);
+
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(It.IsAny<String>(), It.IsAny<String>(), false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Unauthorized));
+
+        }
+        private static void MockUserEnteredBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication, InputArguments input, string password)
+        {
+            var remoteUri = input.GetRemoteUri();
+            bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName)).ReturnsAsync(new TestCredential(input.Host, input.UserName, password));
+        }
+
+        private static void MockUserDidNotEnteredBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication)
+        {
+            bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(It.IsAny<Uri>(), It.IsAny<String>())).ReturnsAsync((TestCredential)null);
+        }
+
+        private static void MockValidRemoteAccount(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password, bool twoFAEnabled)
+        {
+            var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = twoFAEnabled };
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+        }
+
+        private static void MockStoredBasicAccount(TestCommandContext context, InputArguments input, string password)
+        {
+            context.CredentialStore.Add("https://bitbucket.org", new TestCredential(input.Host, input.UserName, password));
+        }
+
+        private static void MockValidStoredOAuthUser(TestCommandContext context, Mock<IBitbucketRestApi> bitbucketApi)
+        {
+            var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = false };
+            bitbucketApi.Setup(x => x.GetUserInformationAsync("jsquire", "password1", false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+            context.CredentialStore.Add("https://bitbucket.org", new TestCredential("https://bitbucket.org", "jsquire", "password1"));
         }
     }
 }

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -12,6 +12,17 @@ using Microsoft.Git.CredentialManager.Authentication.OAuth;
 
 namespace Atlassian.Bitbucket
 {
+
+    [Flags]
+    public enum AuthenticationModes
+    {
+        None = 0,
+        Basic = 1,
+        OAuth = 1 << 1,
+        //Pat = 1 << 2,
+
+        All = Basic | OAuth //| Pat
+    }
     public interface IBitbucketAuthentication : IDisposable
     {
         Task<ICredential> GetBasicCredentialsAsync(Uri targetUri, string userName);

--- a/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
@@ -34,6 +34,7 @@ namespace Atlassian.Bitbucket
             public const string DevOAuthClientId = "GCM_DEV_BITBUCKET_CLIENTID";
             public const string DevOAuthClientSecret = "GCM_DEV_BITBUCKET_CLIENTSECRET";
             public const string DevOAuthRedirectUri = "GCM_DEV_BITBUCKET_REDIRECTURI";
+            public const string AuthenticationModes = "GCM_BITBUCKET_AUTHMODES";
         }
 
         public static class GitConfiguration
@@ -44,7 +45,18 @@ namespace Atlassian.Bitbucket
                 public const string DevOAuthClientId = "bitbucketDevClientId";
                 public const string DevOAuthClientSecret = "bitbucketDevClientSecret";
                 public const string DevOAuthRedirectUri = "bitbucketDevRedirectUri";
+                public const string AuthenticationModes = "bitbucketAuthModes";
             }
         }
+
+        /// <summary>
+        /// Supported authentication modes for Bitbucket.org
+        /// </summary>
+        public const AuthenticationModes DotOrgAuthenticationModes = AuthenticationModes.Basic | AuthenticationModes.OAuth; //| AuthenticationModes.Pat;
+
+        /// <summary>
+        /// Supported authentication modes for Bitbucket Server/DC
+        /// </summary>
+        public const AuthenticationModes ServerAuthenticationModes = AuthenticationModes.Basic;
     }
 }


### PR DESCRIPTION
The following options allow a user to force the GCMC to use Basic Auth and/or OAuth for interactions with bitbucket.org

By default a combination of Basic Auth and OAuth is used.

See the revised docs in this PR on how to configure.


**Testing**

Assuming there are no existing stored credentials and the git 'host' is identified as bitbucket.org then

AuthModes = "" or AuthModes = "basic, oauth"

- using Basic Auth a username/password is requested and used to retrieve the user profile 
  - if this works the username/password are passed back to git.
  - if this fails with a 403 response, this indicates 2FA is on and OAuth is required
    - The user is prompted to run the OAuth flow
      - If this is successful the access_token is passed back to git

AuthModes = "basic"

- using Basic Auth a username/password is requested and used to retrieve the user profile 
  - if this works the username/password are passed back to git.
- the OAuth flow is never triggered 

AuthModes = "oauth"

- The Basic Auth step is skipped
- The user is prompted to run the OAuth flow
      - If this is successful the access_token is passed back to git
      
     
      
  **TBC testing against bitbucket server instances.**

