### PR TITLE
Use built-in `git` path interpolation for config settings

### DIFF
--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsAuthorityCache.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsAuthorityCache.cs
@@ -58,7 +58,8 @@ namespace Microsoft.AzureRepos
 
             IGitConfiguration config = _git.GetConfiguration();
 
-            if (config.TryGet(GitConfigurationLevel.Global, GetAuthorityKey(orgName), out string authority))
+            if (config.TryGet(GitConfigurationLevel.Global, GitConfigurationType.Raw,
+                GetAuthorityKey(orgName), out string authority))
             {
                 return authority;
             }

--- a/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
@@ -94,8 +94,10 @@ namespace Microsoft.AzureRepos
             _trace.WriteLine($"Looking up organization binding for '{orgName}'...");
 
             // NOT using the short-circuiting OR operator here on purpose - we need both branches to be evaluated
-            if (config.TryGet(GitConfigurationLevel.Local, orgKey, out string localUser) |
-                config.TryGet(GitConfigurationLevel.Global, orgKey, out string globalUser))
+            if (config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Raw,
+                    orgKey, out string localUser) |
+                config.TryGet(GitConfigurationLevel.Global, GitConfigurationType.Raw,
+                    orgKey, out string globalUser))
             {
                 return new AzureReposBinding(orgName, globalUser, localUser);
             }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -434,7 +434,7 @@ namespace Microsoft.AzureRepos
 
             IGitConfiguration targetConfig = _context.Git.GetConfiguration();
 
-            if (targetConfig.TryGet(useHttpPathKey, out string currentValue) && currentValue.IsTruthy())
+            if (targetConfig.TryGet(useHttpPathKey, false, out string currentValue) && currentValue.IsTruthy())
             {
                 _context.Trace.WriteLine("Git configuration 'credential.useHttpPath' is already set to 'true' for https://dev.azure.com.");
             }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitTests.cs
@@ -168,6 +168,18 @@ namespace Microsoft.Git.CredentialManager.Tests
             AssertRemote(name, null, pushUrl, remotes[0]);
         }
 
