### PR TITLE
Drop ubuntu 16.04 from CI before GitHub drops the runner

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Drop the Ubuntu 16.04 CI build and test before GitHub drop the Ubuntu 16.04 hosted runner.

https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/