### PR TITLE
Treat empty proxy settings as a signal to _not_ use a proxy

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/SettingsTests.cs
@@ -555,6 +555,31 @@ namespace Microsoft.Git.CredentialManager.Tests
         }
 
         [Fact]
+        public void Settings_ProxyConfiguration_GitHttpConfig_EmptyScopedUriUnscoped_ReturnsNull()
+        {
+            const string remoteUrl = "http://example.com/foo.git";
+            const string section = Constants.GitConfiguration.Http.SectionName;
+            const string property = Constants.GitConfiguration.Http.Proxy;
+            var remoteUri = new Uri(remoteUrl);
+
+            var settingValue = new Uri("http://john.doe:letmein123@proxy.example.com");
+
+            var envars = new TestEnvironment();
+            var git = new TestGit();
+            git.Configuration.Global[$"{section}.{property}"] = new[] {settingValue.ToString()};
+            git.Configuration.Global[$"{section}.{remoteUrl}.{property}"] = new[] {string.Empty};
+
+            var settings = new Settings(envars, git)
+            {
+                RemoteUri = remoteUri
+            };
+
+            ProxyConfiguration actualConfig = settings.GetProxyConfiguration();
+
+            Assert.Null(actualConfig);
+        }
+
+        [Fact]
         public void Settings_ProxyConfiguration_NoProxyMixedSplitChar_ReturnsValue()
         {
             const string remoteUrl = "http://example.com/foo.git";

--- a/src/shared/Microsoft.Git.CredentialManager/Settings.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Settings.cs
@@ -440,6 +440,11 @@ namespace Microsoft.Git.CredentialManager
                     {
                         return true;
                     }
+                    else if (string.IsNullOrWhiteSpace(value))
+                    {
+                        // An empty string value means "no proxy"
+                        return false;
+                    }
                 }
 
                 uri = null;


### PR DESCRIPTION
When proxy settings are set in Git, an empty value is treated as "do not use a proxy". We update GCM to do the same thing; when an empty value is set, we do not use a proxy.

This allows for the scenario where a proxy has been set globally (unscoped) but a specific (scoped) remote does NOT have a proxy set.

Fixes #442 