+        [Fact]
+        public void Git_Version_ReturnsVersion()
+        {
+            string gitPath = GetGitPath();
+            var trace = new NullTrace();
+
+            var git = new GitProcess(trace, gitPath, Path.GetTempPath());
+            GitVersion version = git.Version;
+
+            Assert.NotEqual(new GitVersion(), version);
+        }
+
         #region Test Helpers
 
         private static void AssertRemote(string expectedName, string expectedUrl, GitRemote remote)

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitVersionTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitVersionTests.cs
@@ -1,0 +1,23 @@
+using System;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class GitVersionTests
+    {
+        [Theory]
+        [InlineData(null, 1)]
+        [InlineData("2", 1)]
+        [InlineData("3", -1)]
+        [InlineData("2.33", 0)]
+        [InlineData("2.32.0", 1)]
+        [InlineData("2.33.0.windows.0.1", 0)]
+        [InlineData("2.33.0.2", -1)]
+        public void GitVersion_CompareTo_2_33_0(string input, int expectedCompare)
+        {
+            GitVersion baseline = new GitVersion(2, 33, 0);
+            GitVersion actual = new GitVersion(input);
+            Assert.Equal(expectedCompare, baseline.CompareTo(actual));
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Git.CredentialManager
             //     helper = {appPath} # the expected executable value & directly following the empty value
             //     ...                # any number of helper entries (possibly none, but not the empty value '')
             //
-            string[] currentValues = config.GetAll(configLevel, helperKey).ToArray();
+            string[] currentValues = config.GetAll(configLevel, GitConfigurationType.Raw, helperKey).ToArray();
 
             // Try to locate an existing app entry with a blank reset/clear entry immediately preceding,
             // and no other blank empty/clear entries following (which effectively disable us).
@@ -218,7 +218,7 @@ namespace Microsoft.Git.CredentialManager
             //
             Context.Trace.WriteLine("Removing Git credential helper configuration...");
 
-            string[] currentValues = config.GetAll(configLevel, helperKey).ToArray();
+            string[] currentValues = config.GetAll(configLevel, GitConfigurationType.Raw, helperKey).ToArray();
 
             int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
             if (appIndex > -1)

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/AuthenticationBase.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
         protected bool TryFindHelperExecutablePath(string envar, string configName, string defaultValue, out string path)
         {
             bool isOverride = false;
-            if (Context.Settings.TryGetSetting(
+            if (Context.Settings.TryGetPathSetting(
                 envar, Constants.GitConfiguration.Credential.SectionName, configName, out string helperName))
             {
                 Context.Trace.WriteLine($"UI helper override specified: '{helperName}'.");

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -110,6 +110,8 @@ namespace Microsoft.Git.CredentialManager
 
     public class GitProcessConfiguration : IGitConfiguration
     {
+        private static readonly GitVersion TypeConfigMinVersion = new GitVersion(2, 18, 0);
+
         private readonly ITrace _trace;
         private readonly GitProcess _git;
 
@@ -448,14 +450,26 @@ namespace Microsoft.Git.CredentialManager
             }
         }
 
-        private static string GetCanonicalizeTypeArg(GitConfigurationType type)
+        private string GetCanonicalizeTypeArg(GitConfigurationType type)
         {
-            return type switch
+            if (_git.Version >= TypeConfigMinVersion)
             {
-                GitConfigurationType.Bool         => "--bool",
-                GitConfigurationType.Path         => "--path",
-                _                                 => null
-            };
+                return type switch
+                {
+                    GitConfigurationType.Bool   => "--type=bool",
+                    GitConfigurationType.Path   => "--type=path",
+                    _                           => null
+                };
+            }
+            else
+            {
+                return type switch
+                {
+                    GitConfigurationType.Bool   => "--bool",
+                    GitConfigurationType.Path   => "--path",
+                    _                           => null
+                };
+            }
         }
 
         public static string QuoteCmdArg(string str)

--- a/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitConfiguration.cs
@@ -25,11 +25,7 @@ namespace Microsoft.Git.CredentialManager
     {
         Raw,
         Bool,
-        Int,
-        BoolOrInt,
-        Path,
-        ExpiryDate,
-        Color
+        Path
     }
 
     public interface IGitConfiguration
@@ -456,12 +452,8 @@ namespace Microsoft.Git.CredentialManager
         {
             return type switch
             {
-                GitConfigurationType.Bool         => "--type=bool",
-                GitConfigurationType.BoolOrInt    => "--type=bool-or-int",
-                GitConfigurationType.Int          => "--type=int",
-                GitConfigurationType.Path         => "--type=path",
-                GitConfigurationType.ExpiryDate   => "--type=expiry-date",
-                GitConfigurationType.Color        => "--type=color",
+                GitConfigurationType.Bool         => "--bool",
+                GitConfigurationType.Path         => "--path",
                 _                                 => null
             };
         }

--- a/src/shared/Microsoft.Git.CredentialManager/GitVersion.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitVersion.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Git.CredentialManager
+{
+    public class GitVersion : IComparable, IComparable<GitVersion>
+    {
+        private List<int> components;
+
+        public GitVersion(string versionString)
+        {
+            if (versionString is null)
+            {
+                components = new List<int>();
+                return;
+            }
+
+            string[] splitVersion = versionString.Split('.');
+            components = new List<int>(splitVersion.Length);
+
+            foreach (string part in splitVersion)
+            {
+                if (Int32.TryParse(part, out int component))
+                {
+                    components.Add(component);
+                }
+                else
+                {
+                    // Exit at the first non-integer component
+                    break;
+                }
+            }
+        }
+
+        public GitVersion(params int[] components)
+        {
+            this.components = components.ToList();
+        }
+
+        public override string ToString()
+        {
+            return string.Join(".", this.components);
+        }
+
+        public int CompareTo(object obj)
+        {
+            if (obj is null)
+            {
+                return 1;
+            }
+
+            GitVersion other = obj as GitVersion;
+            if (other == null)
+            {
+                throw new ArgumentException("A GitVersion object is required for comparison.", "obj");
+            }
+
+            return CompareTo(other);
+        }
+
+        public int CompareTo(GitVersion other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            // Compare for as many components as the two versions have in common. If a
+            // component does not exist in a components list, it is assumed to be 0.
+            int thisCount = this.components.Count, otherCount = other.components.Count;
+            for (int i = 0; i < Math.Max(thisCount, otherCount); i++)
+            {
+                int thisComponent = i < thisCount ? this.components[i] : 0;
+                int otherComponent = i < otherCount ? other.components[i] : 0;
+                if (thisComponent != otherComponent)
+                {
+                    return thisComponent.CompareTo(otherComponent);
+                }
+            }
+
+            // No discrepencies found in versions
+            return 0;
+        }
+
+        public static int Compare(GitVersion left, GitVersion right)
+        {
+            if (object.ReferenceEquals(left, right))
+            {
+                return 0;
+            }
+
+            if (left is null)
+            {
+                return -1;
+            }
+
+            return left.CompareTo(right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            GitVersion other = obj as GitVersion;
+            if (other is null)
+            {
+                return false;
+            }
+
+            return this.CompareTo(other) == 0;
+        }
+
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
+        }
+
+        public static bool operator ==(GitVersion left, GitVersion right)
+        {
+            if (left is null)
+            {
+                return right is null;
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(GitVersion left, GitVersion right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) < 0;
+        }
+
+        public static bool operator >(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) > 0;
+        }
+
+        public static bool operator <=(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) <= 0;
+        }
+
+        public static bool operator >=(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) >= 0;
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Git.CredentialManager
                  *        property = value
                  *
                  */
-                if (config.TryGet($"{section}.{property}", out value))
+                if (config.TryGet($"{section}.{property}", false, out value))
                 {
                     yield return value;
                 }

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Git.CredentialManager
         }
 
         public string CustomCertificateBundlePath =>
-            TryGetSetting(KnownEnvars.GitSslCaInfo, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslCaInfo, out string value) ? value : null;
+            TryGetPathSetting(KnownEnvars.GitSslCaInfo, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslCaInfo, out string value) ? value : null;
 
         public TlsBackend TlsBackend =>
             TryGetSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslBackend, out string config)

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         }
 
         #region IGit
+        GitVersion IGit.Version => new GitVersion(2, 33, 0);
 
         string IGit.GetCurrentRepository() => CurrentRepository;
 

--- a/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGitConfiguration.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestGitConfiguration : IGitConfiguration
     {
+        public const string CanonicalPathPrefix = "/my/path/prefix";
+
         public IDictionary<string, IList<string>> System { get; set; } =
             new Dictionary<string, IList<string>>(GitConfigurationKeyComparer.Instance);
         public IDictionary<string, IList<string>> Global { get; set; } =
@@ -34,7 +36,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             }
         }
 
-        public bool TryGet(GitConfigurationLevel level, string name, out string value)
+        public bool TryGet(GitConfigurationLevel level, GitConfigurationType type, string name, out string value)
         {
             value = null;
 
@@ -51,6 +53,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
                     if (values.Count == 1)
                     {
                         value = values[0];
+
+                        if (type == GitConfigurationType.Path)
+                        {
+                            // Create "fake" canonical path
+                            value = value.Replace("~", CanonicalPathPrefix);
+                        }
                     }
                 }
             }
