### PR TITLE
Upgrade `update-winget` action to v1.4

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.2.2
+      uses: mjcheetham/update-winget@v1.4
       with:
         id: Microsoft.GitCredentialManagerCore
         token: ${{ secrets.WINGET_TOKEN }}   


### PR DESCRIPTION
This version allows us to update existing `winget` manifests by
specifying a manifest's SHA if it already exists in `microsoft/winget-pkgs`.

Pull Requests
---------------

* [#178](https://github.com/mjcheetham/update-winget/pull/179): Allow updates to existing winget manifests