### PR TITLE
Updated ISSUE_TEMPLATE from version to --version

### DIFF
--- a/.github/ISSUE_TEMPLATE/auth-problem.md
+++ b/.github/ISSUE_TEMPLATE/auth-problem.md
@@ -8,7 +8,7 @@ assignees: ''
 
 **Which version of GCM Core are you using?**
 
-From a terminal, run `git-credential-manager-core version` and paste the output.
+From a terminal, run `git-credential-manager-core --version` and paste the output.
 
 <!-- Ex:
 Git Credential Manager version 2.0.8-beta+e1f8492d04 (macOS, .NET Core 4.6.27129.04)

--- a/.github/ISSUE_TEMPLATE/experimental.md
+++ b/.github/ISSUE_TEMPLATE/experimental.md
@@ -8,7 +8,7 @@ assignees: ''
 
 **Which version of GCM Core are you using?**
 
-From a terminal, run `git-credential-manager-core version` and paste the output.
+From a terminal, run `git-credential-manager-core --version` and paste the output.
 
 <!-- Ex:
 Git Credential Manager version 2.0.8-beta+e1f8492d04 (macOS, .NET Core 4.6.27129.04)


### PR DESCRIPTION
gcm-core on Linux,macOS takes --version for showing current version.

Error: 
```
'version' was not matched. Did you mean '--version'?
Required command was not provided.
Unrecognized command or argument 'version'

Usage:
dential-manager-core [options] [command]

Options:
  --version         Show version information
  -?, -h, --help    Show help and usage information

Commands:
  get            [Git] Return a stored credential
  store          [Git] Store a credential
  erase          [Git] Erase a stored credential
  configure      Configure Git Credential Manager as the Git credential helper
  unconfigure    Unconfigure Git Credential Manager as the Git credential helper
  azure-repos    Commands for interacting with the Azure Repos host provider
```