### PR TITLE
242 respect ssl ca info

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void HttpClientFactory_GetClient_SetsDefaultHeaders()
         {
-            var factory = new HttpClientFactory(Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
+            var factory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
 
             HttpClient client = factory.CreateClient();
 
@@ -27,7 +27,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void HttpClientFactory_GetClient_MultipleCalls_ReturnsNewInstance()
         {
-            var factory = new HttpClientFactory(Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
+            var factory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
 
             HttpClient client1 = factory.CreateClient();
             HttpClient client2 = factory.CreateClient();
@@ -47,7 +47,7 @@ namespace Microsoft.Git.CredentialManager.Tests
                 RemoteUri = repoRemoteUri,
                 RepositoryPath = repoPath
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Git.CredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -104,7 +104,7 @@ namespace Microsoft.Git.CredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -140,7 +140,7 @@ namespace Microsoft.Git.CredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -176,7 +176,7 @@ namespace Microsoft.Git.CredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -212,7 +212,7 @@ namespace Microsoft.Git.CredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -247,7 +247,7 @@ namespace Microsoft.Git.CredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -257,6 +257,31 @@ namespace Microsoft.Git.CredentialManager.Tests
             Assert.Equal(proxyUrl, configuredProxyUrl?.ToString());
 
             AssertDefaultCredentials(proxy.Credentials);
+        }
+
+        [Theory]
+        [InlineData(null, TlsBackend.OpenSsl, false, false)]
+        [InlineData("ca-bundle.crt", TlsBackend.Other, false, true)]
+        [InlineData("ca-bundle.crt", TlsBackend.Schannel, false, false)]
+        [InlineData("ca-bundle.crt", TlsBackend.Schannel, true, true)]
+        public void HttpClientFactory_GetClient_ChecksCertBundleOnlyIfEnabled(string customCertBundle,
+            TlsBackend tlsBackend, bool useCustomCertBundleWithSchannel, bool expectBundleChecked)
+        {
+            var fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
+
+            var settings = new TestSettings()
+            {
+                CustomCertificateBundlePath = customCertBundle,
+                TlsBackend = tlsBackend,
+                UseCustomCertificateBundleWithSchannel = useCustomCertBundleWithSchannel
+            };
+
+            var factory = new HttpClientFactory(fileSystemMock.Object, Mock.Of<ITrace>(), settings, new TestStandardStreams());
+
+            HttpClient client = factory.CreateClient();
+
+            fileSystemMock.Verify(fs => fs.FileExists(It.IsAny<string>()), expectBundleChecked ? Times.Once : Times.Never);
         }
 
         private static void AssertDefaultCredentials(ICredentials credentials)

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Git.CredentialManager
                 throw new PlatformNotSupportedException();
             }
 
-            HttpClientFactory = new HttpClientFactory(Trace, Settings, Streams);
+            HttpClientFactory = new HttpClientFactory(FileSystem, Trace, Settings, Streams);
 
             // Set the parent window handle/ID
             SystemPrompts.ParentWindowId = Settings.ParentWindowId;

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -119,7 +119,6 @@ namespace Microsoft.Git.CredentialManager
                                         );
                 Settings          = new Settings(Environment, Git);
                 CredentialStore   = new MacOSKeychain(Settings.CredentialNamespace);
-
             }
             else if (PlatformUtils.IsLinux())
             {
@@ -136,7 +135,6 @@ namespace Microsoft.Git.CredentialManager
                                             FileSystem.GetCurrentDirectory()
                                         );
                 Settings          = new Settings(Environment, Git);
-
                 string gpgPath    = GetGpgPath(Environment, FileSystem, Trace);
                 IGpg gpg          = new Gpg(gpgPath, SessionManager);
                 CredentialStore   = new LinuxCredentialStore(FileSystem, Settings, SessionManager, gpg, Environment, Git);

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Git.CredentialManager
             public const string CurlHttpsProxy        = "HTTPS_PROXY";
             public const string GcmHttpProxy          = "GCM_HTTP_PROXY";
             public const string GitSslNoVerify        = "GIT_SSL_NO_VERIFY";
+            public const string GitSslCaInfo          = "GIT_SSL_CAINFO";
             public const string GcmInteractive        = "GCM_INTERACTIVE";
             public const string GcmParentWindow       = "GCM_MODAL_PARENTHWND";
             public const string MsAuthFlow            = "GCM_MSAUTH_FLOW";
