### PR TITLE
Add option for `GCM_GPG_PATH` environment variable (Linux-only)

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -398,6 +398,20 @@ export GCM_PLAINTEXT_STORE_PATH=/mnt/external-drive/credentials
 
 ---
 
+### GCM_GPG_PATH
+
+Specify the path (_including_ the executable name) to the version of `gpg` used by `pass` (`gpg2` if present, otherwise `gpg`). This is primarily meant to allow manual resolution of the conflict that occurs on legacy Linux systems with parallel installs of `gpg` and `gpg2`.
+
+If not specified, GCM Core defaults to using the version of `gpg2` on the `$PATH`, falling back on `gpg` if `gpg2` is not found.
+
+##### Linux
+
+```bash
+export GCM_GPG_PATH="/usr/local/bin/gpg2"
+```
+
+---
+
 ### GCM_MSAUTH_FLOW
 
 Specify which authentication flow should be used when performing Microsoft authentication and an interactive flow is required.

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Git.CredentialManager
             public const string GcmCredCacheOptions   = "GCM_CREDENTIAL_CACHE_OPTIONS";
             public const string GcmPlaintextStorePath = "GCM_PLAINTEXT_STORE_PATH";
             public const string GitExecutablePath     = "GIT_EXEC_PATH";
+            public const string GpgExecutablePath     = "GCM_GPG_PATH";
         }
 
         public static class Http


### PR DESCRIPTION
Fixes #356.

## Changes
- Add support for `GCM_GPG_PATH` environment variable, used as location of GPG executable if specified (if specified but invalid, exception thrown)
- Updated logic to find GPG executable if explicit path not specified (meant to match behavior in `pass`, see [here](https://github.com/zx2c4/password-store/blob/master/src/password-store.sh#L10-L12))
  - If `gpg2` exists, use that; otherwise, use `gpg`

## Testing
- when `GCM_GPG_PATH` is not set or set to valid GPG executable, GPG is found without error
- when `GCM_GPG_PATH` is set to "nonsense" (or some other non-file), receive the following error for _any_ `git-credential-manager` invocation:
  ```
  Unhandled exception. System.Exception: GPG executable does not exist with path 'nonsense'
   at Microsoft.Git.CredentialManager.CommandContext.GetGpgPath(IEnvironment environment, IFileSystem fileSystem)
   at Microsoft.Git.CredentialManager.CommandContext..ctor(String appPath)  
   at Microsoft.Git.CredentialManager.Program.Main(String[] args)
  ```