### PR TITLE
Remove planned features section, completed feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ Proxy support|&#10003;|&#10003;|&#10003;
 
 (\*\*) Debian package offered but not yet available on an official Microsoft feed.
 
-### Planned features
-
-- [ ] macOS/Linux native UI ([#136](https://github.com/microsoft/Git-Credential-Manager-Core/issues/136))
-
 ## Download and Install
 
 ### macOS Homebrew


### PR DESCRIPTION
First of all, thanks for this project! I've seen it make things much smoother for some of our bootcamp students. Considering also including this in our [macOS System Setup guide](https://github.com/upleveled/system-setup/blob/main/macos.md) to avoid the problems associated with password-based CLI authentication failing (due to the [new changes to remove password-based auth for Git operations](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/))

The native UI feature from issue https://github.com/microsoft/Git-Credential-Manager-Core/issues/136 was completed in https://github.com/microsoft/Git-Credential-Manager-Core/pull/336 by https://github.com/mjcheetham .

cc @mjcheetham

---

PS. Side question: Is my assumption in the first paragraph above correct? If I get the students to install the Git Credential Manager Core on their macOS systems via Homebrew, will this avoid them getting the dreaded error below?

```
remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
```

My assumption is that Git Credential Manager Core will avoid this by generating an auth token for them, but I haven't tested this yet.