@@ -97,7 +98,10 @@ namespace Microsoft.Git.CredentialManager
             {
                 public const string SectionName = "http";
                 public const string Proxy = "proxy";
+                public const string SchannelUseSslCaInfo = "schannelUseSSLCAInfo";
+                public const string SslBackend = "sslBackend";
                 public const string SslVerify = "sslVerify";
+                public const string SslCaInfo = "sslCAInfo";
             }
 
             public static class Remote

--- a/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Git.CredentialManager
 {
@@ -34,16 +37,19 @@ namespace Microsoft.Git.CredentialManager
 
     public class HttpClientFactory : IHttpClientFactory
     {
+        private readonly IFileSystem _fileSystem;
         private readonly ITrace _trace;
         private readonly ISettings _settings;
         private readonly IStandardStreams _streams;
 
-        public HttpClientFactory(ITrace trace, ISettings settings, IStandardStreams streams)
+        public HttpClientFactory(IFileSystem fileSystem, ITrace trace, ISettings settings, IStandardStreams streams)
         {
+            EnsureArgument.NotNull(fileSystem, nameof(fileSystem));
             EnsureArgument.NotNull(trace, nameof(trace));
             EnsureArgument.NotNull(settings, nameof(settings));
             EnsureArgument.NotNull(streams, nameof(streams));
 
+            _fileSystem = fileSystem;
             _trace = trace;
             _settings = settings;
             _streams = streams;
@@ -70,6 +76,7 @@ namespace Microsoft.Git.CredentialManager
                 handler = new HttpClientHandler();
             }
 
+            // IsCertificateVerificationEnabled takes precedence over custom TLS cert verification
             if (!_settings.IsCertificateVerificationEnabled)
             {
                 _trace.WriteLine("TLS certificate verification has been disabled.");
@@ -82,6 +89,95 @@ namespace Microsoft.Git.CredentialManager
                 ServicePointManager.ServerCertificateValidationCallback = (req, cert, chain, errors) => true;
 #elif NETSTANDARD
                 handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true;
+#endif
+            }
+            // If schannel is the TLS backend, custom certificate usage must be explicitly enabled
+            else if (!string.IsNullOrWhiteSpace(_settings.CustomCertificateBundlePath) &&
+                ((_settings.TlsBackend != TlsBackend.Schannel) || _settings.UseCustomCertificateBundleWithSchannel))
+            {
+                string certBundlePath = _settings.CustomCertificateBundlePath;
+                _trace.WriteLine($"Custom certificate verification has been enabled with certificate bundle at {certBundlePath}");
+
+                // Throw exception if cert bundle file not found
+                if (!_fileSystem.FileExists(certBundlePath))
+                {
+                    throw new FileNotFoundException($"Custom certificate bundle not found at path: {certBundlePath}", certBundlePath);
+                }
+
+                Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> validationCallback = (cert, chain, errors) =>
+                {
+                    // Fail immediately if there are non-chain issues with the remote cert
+                    if ((errors & ~SslPolicyErrors.RemoteCertificateChainErrors) != 0)
+                    {
+                        return false;
+                    }
+
+                    // Import the custom certs
+                    X509Certificate2Collection certBundle = new X509Certificate2Collection();
+                    certBundle.Import(certBundlePath);
+
+                    try
+                    {
+                        // Add the certs to the chain
+                        chain.ChainPolicy.ExtraStore.AddRange(certBundle);
+
+                        // Rebuild the chain
+                        if (chain.Build(cert))
+                        {
+                            return true;
+                        }
+
+                        // Manually handle case where only error is UntrustedRoot
+                        if (chain.ChainStatus.All(status => status.Status == X509ChainStatusFlags.UntrustedRoot))
+                        {
+                            // Verify root is contained within the certBundle
+                            X509Certificate2 rootCert = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
+                            var matchingCerts = certBundle.Find(X509FindType.FindByThumbprint, rootCert.Thumbprint, false);
+                            if (matchingCerts.Count > 0)
+                            {
+                                // Check the content of the first matching cert found (do
+                                // not try others if mismatched - mirrors OpenSSL:
+                                // https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_default_verify_paths.html#WARNINGS)
+                                return rootCert.RawData.SequenceEqual(matchingCerts[0].RawData);
+                            }
+                            else
+                            {
+                                // Untrusted root not found in custom cert bundle
+                                return false;
+                            }
+                        }
+
+                        // Fail for errors other than UntrustedRoot
+                        return false;
+                    }
+                    finally
+                    {
+                        // Dispose imported cert bundle
+                        for (int i = 0; i < certBundle.Count; i++)
+                        {
+                            certBundle[i].Dispose();
+                        }
+                    }
+                };
+
+                // Set the custom server certificate validation callback.
+                // NOTE: this is executed after the default platform server certificate validation is performed
+#if NETFRAMEWORK
+                ServicePointManager.ServerCertificateValidationCallback = (_, cert, chain, errors) =>
+                {
+                    // Fail immediately if the cert or chain isn't present
+                    if (cert is null || chain is null)
+                    {
+                        return false;
+                    }
+
+                    using (X509Certificate2 cert2 = new X509Certificate2(cert))
+                    {
+                        return validationCallback(cert2, chain, errors);
+                    }
+                };
+#elif NETSTANDARD
+                handler.ServerCertificateCustomValidationCallback = (_, cert, chain, errors) => validationCallback(cert, chain, errors);
 #endif
             }
 

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -39,6 +39,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
         public string CredentialBackingStore { get; set; }
 
+        public string CustomCertificateBundlePath { get; set; }
+
+        public TlsBackend TlsBackend { get; set; }
+
+        public bool UseCustomCertificateBundleWithSchannel { get; set; }
+
         #region ISettings
 
         public bool TryGetSetting(string envarName, string section, string property, out string value)
@@ -116,6 +122,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         string ISettings.CredentialNamespace => CredentialNamespace;
 
         string ISettings.CredentialBackingStore => CredentialBackingStore;
+
+        string ISettings.CustomCertificateBundlePath => CustomCertificateBundlePath;
+
+        TlsBackend ISettings.TlsBackend => TlsBackend;
+
+        bool ISettings.UseCustomCertificateBundleWithSchannel => UseCustomCertificateBundleWithSchannel;
 
         #endregion
 


### PR DESCRIPTION
Implements #242 

## Changes
- Add parsing for `sslCAInfo` git config parameter (and corresponding environment variable)
  - Ignored if `sslBackend` is `schannel` and `schannelUseSSLCAInfo` is false or not set
- If `sslCAInfo` _is_ set, custom cert validation callback is called for HTTP client
  - If there are any non-certificate chain errors with the server cert, **fail** (see `RemoteCertificateNameMismatch` and `RemoteCertificateNotAvailable` [here](https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslpolicyerrors?view=net-5.0))
  - If there are any SSL chain errors _other than_ untrusted root, **fail** (see flags listed [here](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509chainstatusflags?view=net-5.0))
  - Check the root of the server certificate 
    - If the server cert root matches the cert pointed to by `sslCAInfo`, **success**
    - If the certs do not match, **fail**
- Unit tests for the `sslCAInfo` setting
- Minor whitespace fixes from my last pull request 😜 

## Testing
For all tests, ran the `get` command as described in "[Development and Debugging](https://github.com/microsoft/Git-Credential-Manager-Core/blob/d9d62c7ce9100c9b1866a5ca3ed390151ff6e7be/docs/development.md#debugging)" (changing the protocol from "http" to "https" for `github.com`)

- **Before starting**, ran `sudo dpkg-reconfigure ca-certificates` to interactively (and temporarily) disable the root cert used by `github.com`
- Do not set `GIT_SSL_CAINFO`
  - Result: 
    ```
    fatal: The SSL connection could not be established, see inner exception.
    fatal: The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
    ```
- Set `GIT_SSL_CAINFO` to path to trusted root certificate
  - Result: successful `get` execution
- Set `GIT_SSL_CAINFO` to path to an unrelated trusted root certificate for GitHub 
  - Result: 
    ```
    fatal: The SSL connection could not be established, see inner exception.
    fatal: The remote certificate was rejected by the provided RemoteCertificateValidationCallback.
    ```
- Set `GIT_SSL_CAINFO` to path to a non-existent file
  - Result:  failure with the following printout (caused by uncaught exception in callback)
    ```
    fatal: Custom certificate bundle not found at path: <path to fake cert>
    ```

## Questions
- [x] Should this check whether the `sslCAInfo` file exists, or let the program fail?
  - Answer: Check first!
- [x] Should the other `X509ChainStatusFlags` be allowed to continue on to the cert match check? 
  - Answer: nope! be conservative with errors
  - Because the HTTP client first validates the cert against your local root store (and I didn't remove GitHub's actual root CA from my System Roots when testing), I wasn't able to verify that the Untrusted Root error is the _only_ one to come through with an otherwise-valid self-signed cert