### PR TITLE
Only enumerate local Azure Repos user bindings when inside a repository

### DIFF
--- a/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
@@ -190,11 +190,15 @@ namespace Microsoft.AzureRepos
                 return true;
             }
 
-            config.Enumerate(
-                GitConfigurationLevel.Local,
-                Constants.GitConfiguration.Credential.SectionName,
-                Constants.GitConfiguration.Credential.UserName,
-                entry => ExtractUserBinding(entry, localUsers));
+            // Only enumerate local configuration if we are inside a repository
+            if (_git.IsInsideRepository())
+            {
+                config.Enumerate(
+                    GitConfigurationLevel.Local,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.UserName,
+                    entry => ExtractUserBinding(entry, localUsers));
+            }
 
             config.Enumerate(
                 GitConfigurationLevel.Global,

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -130,6 +130,11 @@ namespace Microsoft.Git.CredentialManager
                     break;
             }
 
+            // If tracing is enabled then also print the stack trace to stderr
+            bool printStack = Context.Settings.GetTracingEnabled(out _);
+            if (printStack)
+                Context.Streams.Error.WriteLine(ex.StackTrace);
+
             // Recurse to print all inner exceptions
             if (!(ex.InnerException is null))
             {


### PR DESCRIPTION
Only attempt to enumerate Azure Repos user bindings in the local Git configuration, when inside a Git repository.
Also print any exception stack traces to standard error if application tracing is enabled to aid in debugging such issues "in the wild".

Fixes #416