### PR TITLE
Split macOS and Linux implementations and fix password echo bug

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Git.CredentialManager
                 SessionManager    = new MacOSSessionManager();
                 SystemPrompts     = new MacOSSystemPrompts();
                 Environment       = new PosixEnvironment(FileSystem);
-                Terminal          = new PosixTerminal(Trace);
+                Terminal          = new MacOSTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
@@ -127,7 +127,7 @@ namespace Microsoft.Git.CredentialManager
                 SessionManager    = new PosixSessionManager();
                 SystemPrompts     = new LinuxSystemPrompts();
                 Environment       = new PosixEnvironment(FileSystem);
-                Terminal          = new PosixTerminal(Trace);
+                Terminal          = new LinuxTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxTerminal.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/LinuxTerminal.cs
@@ -1,0 +1,76 @@
+using System;
+using Microsoft.Git.CredentialManager.Interop.Linux.Native;
+using Microsoft.Git.CredentialManager.Interop.Posix;
+using Microsoft.Git.CredentialManager.Interop.Posix.Native;
+
+namespace Microsoft.Git.CredentialManager.Interop.Linux
+{
+    public class LinuxTerminal : PosixTerminal
+    {
+        public LinuxTerminal(ITrace trace)
+            : base(trace) { }
+
+        protected override IDisposable CreateTtyContext(int fd, bool echo)
+        {
+            return new TtyContext(Trace, fd, echo);
+        }
+
+        private class TtyContext : IDisposable
+        {
+            private readonly ITrace _trace;
+            private readonly int _fd;
+
+            private termios_Linux _originalTerm;
+            private bool _isDisposed;
+
+            public TtyContext(ITrace trace, int fd, bool echo)
+            {
+                EnsureArgument.NotNull(trace, nameof(trace));
+                EnsureArgument.PositiveOrZero(fd, nameof(fd));
+
+                _trace = trace;
+                _fd = fd;
+
+                int error = 0;
+
+                // Capture current terminal settings so we can restore them later
+                if ((error = Termios_Linux.tcgetattr(_fd, out termios_Linux t)) != 0)
+                {
+                    throw new InteropException("Failed to get initial terminal settings", error);
+                }
+
+                _originalTerm = t;
+
+                // Set desired echo state
+                _trace.WriteLine($"Setting terminal echo state to '{echo}'");
+                if (echo)
+                    t.c_lflag |= LocalFlags.ECHO;
+                else
+                    t.c_lflag &= ~LocalFlags.ECHO;
+
+                if ((error = Termios_Linux.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref t)) != 0)
+                {
+                    throw new InteropException("Failed to set terminal settings", error);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                int error = 0;
+
+                // Restore original terminal settings
+                if ((error = Termios_Linux.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref _originalTerm)) != 0)
+                {
+                    _trace.WriteLine($"Failed to get restore terminal settings (error: {error:x}");
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/termios_Linux.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Linux/Native/termios_Linux.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+using Microsoft.Git.CredentialManager.Interop.Posix.Native;
+
+namespace Microsoft.Git.CredentialManager.Interop.Linux.Native
+{
+    public static class Termios_Linux
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcgetattr(int fd, out termios_Linux termios);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcsetattr(int fd, SetActionFlags optActions, ref termios_Linux termios);
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct termios_Linux
+    {
+        // Linux has an array of 32 elements
+        private const int NCCS = 32;
+
+        // Linux uses unsigned 32-bit sized flags
+        [FieldOffset(0)]  public InputFlags   c_iflag;
+        [FieldOffset(4)]  public OutputFlags  c_oflag;
+        [FieldOffset(8)]  public ControlFlags c_cflag;
+        [FieldOffset(12)] public LocalFlags   c_lflag;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = NCCS)]
+        [FieldOffset(16)] public byte[] c_cc;
+
+        [FieldOffset(16 + NCCS)]     public uint c_ispeed;
+        [FieldOffset(16 + NCCS + 4)] public uint c_ospeed;
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSTerminal.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/MacOSTerminal.cs
@@ -1,0 +1,76 @@
+using System;
+using Microsoft.Git.CredentialManager.Interop.MacOS.Native;
+using Microsoft.Git.CredentialManager.Interop.Posix;
+using Microsoft.Git.CredentialManager.Interop.Posix.Native;
+
+namespace Microsoft.Git.CredentialManager.Interop.MacOS
+{
+    public class MacOSTerminal : PosixTerminal
+    {
+        public MacOSTerminal(ITrace trace)
+            : base(trace) { }
+
+        protected override IDisposable CreateTtyContext(int fd, bool echo)
+        {
+            return new TtyContext(Trace, fd, echo);
+        }
+
+        private class TtyContext : IDisposable
+        {
+            private readonly ITrace _trace;
+            private readonly int _fd;
+
+            private termios_MacOS _originalTerm;
+            private bool _isDisposed;
+
+            public TtyContext(ITrace trace, int fd, bool echo)
+            {
+                EnsureArgument.NotNull(trace, nameof(trace));
+                EnsureArgument.PositiveOrZero(fd, nameof(fd));
+
+                _trace = trace;
+                _fd = fd;
+
+                int error = 0;
+
+                // Capture current terminal settings so we can restore them later
+                if ((error = Termios_MacOS.tcgetattr(_fd, out termios_MacOS t)) != 0)
+                {
+                    throw new InteropException("Failed to get initial terminal settings", error);
+                }
+
+                _originalTerm = t;
+
+                // Set desired echo state
+                _trace.WriteLine($"Setting terminal echo state to '{echo}'");
+                if (echo)
+                    t.c_lflag |= LocalFlags.ECHO;
+                else
+                    t.c_lflag &= ~LocalFlags.ECHO;
+
+                if ((error = Termios_MacOS.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref t)) != 0)
+                {
+                    throw new InteropException("Failed to set terminal settings", error);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                int error = 0;
+
+                // Restore original terminal settings
+                if ((error = Termios_MacOS.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref _originalTerm)) != 0)
+                {
+                    _trace.WriteLine($"Failed to get restore terminal settings (error: {error:x}");
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/termios_MacOS.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/MacOS/Native/termios_MacOS.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+using Microsoft.Git.CredentialManager.Interop.Posix.Native;
+
+namespace Microsoft.Git.CredentialManager.Interop.MacOS.Native
+{
+    public static class Termios_MacOS
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcgetattr(int fd, out termios_MacOS termios);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcsetattr(int fd, SetActionFlags optActions, ref termios_MacOS termios);
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct termios_MacOS
+    {
+        // macOS has an array of 20 elements
+        private const int NCCS = 20;
+
+        // macOS uses unsigned 64-bit sized flags
+        [FieldOffset(0)]  public InputFlags   c_iflag;
+        [FieldOffset(8)]  public OutputFlags  c_oflag;
+        [FieldOffset(16)] public ControlFlags c_cflag;
+        [FieldOffset(24)] public LocalFlags   c_lflag;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = NCCS)]
+        [FieldOffset(32)] public byte[] c_cc;
+
+        [FieldOffset(32 + NCCS)]     public ulong c_ispeed;
+        [FieldOffset(32 + NCCS + 8)] public ulong c_ospeed;
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Termios.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/Native/Termios.cs
@@ -1,36 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.Git.CredentialManager.Interop.Posix.Native
 {
-    public static class Termios
-    {
-        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        public static extern int tcgetattr(int fd, out termios termios);
-
-        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        public static extern int tcsetattr(int fd, SetActionFlags optActions, ref termios termios);
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct termios
-    {
-        private const int NCCS = 20;
-
-        public InputFlags   c_iflag;
-        public OutputFlags  c_oflag;
-        public ControlFlags c_cflag;
-        public LocalFlags   c_lflag;
-
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = NCCS)]
-        public byte[] c_cc;
-
-        public ulong c_ispeed;
-        public ulong c_ospeed;
-    }
-
     [Flags]
     public enum SetActionFlags
     {
@@ -51,7 +24,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix.Native
     }
 
     [Flags]
-    public enum InputFlags : ulong
+    public enum InputFlags : uint
     {
         IGNBRK  = 0x00000001, // ignore BREAK condition
         BRKINT  = 0x00000002, // map BREAK to SIGINTR
@@ -70,7 +43,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix.Native
     }
 
     [Flags]
-    public enum OutputFlags : ulong
+    public enum OutputFlags : uint
     {
         OPOST  = 0x00000001, // enable following output processing
         ONLCR  = 0x00000002, // map NL to CR-NL (ala CRMOD)
@@ -90,7 +63,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix.Native
     }
 
     [Flags]
-    public enum ControlFlags : ulong
+    public enum ControlFlags : uint
     {
         CIGNORE    = 0x00000001, // ignore control flags
         CSIZE      = 0x00000300, // character size mask
@@ -114,7 +87,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix.Native
     }
 
     [Flags]
-    public enum LocalFlags : ulong
+    public enum LocalFlags : uint
     {
         ECHOKE     = 0x00000001, // visual erase for line kill
         ECHOE      = 0x00000002, // visually erase chars

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixTerminal.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Posix/PosixTerminal.cs
@@ -9,19 +9,19 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
     /// <summary>
     /// Represents a thin wrapper around the POSIX TTY device (/dev/tty).
     /// </summary>
-    public class PosixTerminal : ITerminal
+    public abstract class PosixTerminal : ITerminal
     {
         private const string TtyDeviceName = "/dev/tty";
         private const byte DeleteChar = 127;
 
-        private readonly ITrace _trace;
+        protected readonly ITrace Trace;
 
         public PosixTerminal(ITrace trace)
         {
             PlatformUtils.EnsurePosix();
             EnsureArgument.NotNull(trace, nameof(trace));
 
-            _trace = trace;
+            Trace = trace;
         }
 
         public void WriteLine(string format, params object[] args)
@@ -30,7 +30,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
             {
                 if (fd.IsInvalid)
                 {
-                    _trace.WriteLine("Not a TTY, abandoning write line.");
+                    Trace.WriteLine("Not a TTY, abandoning write line.");
                     return;
                 }
 
@@ -49,13 +49,15 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
             return Prompt(prompt, echo: false);
         }
 
+        protected abstract IDisposable CreateTtyContext(int fd, bool echo);
+
         private string Prompt(string prompt, bool echo)
         {
             using (var fd = new PosixFileDescriptor(TtyDeviceName, OpenFlags.O_RDWR))
             {
                 if (fd.IsInvalid)
                 {
-                    _trace.WriteLine("Not a TTY, abandoning prompt.");
+                    Trace.WriteLine("Not a TTY, abandoning prompt.");
                     return null;
                 }
 
@@ -63,7 +65,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
 
                 var sb = new StringBuilder();
 
-                using (new TtyContext(_trace, fd, echo))
+                using (CreateTtyContext(fd, echo))
                 {
                     var readBuf = new byte[1];
                     bool eol = false;
@@ -75,7 +77,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
                         {
                             // Either we reached end of file or an error occured.
                             // We don't care which so let's just trace and terminate further reading.
-                            _trace.WriteLine($"Exiting POSIX terminal prompt read-loop unexpectedly (nr={nr})");
+                            Trace.WriteLine($"Exiting POSIX terminal prompt read-loop unexpectedly (nr={nr})");
                             eol = true;
                             break;
                         }
@@ -87,7 +89,7 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
                                 // Since `read` is a blocking call we must manually raise the SIGINT signal
                                 // when the user types CTRL+C into the terminal window.
                                 int pid = Unistd.getpid();
-                                _trace.WriteLine($"Intercepted SIGINT during terminal prompt read-loop - sending SIGINT to self (pid={pid})");
+                                Trace.WriteLine($"Intercepted SIGINT during terminal prompt read-loop - sending SIGINT to self (pid={pid})");
                                 Signal.kill(pid, Signal.SIGINT);
                                 break;
 
@@ -117,63 +119,6 @@ namespace Microsoft.Git.CredentialManager.Interop.Posix
                     }
                     return sb.ToString();
                 }
-            }
-        }
-
-        private class TtyContext : IDisposable
-        {
-            private readonly ITrace _trace;
-            private readonly int _fd;
-
-            private termios _originalTerm;
-            private bool _isDisposed;
-
-            public TtyContext(ITrace trace, int fd, bool echo)
-            {
-                EnsureArgument.NotNull(trace, nameof(trace));
-                EnsureArgument.PositiveOrZero(fd, nameof(fd));
-
-                _trace = trace;
-                _fd = fd;
-
-                int error = 0;
-
-                // Capture current terminal settings so we can restore them later
-                if ((error = Termios.tcgetattr(_fd, out termios t)) != 0)
-                {
-                    throw new InteropException("Failed to get initial terminal settings", error);
-                }
-
-                _originalTerm = t;
-
-                // Set desired echo state
-                _trace.WriteLine($"Setting terminal echo state to '{echo}'");
-                t.c_lflag &= echo
-                    ? LocalFlags.ECHO
-                    : ~LocalFlags.ECHO;
-
-                if ((error = Termios.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref t)) != 0)
-                {
-                    throw new InteropException("Failed to set terminal settings", error);
-                }
-            }
-
-            public void Dispose()
-            {
-                if (_isDisposed)
-                {
-                    return;
-                }
-
-                int error = 0;
-
-                // Restore original terminal settings
-                if ((error = Termios.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref _originalTerm)) != 0)
-                {
-                    _trace.WriteLine($"Failed to get restore terminal settings (error: {error:x}");
-                }
-
-                _isDisposed = true;
             }
         }
     }


### PR DESCRIPTION
Previously the `PosixTerminal` class used the POSIX `termios` structure and `tcgetattr`/`tcsetattr` functions for both macOS and Linux systems.

However, it transpires that the definition of the `termios` flags fields differs between Mac and Linux. On Linux the fields are `unsigned int` (4 bytes), but on macOS the fields are `unsigned long` (8 bytes).

This change splits the `termios` structure into Mac and Linux flavours and sets the correct field offsets.

This also fixes a bug with the bit fiddling.. previously we correctly cleared the `echo` bit when needed, but failed to set the bit if needed. This was not really an issue since echo is usually default "on" anyway.

Fixes #432