### PR TITLE
Update copyright information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Git Credential Manager Core
-Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright © GitHub, Inc. and contributors
 
 MIT License
 

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -166,7 +166,7 @@ Section: vcs
 Priority: optional
 Architecture: $ARCH
 Depends:
-Maintainer: GCM-Core <gcmsupport@microsoft.com>
+Maintainer: GCM-Core <gitfundamentals@github.com>
 Description: Cross Platform Git Credential Manager Core command line utility.
  GCM Core supports authentication with a number of Git hosting providers
  including GitHub, BitBucket, and Azure DevOps.

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Atlassian.Bitbucket

--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;

--- a/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Net.Http;
 using Microsoft.Git.CredentialManager;

--- a/src/shared/Git-Credential-Manager/NOTICE
+++ b/src/shared/Git-Credential-Manager/NOTICE
@@ -1,20 +1,8 @@
 NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-This software incorporates material from third parties. Microsoft makes certain
-open source code available at https://3rdpartysource.microsoft.com, or you may
-send a check or money order for US $5.00, including the product name, the open
-source component name, and version number, to:
-
-Source Code Compliance Team
-Microsoft Corporation
-One Microsoft Way
-Redmond, WA 98052
-USA
-
-Notwithstanding any other terms, you may reverse engineer this software to the
-extent required to debug changes to any libraries licensed under the GNU Lesser
-General Public License.
+This repository for Git Credential Manager Core includes material from the
+projects listed below.
 
 --------------------------------------------------------------------------------
 1. GitHub/VisualStudio (https://github.com/github/VisualStudio)

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Atlassian.Bitbucket;
 using GitHub;

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/shared/GitHub.Tests/GitHubRestApiTests.cs
+++ b/src/shared/GitHub.Tests/GitHubRestApiTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Linq;
 using System.Net;

--- a/src/shared/GitHub/AuthenticationResult.cs
+++ b/src/shared/GitHub/AuthenticationResult.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using Microsoft.Git.CredentialManager;
 
 namespace GitHub

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace GitHub

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/src/shared/GitHub/GitHubOAuth2Client.cs
+++ b/src/shared/GitHub/GitHubOAuth2Client.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Net.Http;
 using Microsoft.Git.CredentialManager;

--- a/src/shared/GitHub/GitHubRestApi.cs
+++ b/src/shared/GitHub/GitHubRestApi.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/GitHub/InternalsVisibleTo.cs
+++ b/src/shared/GitHub/InternalsVisibleTo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Runtime.CompilerServices;
 
 [assembly:InternalsVisibleTo("GitHub.Tests")]

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposAuthorityCacheTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposAuthorityCacheTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposBindingManagerTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposBindingManagerTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/UriHelpersTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using Microsoft.Git.CredentialManager;

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsAuthorityCache.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsAuthorityCache.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.AzureRepos

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/src/shared/Microsoft.AzureRepos/InternalsVisibleTo.cs
+++ b/src/shared/Microsoft.AzureRepos/InternalsVisibleTo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Runtime.CompilerServices;
 
 [assembly:InternalsVisibleTo("Microsoft.AzureRepos.Tests")]

--- a/src/shared/Microsoft.AzureRepos/UriHelpers.cs
+++ b/src/shared/Microsoft.AzureRepos/UriHelpers.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Linq;
 using Microsoft.Git.CredentialManager;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/ApplicationTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/AuthenticationBaseTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/AuthenticationBaseTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using Microsoft.Git.CredentialManager.Authentication;
 using Xunit;
 

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/BasicAuthenticationTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Microsoft.Git.CredentialManager.Authentication;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/MicrosoftAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/MicrosoftAuthenticationTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Microsoft.Git.CredentialManager.Authentication;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/OAuth2ClientTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/OAuth2ClientTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Net.Http;
 using System.Threading;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/WindowsIntegratedAuthenticationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Authentication/WindowsIntegratedAuthenticationTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Base64UrlConvertTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Base64UrlConvertTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/ConfigureCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/ConfigureCommandTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Commands;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/EraseCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/EraseCommandTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Commands;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GetCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GetCommandTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GitCommandBaseTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/GitCommandBaseTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/StoreCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/StoreCommandTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Commands;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/UnconfigureCommandTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/UnconfigureCommandTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Commands;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/ConfigurationServiceTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/ConfigurationServiceTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Tests.Objects;
 using Moq;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/EnumerableExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/EnumerableExtensionsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GenericHostProviderTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GenericHostProviderTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationKeyComparerTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationKeyComparerTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.IO;
 using System.Linq;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager.Tests.Objects;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientExtensionsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HttpRequestExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HttpRequestExtensionsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Net.Http;
 using Xunit;
 

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Linux/SecretServiceCollectionTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Linux/SecretServiceCollectionTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Xunit;
 using Microsoft.Git.CredentialManager.Interop.Linux;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/MacOS/MacOSKeychainTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/MacOS/MacOSKeychainTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Xunit;
 using Microsoft.Git.CredentialManager.Interop;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/U8StringConverterTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/U8StringConverterTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Microsoft.Git.CredentialManager.Interop;
 using Xunit;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Xunit;
 using Microsoft.Git.CredentialManager.Interop.Windows;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/PlaintextCredentialStoreTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/PlaintextCredentialStoreTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/StreamExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/StreamExtensionsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Xunit;
 

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/TraceTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/TraceTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 using System;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/UriExtensionsTests.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ApplicationBase.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/BasicAuthentication.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager.Authentication

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/HttpListenerExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/HttpListenerExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/IOAuth2WebBrowser.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/IOAuth2WebBrowser.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Net;
 using System.Threading;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Newtonsoft.Json;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/ErrorResponseJson.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/ErrorResponseJson.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Text;
 using Newtonsoft.Json;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/TimeSpanSecondsConverter.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/TimeSpanSecondsConverter.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Newtonsoft.Json;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/TokenEndpointResponseJson.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/Json/TokenEndpointResponseJson.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Newtonsoft.Json;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager.Authentication.OAuth

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2Client.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2Client.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2Constants.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager.Authentication.OAuth
 {

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2CryptographicGenerator.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2CryptographicGenerator.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Security.Cryptography;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2DeviceCodeResult.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2DeviceCodeResult.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager.Authentication.OAuth

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2ServerEndpoints.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2ServerEndpoints.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager.Authentication.OAuth

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2SystemWebBrowser.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2TokenResult.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/OAuth/OAuth2TokenResult.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager.Authentication.OAuth

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/WindowsIntegratedAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/WindowsIntegratedAuthentication.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/shared/Microsoft.Git.CredentialManager/Base64UrlConvert.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Base64UrlConvert.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using Microsoft.Git.CredentialManager.Interop.Linux;

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/ConfigurationCommands.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/ConfigurationCommands.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/EraseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/EraseCommand.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager.Commands

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/GitCommandBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/GitCommandBase.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/StoreCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/StoreCommand.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Threading.Tasks;
 

--- a/src/shared/Microsoft.Git.CredentialManager/ConfigurationService.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ConfigurationService.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Reflection;
 

--- a/src/shared/Microsoft.Git.CredentialManager/ConvertUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ConvertUtils.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/shared/Microsoft.Git.CredentialManager/Credential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Credential.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager
 {

--- a/src/shared/Microsoft.Git.CredentialManager/CredentialCacheStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CredentialCacheStore.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/shared/Microsoft.Git.CredentialManager/DictionaryExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/DictionaryExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/DisposableObject.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/DisposableObject.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/shared/Microsoft.Git.CredentialManager/EnsureArgument.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/EnsureArgument.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/shared/Microsoft.Git.CredentialManager/EnumerableExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/EnumerableExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager/EnvironmentBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/EnvironmentBase.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/FileCredential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/FileCredential.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 namespace Microsoft.Git.CredentialManager
 {
     public class FileCredential : ICredential

--- a/src/shared/Microsoft.Git.CredentialManager/FileSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/FileSystem.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager/Git.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Git.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfigurationEntry.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfigurationEntry.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 namespace Microsoft.Git.CredentialManager
 {
     public class GitConfigurationEntry

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfigurationKeyComparer.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfigurationKeyComparer.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/shared/Microsoft.Git.CredentialManager/Gpg.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Gpg.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Diagnostics;
 

--- a/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager/HttpClientExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HttpClientExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HttpClientFactory.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/HttpRequestExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HttpRequestExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Globalization;
 using System.Net.Http;

--- a/src/shared/Microsoft.Git.CredentialManager/ICredentialStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ICredentialStore.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager
 {

--- a/src/shared/Microsoft.Git.CredentialManager/ISystemPrompts.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ISystemPrompts.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager
 {

--- a/src/shared/Microsoft.Git.CredentialManager/ITerminal.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/ITerminal.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Microsoft.Git.CredentialManager.Interop;
 

--- a/src/shared/Microsoft.Git.CredentialManager/InputArguments.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/InputArguments.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/InteropException.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/InteropException.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/InteropUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/InteropUtils.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxCredentialStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxCredentialStore.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxFileSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxFileSystem.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using Microsoft.Git.CredentialManager.Interop.Posix;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxSystemPrompts.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxSystemPrompts.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager.Interop.Linux
 {

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Glib.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Glib.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Gobject.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Gobject.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Libsecret.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/Libsecret.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/SecretServiceCollection.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/SecretServiceCredential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/SecretServiceCredential.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Diagnostics;
 
 namespace Microsoft.Git.CredentialManager.Interop.Linux

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSFileSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSFileSystem.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using Microsoft.Git.CredentialManager.Interop.Posix;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSKeychain.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSKeychain.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSKeychainCredential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSKeychainCredential.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Diagnostics;
 
 namespace Microsoft.Git.CredentialManager.Interop.MacOS

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSSessionManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSSessionManager.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using Microsoft.Git.CredentialManager.Interop.MacOS.Native;
 using Microsoft.Git.CredentialManager.Interop.Posix;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSSystemPrompts.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSSystemPrompts.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager.Interop.MacOS
 {

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/CoreFoundation.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/CoreFoundation.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using static Microsoft.Git.CredentialManager.Interop.MacOS.Native.LibSystem;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/LibSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/LibSystem.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/SecurityFramework.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/SecurityFramework.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using static Microsoft.Git.CredentialManager.Interop.MacOS.Native.LibSystem;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/GpgPassCredentialStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/GpgPassCredentialStore.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Fcntl.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Fcntl.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Signal.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Signal.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Git.CredentialManager.Interop.Posix.Native

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stat.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stat.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stdio.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stdio.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stdlib.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Stdlib.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Git.CredentialManager.Interop.Posix.Native

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Termios.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Termios.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Unistd.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Unistd.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixEnvironment.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixFileDescriptor.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixFileDescriptor.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Text;
 using Microsoft.Git.CredentialManager.Interop.Posix.Native;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixFileSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixFileSystem.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager.Interop.Posix
 {

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixSessionManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixSessionManager.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager.Interop.Posix

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixTerminal.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixTerminal.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Text;
 using Microsoft.Git.CredentialManager.Interop.Posix.Native;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/U8StringConverter.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/U8StringConverter.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/U8StringMarshaler.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/U8StringMarshaler.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Advapi32.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Advapi32.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/CredUi.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/CredUi.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Kernel32.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Kernel32.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Ole32.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Ole32.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Git.CredentialManager.Interop.Windows.Native

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/User32.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/User32.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Win32Error.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/Native/Win32Error.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredential.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredential.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager.Interop.Windows
 {

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsCredentialManager.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsEnvironment.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsFileSystem.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsFileSystem.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsSessionManager.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsSessionManager.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using Microsoft.Git.CredentialManager.Interop.Windows.Native;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsSettings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsSettings.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager.Interop.Windows
 {

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsSystemPrompts.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsSystemPrompts.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsTerminal.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsTerminal.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/NameValueCollectionExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/NameValueCollectionExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/shared/Microsoft.Git.CredentialManager/PlaintextCredentialStore.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/PlaintextCredentialStore.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.Git.CredentialManager.Interop.Posix.Native;

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/Microsoft.Git.CredentialManager/StandardStreams.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/StandardStreams.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.IO;
 using System.Text;

--- a/src/shared/Microsoft.Git.CredentialManager/StreamExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/StreamExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/Microsoft.Git.CredentialManager/StringExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/StringExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/shared/Microsoft.Git.CredentialManager/TerminalMenu.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/TerminalMenu.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/shared/Microsoft.Git.CredentialManager/Trace.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Trace.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/UriExtensions.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/shared/TestInfrastructure/GitTestUtilities.cs
+++ b/src/shared/TestInfrastructure/GitTestUtilities.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/shared/TestInfrastructure/Objects/TestCredentialStore.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCredentialStore.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
+++ b/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
+++ b/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/TestInfrastructure/Objects/TestGpg.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGpg.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Threading.Tasks;
 

--- a/src/shared/TestInfrastructure/Objects/TestHostProviderRegistry.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHostProviderRegistry.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects

--- a/src/shared/TestInfrastructure/Objects/TestHttpClientFactory.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHttpClientFactory.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.Net;
 using System.Net.Http;
 

--- a/src/shared/TestInfrastructure/Objects/TestHttpMessageHandler.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHttpMessageHandler.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/shared/TestInfrastructure/Objects/TestOAuth2Server.cs
+++ b/src/shared/TestInfrastructure/Objects/TestOAuth2Server.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/shared/TestInfrastructure/Objects/TestOAuth2WebBrowser.cs
+++ b/src/shared/TestInfrastructure/Objects/TestOAuth2WebBrowser.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Net.Http;
 using System.Threading;

--- a/src/shared/TestInfrastructure/Objects/TestSessionManager.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSessionManager.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects
 {

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 

--- a/src/shared/TestInfrastructure/Objects/TestStandardStreams.cs
+++ b/src/shared/TestInfrastructure/Objects/TestStandardStreams.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System.IO;
 using System.Text;
 

--- a/src/shared/TestInfrastructure/Objects/TestSystemPrompts.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSystemPrompts.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects

--- a/src/shared/TestInfrastructure/Objects/TestTerminal.cs
+++ b/src/shared/TestInfrastructure/Objects/TestTerminal.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 

--- a/src/shared/TestInfrastructure/PlatformAttributes.cs
+++ b/src/shared/TestInfrastructure/PlatformAttributes.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using Xunit;

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/AuthenticationPrompts.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/AuthenticationPrompts.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using Atlassian.Bitbucket.UI.Controls;
+﻿using Atlassian.Bitbucket.UI.Controls;
 using Atlassian.Bitbucket.UI.ViewModels;
 using Microsoft.Git.CredentialManager.UI;
 

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/CredentialsControl.xaml.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/CredentialsControl.xaml.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/OAuthControl.xaml.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/OAuthControl.xaml.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace Atlassian.Bitbucket.UI.Controls
 {

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Helpers/AccessKeysManagerScoping.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Helpers/AccessKeysManagerScoping.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Helpers/FocusHelper.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Helpers/FocusHelper.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.UI;

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Tester.xaml.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Tester.xaml.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Interop;
 using Atlassian.Bitbucket.UI.Controls;

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/ViewModels/CredentialsViewModel.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/ViewModels/CredentialsViewModel.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Security;
 using System.Windows.Input;
 using Microsoft.Git.CredentialManager;

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/ViewModels/OAuthViewModel.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/ViewModels/OAuthViewModel.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Windows.Input;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.UI;

--- a/src/windows/GitHub.UI.Windows/AuthenticationPrompts.cs
+++ b/src/windows/GitHub.UI.Windows/AuthenticationPrompts.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using GitHub.UI.Login;
 using Microsoft.Git.CredentialManager.UI;
 

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Git.CredentialManager;

--- a/src/windows/GitHub.UI.Windows/Tester.xaml.cs
+++ b/src/windows/GitHub.UI.Windows/Tester.xaml.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Interop;
 using GitHub.UI.Login;

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -33,7 +33,7 @@
 #define GcmShortName "Git Credential Manager Core"
 #define GcmPublisher "Microsoft Corporation"
 #define GcmPublisherUrl "https://www.microsoft.com"
-#define GcmCopyright "Copyright (c) Microsoft 2020"
+#define GcmCopyright "Copyright (c) GitHub, Inc. and contributors"
 #define GcmUrl "https://aka.ms/gcmcore"
 #define GcmReadme "https://github.com/microsoft/Git-Credential-Manager-Core/blob/main/README.md"
 #define GcmRepoRoot "..\..\.."

--- a/src/windows/Shared.UI.Windows/CommandLineUtils.cs
+++ b/src/windows/Shared.UI.Windows/CommandLineUtils.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
 using System;
 using System.Linq;
 

--- a/src/windows/Shared.UI.Windows/Controls/DialogWindow.xaml.cs
+++ b/src/windows/Shared.UI.Windows/Controls/DialogWindow.xaml.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Input;
 using Microsoft.Git.CredentialManager.UI.ViewModels;
 

--- a/src/windows/Shared.UI.Windows/Controls/ValidationMessage.cs
+++ b/src/windows/Shared.UI.Windows/Controls/ValidationMessage.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;

--- a/src/windows/Shared.UI.Windows/Converters/BooleanAndConverter.cs
+++ b/src/windows/Shared.UI.Windows/Converters/BooleanAndConverter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq;
 using System.Windows;

--- a/src/windows/Shared.UI.Windows/Converters/BooleanToVisibilityConverter.cs
+++ b/src/windows/Shared.UI.Windows/Converters/BooleanToVisibilityConverter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;

--- a/src/windows/Shared.UI.Windows/Converters/ConverterUtils.cs
+++ b/src/windows/Shared.UI.Windows/Converters/ConverterUtils.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Windows;
 
 namespace Microsoft.Git.CredentialManager.UI.Converters

--- a/src/windows/Shared.UI.Windows/Converters/NonEmptyStringToVisibleConverter.cs
+++ b/src/windows/Shared.UI.Windows/Converters/NonEmptyStringToVisibleConverter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;

--- a/src/windows/Shared.UI.Windows/Gui.cs
+++ b/src/windows/Shared.UI.Windows/Gui.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/windows/Shared.UI.Windows/RelayCommand.cs
+++ b/src/windows/Shared.UI.Windows/RelayCommand.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Windows.Input;
 
 namespace Microsoft.Git.CredentialManager.UI

--- a/src/windows/Shared.UI.Windows/ViewModels/Validation/ModelValidator.cs
+++ b/src/windows/Shared.UI.Windows/ViewModels/Validation/ModelValidator.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/windows/Shared.UI.Windows/ViewModels/Validation/PropertyValidationResult.cs
+++ b/src/windows/Shared.UI.Windows/ViewModels/Validation/PropertyValidationResult.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-
+﻿
 namespace Microsoft.Git.CredentialManager.UI.ViewModels.Validation
 {
     public class PropertyValidationResult

--- a/src/windows/Shared.UI.Windows/ViewModels/Validation/PropertyValidator.cs
+++ b/src/windows/Shared.UI.Windows/ViewModels/Validation/PropertyValidator.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/windows/Shared.UI.Windows/ViewModels/Validation/PropertyValidatorExtensions.cs
+++ b/src/windows/Shared.UI.Windows/ViewModels/Validation/PropertyValidatorExtensions.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Security;
 
 namespace Microsoft.Git.CredentialManager.UI.ViewModels.Validation

--- a/src/windows/Shared.UI.Windows/ViewModels/Validation/ValidationStatus.cs
+++ b/src/windows/Shared.UI.Windows/ViewModels/Validation/ValidationStatus.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-
+﻿
 namespace Microsoft.Git.CredentialManager.UI.ViewModels.Validation
 {
     public enum ValidationStatus

--- a/src/windows/Shared.UI.Windows/ViewModels/ViewModel.cs
+++ b/src/windows/Shared.UI.Windows/ViewModels/ViewModel.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Git.CredentialManager.UI.ViewModels

--- a/src/windows/Shared.UI.Windows/ViewModels/WindowViewModel.cs
+++ b/src/windows/Shared.UI.Windows/ViewModels/WindowViewModel.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-using System;
+﻿using System;
 using System.Diagnostics;
 
 namespace Microsoft.Git.CredentialManager.UI.ViewModels


### PR DESCRIPTION
Per a conversation with Microsoft CELA, I believe this is the correct copyright attribution for the project.

@mjcheetham for maintainer's 👀 , @ashleywolf as FYI from GitHub OSPO, @royaljust as FYI from Microsoft CELA

Changes:
- https://github.com/microsoft/Git-Credential-Manager-Core/pull/426/commits/9e31a9de3abf6bbc7edca2bfe1d535662b949b0d mechanically removes the copyright header from every .cs file. It can safely be ignored.
- https://github.com/microsoft/Git-Credential-Manager-Core/commit/0d779ccaccd74f8f59fd730c5f1c87f79d85ecb6 is the interesting part which updates the copyright holder to "GitHub, Inc. and contributors".