### PR TITLE
Return non-zero exit code on exception

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Application.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Application.cs
@@ -111,6 +111,8 @@ namespace Microsoft.Git.CredentialManager
             {
                 WriteException(ex);
             }
+
+            invocationContext.ResultCode = -1;
         }
 
         private bool WriteException(Exception ex)


### PR DESCRIPTION
Return a non-zero program exit code when an unhandled exception is encountered at the top-level command line handling.

Fixes #440 