### PR TITLE
Drop unnecessary async keyword from method in tests

### DIFF
--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -213,7 +213,7 @@ namespace Atlassian.Bitbucket.Tests
         [InlineData("https://Bitbucket.org", "none", BitbucketConstants.DotOrgAuthenticationModes)]
         [InlineData("https://bitbucket.org", null, BitbucketConstants.DotOrgAuthenticationModes)]
         [InlineData("https://Bitbucket.org", null, BitbucketConstants.DotOrgAuthenticationModes)]
-        public async Task BitbucketHostProvider_GetSupportedAuthenticationModes(string uriString, string bitbucketAuthModes, AuthenticationModes expectedModes)
+        public void BitbucketHostProvider_GetSupportedAuthenticationModes(string uriString, string bitbucketAuthModes, AuthenticationModes expectedModes)
         {
             var targetUri = new Uri(uriString);
 
@@ -224,7 +224,7 @@ namespace Atlassian.Bitbucket.Tests
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
-            AuthenticationModes actualModes = provider.GetSupportedAuthenticationModesAsync(targetUri);
+            AuthenticationModes actualModes = provider.GetSupportedAuthenticationModes(targetUri);
 
             Assert.Equal(expectedModes, actualModes);
         }

--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -89,7 +89,7 @@ namespace Atlassian.Bitbucket
             // Check for presence of refresh_token entry in credential store
             string refreshTokenService = GetRefreshTokenServiceName(input);
 
-            AuthenticationModes authModes = GetSupportedAuthenticationModesAsync(targetUri);
+            AuthenticationModes authModes = GetSupportedAuthenticationModes(targetUri);
 
             _context.Trace.WriteLine("Checking for refresh token...");
             ICredential refreshToken = SupportsOAuth(authModes) ? _context.CredentialStore.Get(refreshTokenService, input.UserName) : null;
@@ -222,7 +222,7 @@ namespace Atlassian.Bitbucket
             return (authModes & AuthenticationModes.Basic) != 0;
         }
 
-        public AuthenticationModes GetSupportedAuthenticationModesAsync(Uri targetUri)
+        public AuthenticationModes GetSupportedAuthenticationModes(Uri targetUri)
         {
             if(!IsBitbucketOrg(targetUri))
             {


### PR DESCRIPTION
Remove the unnecessary `async` keyword from the `GetSupportedAuthModes` method's test, and drop the `Async` suffix from the method name.

This removes a warning from the build of the test assemblies that there is an async method.