@@ -110,7 +118,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             dict.Remove(name);
         }
 
-        public IEnumerable<string> GetAll(GitConfigurationLevel level, string name)
+        public IEnumerable<string> GetAll(GitConfigurationLevel level, GitConfigurationType type, string name)
         {
             foreach (var (_, dict) in GetDictionaries(level))
             {
@@ -124,7 +132,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             }
         }
 
-        public IEnumerable<string> GetRegex(GitConfigurationLevel level, string nameRegex, string valueRegex)
+        public IEnumerable<string> GetRegex(GitConfigurationLevel level, GitConfigurationType type, string nameRegex, string valueRegex)
         {
             foreach (var (_, dict) in GetDictionaries(level))
             {

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
                 return true;
             }
 
-            if (GitConfiguration?.TryGet($"{section}.{property}", out value) ?? false)
+            if (GitConfiguration?.TryGet($"{section}.{property}", false, out value) ?? false)
             {
                 return true;
             }
@@ -62,7 +62,12 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
             return false;
         }
 
-        public IEnumerable<string> GetSettingValues(string envarName, string section, string property)
+        public bool TryGetPathSetting(string envarName, string section, string property, out string value)
+        {
+            return TryGetSetting(envarName, section, property, out value);
+        }
+
+        public IEnumerable<string> GetSettingValues(string envarName, string section, string property, bool isPath)
         {
             string envarValue = null;
             if (Environment?.Variables.TryGetValue(envarName, out envarValue) ?? false)


### PR DESCRIPTION
## Changes
- Added optional config type specification ([documentation](https://git-scm.com/docs/git-config#Documentation/git-config.txt---typelttypegt)) to `GitConfiguration` getter functions
- Added `TryGetPathSetting` to `Settings`, including handling URL-scoped config settings
- Updated `sslCAInfo` & credential helper settings to use path type from git config

## Notes
- Internal to `GitConfiguration`, an enum (`GitConfigurationType`) is used to specify the type of the config setting, but the `TryGet` extension & functions in `Settings` instead use an `isPath` boolean. 
  - My main reasoning for using the boolean is that paths are the only config type that seem particularly useful for settings in GCM Core, and abstracting that away has some precedent with `GitConfigurationLevel`.