### PR TITLE
Add support for using WSL Git for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Git Credential Manager Core can be used with the [Windows Subsystem for Linux
 (WSL)](https://aka.ms/wsl) to enable secure authentication of your remote Git
 repositories from inside of WSL.
 
-Please read [here](docs/wsl.md) for information.
+[Please see the GCM Core on WSL docs](docs/wsl.md) for more information.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,6 @@ There are two flavors of standalone installation on Windows:
 
 To install, double-click the desired installation package and follow the instructions presented.
 
-#### Git Credential Manager for Windows
-
-GCM Core installs side-by-side any existing Git Credential Manager for Windows installation and will take precedence over it and use any existing credentials so you shouldn't need to re-authenticate.
-
 #### Uninstall (Windows 10)
 
 To uninstall, open the Settings app and navigate to the Apps section. Select "Git Credential Manager Core" and click "Uninstall".
@@ -163,6 +159,14 @@ To uninstall, open the Settings app and navigate to the Apps section. Select "Gi
 #### Uninstall (Windows 7-8.1)
 
 To uninstall, open Control Panel and navigate to the Programs and Features screen. Select "Git Credential Manager Core" and click "Remove".
+
+#### Windows Subsystem for Linux (WSL)
+
+Git Credential Manager Core can be used with the [Windows Subsystem for Linux
+(WSL)](https://aka.ms/wsl) to enable secure authentication of your remote Git
+repositories from inside of WSL.
+
+Please read [here](docs/wsl.md) for information.
 
 ## How to use
 

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -1,0 +1,96 @@
+# Windows Subsystem for Linux (WSL)
+
+Git Credential Manager Core can be used with the [Windows Subsystem for Linux
+(WSL)](https://aka.ms/wsl) to enable secure authentication of your remote Git
+repositories from inside of WSL.
+
+## Supported versions
+
+GCM Core supports being called from both WSL1 and WSL2 installations.
+
+**Note:** In order to use GCM with WSL, _without_ a Git for Windows installation
+you must be using GCM version 2.0.XXX or later.
+You must also be on Windows 10 Version 1903 and later. This is the first version
+of Windows that includes the required `wsl.exe` command-line tool that GCM uses
+to interoperate with Git in your WSL distributions.
+
+## Set up WSL & Git Credential Manager
+
+### Step 1
+
+[Install the latest Git for Windows ⬇️](https://github.com/git-for-windows/git/releases/latest)
+
+### Step 2
+
+_Inside your WSL installation_, run the following command to set GCM as the Git
+credential helper:
+
+```shell
+git config --global credential.helper /mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe
+```
+
+### Step 3 (Azure DevOps only)
+
+If you intend to use Azure DevOps you must _also_ set the following Git
+configuration _inside of your WSL installation_.
+
+```shell
+git config --global credential.https://dev.azure.com.useHttpPath true
+```
+
+## Using GCM & WSL without Git for Windows
+
+If you wish to use GCM Core inside of WSL _without installing Git for Windows_
+you must complete additional configuration so that GCM can callback to Git
+inside of your WSL installation.
+
+In **_Windows_** you need to update the `WSLENV` environment variable to include
+the value `GIT_EXEC_PATH/wp`. From an _Administrator_ Command Prompt run the
+following:
+
+```batch
+SETX WSLENV=%WSLENV%:GIT_EXEC_PATH/wp
+```
+
+..and then restart your WSL installation.
+
+## How it works
+
+GCM leverages the built-in interoperability between Windows and WSL, provided by
+Microsoft. You can read more about Windows/WSL interop [here](https://docs.microsoft.com/en-us/windows/wsl/interop).
+
+Git inside of a WSL installation can launch the GCM _Windows_ application
+transparently to acquire credentials. Running GCM as a Windows application
+allows it to take full advantage of the host operating system for storing
+credentials securely, and presenting GUI prompts for authentication.
+
+By using the host operating system (Windows) to store credentials also means
+that your Windows applications and WSL distributions can all share those
+credentials, removing the need to sign-in multiple times.
+
+## Caveats
+
+Using GCM as a credential helper for a WSL Git installation means that any
+configuration set in WSL Git is NOT respected by GCM (by default). This is
+because GCM is running as a Windows application, and therefore will use the Git
+for Windows installation to query configuration.
+
+This means things like proxy settings for GCM need to be set in Git for Windows
+as well as WSL Git as they are stored in different files
+(`%USERPROFILE%\.gitconfig` vs `\\wsl$\distro\home\$USER\.gitconfig`).
+
+You can configure WSL such that GCM will use the WSL Git configuration following
+the [instructions above](#using-gcm--wsl-without-git-for-windows). However, this
+then means that things like proxy settings are unique to the specific WSL
+installation, and not shared with others or the Windows host.
+
+## Can I install Git Credential Manager directly inside of WSL?
+
+Yes. Rather than install GCM as a Windows application (and have WSL Git invoke
+the Windows GCM), can you install GCM as a Linux application instead.
+
+To do this, simply follow the [GCM installation instructions for Linux](../README.md#linux-install-instructions).
+
+**Note:** In this scenario, because GCM is running as a Linux application
+it cannot utilize authentication or credential storage features of the host
+Windows operating system.

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -1,26 +1,22 @@
 # Windows Subsystem for Linux (WSL)
 
-Git Credential Manager Core can be used with the [Windows Subsystem for Linux
-(WSL)](https://aka.ms/wsl) to enable secure authentication of your remote Git
-repositories from inside of WSL.
+GCM Core can be used with the
+[Windows Subsystem for Linux (WSL)](https://aka.ms/wsl), both WSL1 and WSL2, by
+following these instructions.
 
-## Supported versions
+In order to use GCM with WSL you must be on Windows 10 Version 1903 or later.
+This is the first version of Windows that includes the required `wsl.exe` tool
+that GCM uses to interoperate with Git in your WSL distributions.
 
-GCM Core supports being called from both WSL1 and WSL2 installations.
+It is highly recommended that you install Git for Windows to both install GCM
+and enable the best experience sharing credentials & settings between WSL and
+the Windows host. Alternatively, you must be using GCM version 2.0.XXX or later
+and configure the `WSLENV` environment variable as
+[described below](#configuring-wsl-without-git-for-windows).
 
-**Note:** In order to use GCM with WSL, _without_ a Git for Windows installation
-you must be using GCM version 2.0.XXX or later.
-You must also be on Windows 10 Version 1903 and later. This is the first version
-of Windows that includes the required `wsl.exe` command-line tool that GCM uses
-to interoperate with Git in your WSL distributions.
+## Configuring WSL with Git for Windows (recommended)
 
-## Set up WSL & Git Credential Manager
-
-### Step 1
-
-[Install the latest Git for Windows ⬇️](https://github.com/git-for-windows/git/releases/latest)
-
-### Step 2
+Start by installing the [latest Git for Windows ⬇️](https://github.com/git-for-windows/git/releases/latest)
 
 _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:
@@ -29,8 +25,6 @@ credential helper:
 git config --global credential.helper /mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe
 ```
 
-### Step 3 (Azure DevOps only)
-
 If you intend to use Azure DevOps you must _also_ set the following Git
 configuration _inside of your WSL installation_.
 
@@ -38,11 +32,23 @@ configuration _inside of your WSL installation_.
 git config --global credential.https://dev.azure.com.useHttpPath true
 ```
 
-## Using GCM & WSL without Git for Windows
+## Configuring WSL without Git for Windows
 
 If you wish to use GCM Core inside of WSL _without installing Git for Windows_
 you must complete additional configuration so that GCM can callback to Git
 inside of your WSL installation.
+
+Start by installing the [latest GCM ⬇️](https://aka.ms/gcmcore-latest)
+
+_Inside your WSL installation_, run the following command to set GCM as the Git
+credential helper:
+
+```shell
+git config --global credential.helper /mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe
+
+# For Azure DevOps support only
+git config --global credential.https://dev.azure.com.useHttpPath true
+```
 
 In **_Windows_** you need to update the `WSLENV` environment variable to include
 the value `GIT_EXEC_PATH/wp`. From an _Administrator_ Command Prompt run the
@@ -52,7 +58,7 @@ following:
 SETX WSLENV=%WSLENV%:GIT_EXEC_PATH/wp
 ```
 
-..and then restart your WSL installation.
+After updating the `WSLENV` environment variable, restart your WSL installation.
 
 ## How it works
 
@@ -64,11 +70,11 @@ transparently to acquire credentials. Running GCM as a Windows application
 allows it to take full advantage of the host operating system for storing
 credentials securely, and presenting GUI prompts for authentication.
 
-By using the host operating system (Windows) to store credentials also means
-that your Windows applications and WSL distributions can all share those
-credentials, removing the need to sign-in multiple times.
+Using the host operating system (Windows) to store credentials also means that
+your Windows applications and WSL distributions can all share those credentials,
+removing the need to sign-in multiple times.
 
-## Caveats
+## Shared configuration
 
 Using GCM as a credential helper for a WSL Git installation means that any
 configuration set in WSL Git is NOT respected by GCM (by default). This is
@@ -80,8 +86,8 @@ as well as WSL Git as they are stored in different files
 (`%USERPROFILE%\.gitconfig` vs `\\wsl$\distro\home\$USER\.gitconfig`).
 
 You can configure WSL such that GCM will use the WSL Git configuration following
-the [instructions above](#using-gcm--wsl-without-git-for-windows). However, this
-then means that things like proxy settings are unique to the specific WSL
+the [instructions above](#configuring-wsl-without-git-for-windows). However,
+this then means that things like proxy settings are unique to the specific WSL
 installation, and not shared with others or the Windows host.
 
 ## Can I install Git Credential Manager directly inside of WSL?

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitConfigurationTests.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath);
             var config = git.GetConfiguration();
             Assert.NotNull(config);
         }
@@ -69,7 +70,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             var actualVisitedEntries = new List<(string name, string value)>();
@@ -106,7 +108,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             var actualVisitedEntries = new List<(string name, string value)>();
@@ -135,7 +138,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("user.name", false, out string value);
@@ -151,7 +155,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
@@ -169,7 +174,8 @@ namespace Microsoft.Git.CredentialManager.Tests
             string homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("example.path", true, out string value);
@@ -186,7 +192,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("example.path", false, out string value);
@@ -203,7 +210,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Bool,
@@ -221,7 +229,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Raw,
@@ -239,7 +248,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string value = config.Get("user.name");
@@ -254,7 +264,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
@@ -268,7 +279,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             config.Set(GitConfigurationLevel.Local, "core.foobar", "foo123");
@@ -285,7 +297,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             Assert.Throws<InvalidOperationException>(() => config.Set(GitConfigurationLevel.All, "core.foobar", "test123"));
@@ -303,7 +316,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
                 string gitPath = GetGitPath();
                 var trace = new NullTrace();
-                var git = new GitProcess(trace, gitPath, repoPath);
+                var env = new TestEnvironment();
+                var git = new GitProcess(trace, env, gitPath, repoPath);
                 IGitConfiguration config = git.GetConfiguration();
 
                 config.Unset(GitConfigurationLevel.Global, "core.foobar");
@@ -333,7 +347,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
                 string gitPath = GetGitPath();
                 var trace = new NullTrace();
-                var git = new GitProcess(trace, gitPath, repoPath);
+                var env = new TestEnvironment();
+                var git = new GitProcess(trace, env, gitPath, repoPath);
                 IGitConfiguration config = git.GetConfiguration();
 
                 config.Unset(GitConfigurationLevel.Local, "core.foobar");
@@ -358,7 +373,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             Assert.Throws<InvalidOperationException>(() => config.Unset(GitConfigurationLevel.All, "core.foobar"));
@@ -374,7 +390,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             config.UnsetAll(GitConfigurationLevel.Local, "core.foobar", "foo*");
@@ -391,7 +408,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, repoPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             Assert.Throws<InvalidOperationException>(() => config.UnsetAll(GitConfigurationLevel.All, "core.foobar", Constants.RegexPatterns.Any));

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GitTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GitTests.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, Path.GetTempPath());
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, Path.GetTempPath());
 
             string actual = git.GetCurrentRepository();
 
@@ -27,7 +28,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, workDirPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, workDirPath);
 
             string actual = git.GetCurrentRepository();
 
@@ -39,7 +41,8 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, Path.GetTempPath());
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, Path.GetTempPath());
 
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
@@ -53,7 +56,8 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var git = new GitProcess(trace, gitPath, workDirPath);
+            var env = new TestEnvironment();
+            var git = new GitProcess(trace, env, gitPath, workDirPath);
 
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
@@ -70,8 +74,9 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
+            var env = new TestEnvironment();
 
-            var git = new GitProcess(trace, gitPath, workDirPath);
+            var git = new GitProcess(trace, env, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -90,8 +95,9 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
+            var env = new TestEnvironment();
 
-            var git = new GitProcess(trace, gitPath, workDirPath);
+            var git = new GitProcess(trace, env, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -112,8 +118,9 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
+            var env = new TestEnvironment();
 
-            var git = new GitProcess(trace, gitPath, workDirPath);
+            var git = new GitProcess(trace, env, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -136,8 +143,9 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
+            var env = new TestEnvironment();
 
-            var git = new GitProcess(trace, gitPath, workDirPath);
+            var git = new GitProcess(trace, env, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Equal(3, remotes.Length);
@@ -159,8 +167,9 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
+            var env = new TestEnvironment();
 
-            var git = new GitProcess(trace, gitPath, workDirPath);
+            var git = new GitProcess(trace, env, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -173,8 +182,9 @@ namespace Microsoft.Git.CredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
+            var env = new TestEnvironment();
 
-            var git = new GitProcess(trace, gitPath, Path.GetTempPath());
+            var git = new GitProcess(trace, env, gitPath, Path.GetTempPath());
             GitVersion version = git.Version;
 
             Assert.NotEqual(new GitVersion(), version);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/WslUtilsTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/WslUtilsTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Diagnostics;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class WslUtilsTests
+    {
+        [PlatformTheory(Platforms.Windows)]
+        [InlineData(null, false)]
+        [InlineData(@"", false)]
+        [InlineData(@" ", false)]
+        [InlineData(@"\", false)]
+        [InlineData(@"wsl", false)]
+        [InlineData(@"\wsl\ubuntu\home", false)]
+        [InlineData(@"\\wsl\ubuntu\home", false)]
+        [InlineData(@"\wsl$\ubuntu\home", false)]
+        [InlineData(@"wsl$\ubuntu\home", false)]
+        [InlineData(@"//wsl$/ubuntu/home", false)]
+        [InlineData(@"\\wsl", false)]
+        [InlineData(@"\\wsl$", false)]
+        [InlineData(@"\\wsl$\", false)]
+        [InlineData(@"\\wsl$\ubuntu", true)]
+        [InlineData(@"\\wsl$\ubuntu\", true)]
+        [InlineData(@"\\wsl$\ubuntu\home", true)]
+        [InlineData(@"\\WSL$\UBUNTU\home", true)]
+        [InlineData(@"\\wsl$\ubuntu\home\", true)]
+        [InlineData(@"\\wsl$\openSUSE-42\home", true)]
+        public void WslUtils_IsWslPath(string path, bool expected)
+        {
+            bool actual = WslUtils.IsWslPath(path);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(@"\\wsl$\ubuntu", "ubuntu", "/")]
+        [InlineData(@"\\wsl$\ubuntu\", "ubuntu", "/")]
+        [InlineData(@"\\wsl$\ubuntu\home", "ubuntu", "/home")]
+        [InlineData(@"\\wsl$\ubuntu\HOME", "ubuntu", "/HOME")]
+        [InlineData(@"\\wsl$\UBUNTU\home", "UBUNTU", "/home")]
+        [InlineData(@"\\wsl$\ubuntu\home\", "ubuntu", "/home/")]
+        [InlineData(@"\\wsl$\openSUSE-42\home", "openSUSE-42", "/home")]
+        public void WslUtils_ConvertToDistroPath(string path, string expectedDistro, string expectedPath)
+        {
+            string actualPath = WslUtils.ConvertToDistroPath(path, out string actualDistro);
+            Assert.Equal(expectedPath, actualPath);
+            Assert.Equal(expectedDistro, actualDistro);
+        }
+
+        [PlatformTheory(Platforms.Windows)]
+        [InlineData(null)]
+        [InlineData(@"")]
+        [InlineData(@" ")]
+        [InlineData(@"\")]
+        [InlineData(@"wsl")]
+        [InlineData(@"\wsl\ubuntu\home")]
+        [InlineData(@"\\wsl\ubuntu\home")]
+        [InlineData(@"\wsl$\ubuntu\home")]
+        [InlineData(@"wsl$\ubuntu\home")]
+        [InlineData(@"//wsl$/ubuntu/home")]
+        [InlineData(@"\\wsl")]
+        [InlineData(@"\\wsl$")]
+        [InlineData(@"\\wsl$\")]
+        public void WslUtils_ConvertToDistroPath_Invalid_ThrowsException(string path)
+        {
+            Assert.Throws<ArgumentException>(() => WslUtils.ConvertToDistroPath(path, out _));
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public void WslUtils_CreateWslProcess()
+        {
+            const string distribution = "ubuntu";
+            const string command = "/usr/lib/git-core/git version";
+
+            string expectedFileName = WslUtils.GetWslPath();
+            string expectedArgs = $"--distribution {distribution} --exec {command}";
+
+            Process process = WslUtils.CreateWslProcess(distribution, command);
+
+            Assert.NotNull(process);
+            Assert.Equal(expectedArgs, process.StartInfo.Arguments);
+            Assert.Equal(expectedFileName, process.StartInfo.FileName);
+            Assert.True(process.StartInfo.RedirectStandardInput);
+            Assert.True(process.StartInfo.RedirectStandardOutput);
+            Assert.True(process.StartInfo.RedirectStandardError);
+            Assert.False(process.StartInfo.UseShellExecute);
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public void WslUtils_CreateWslProcess_WorkingDirectory()
+        {
+            const string distribution = "ubuntu";
+            const string command = "/usr/lib/git-core/git version";
+            const string expectedWorkingDirectory = @"C:\Projects\";
+
+            string expectedFileName = WslUtils.GetWslPath();
+            string expectedArgs = $"--distribution {distribution} --exec {command}";
+
+            Process process = WslUtils.CreateWslProcess(distribution, command, expectedWorkingDirectory);
+
+            Assert.NotNull(process);
+            Assert.Equal(expectedArgs, process.StartInfo.Arguments);
+            Assert.Equal(expectedFileName, process.StartInfo.FileName);
+            Assert.True(process.StartInfo.RedirectStandardInput);
+            Assert.True(process.StartInfo.RedirectStandardOutput);
+            Assert.True(process.StartInfo.RedirectStandardError);
+            Assert.False(process.StartInfo.UseShellExecute);
+            Assert.Equal(expectedWorkingDirectory, process.StartInfo.WorkingDirectory);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Git.CredentialManager
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
+                                            Environment,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
                                         );
@@ -112,6 +113,7 @@ namespace Microsoft.Git.CredentialManager
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
+                                            Environment,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
                                         );
@@ -129,6 +131,7 @@ namespace Microsoft.Git.CredentialManager
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
+                                            Environment,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
                                         );

--- a/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -153,13 +153,22 @@ namespace Microsoft.Git.CredentialManager
 
         private static string GetGitPath(IEnvironment environment, IFileSystem fileSystem, ITrace trace)
         {
+            const string unixGitName = "git";
+            const string winGitName = "git.exe";
+
             string gitExecPath;
-            string programName = PlatformUtils.IsWindows() ? "git.exe" : "git";
+            string programName = PlatformUtils.IsWindows() ? winGitName : unixGitName;
 
             // Use the GIT_EXEC_PATH environment variable if set
             if (environment.Variables.TryGetValue(Constants.EnvironmentVariables.GitExecutablePath,
                 out gitExecPath))
             {
+                // If we're invoked from WSL we must locate the UNIX Git executable
+                if (PlatformUtils.IsWindows() && WslUtils.IsWslPath(gitExecPath))
+                {
+                    programName = unixGitName;
+                }
+
                 string candidatePath = Path.Combine(gitExecPath, programName);
                 if (fileSystem.FileExists(candidatePath))
                 {

--- a/src/shared/Microsoft.Git.CredentialManager/Git.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Git.cs
@@ -58,15 +58,18 @@ namespace Microsoft.Git.CredentialManager
     public class GitProcess : IGit
     {
         private readonly ITrace _trace;
+        private readonly IEnvironment _environment;
         private readonly string _gitPath;
         private readonly string _workingDirectory;
 
-        public GitProcess(ITrace trace, string gitPath, string workingDirectory = null)
+        public GitProcess(ITrace trace, IEnvironment environment, string gitPath, string workingDirectory = null)
         {
             EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(environment, nameof(environment));
             EnsureArgument.NotNullOrWhiteSpace(gitPath, nameof(gitPath));
 
             _trace = trace;
+            _environment = environment;
             _gitPath = gitPath;
             _workingDirectory = workingDirectory;
         }
@@ -176,15 +179,7 @@ namespace Microsoft.Git.CredentialManager
 
         public Process CreateProcess(string args)
         {
-            var psi = new ProcessStartInfo(_gitPath, args)
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                WorkingDirectory = _workingDirectory
-            };
-
-            return new Process {StartInfo = psi};
+            return _environment.CreateProcess(_gitPath, args, false, _workingDirectory);
         }
 
         // This code was originally copied from

--- a/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Interop/Windows/WindowsEnvironment.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace Microsoft.Git.CredentialManager.Interop.Windows
@@ -88,6 +87,18 @@ namespace Microsoft.Git.CredentialManager.Interop.Windows
 
             path = null;
             return false;
+        }
+
+        public override Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
+        {
+            // If we're asked to start a WSL executable we must launch via the wsl.exe command tool
+            if (!useShellExecute && WslUtils.IsWslPath(path))
+            {
+                string wslPath = WslUtils.ConvertToDistroPath(path, out string distro);
+                return WslUtils.CreateWslProcess(distro, $"{wslPath} {args}", workingDirectory);
+            }
+
+            return base.CreateProcess(path, args, useShellExecute, workingDirectory);
         }
 
         #endregion

--- a/src/shared/Microsoft.Git.CredentialManager/WslUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/WslUtils.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Git.CredentialManager
+{
+    public static class WslUtils
+    {
+        private const string WslUncPrefix = @"\\wsl$\";
+        private const string WslCommandName = "wsl.exe";
+
+        /// <summary>
+        /// Test if a file path points to a location in a Windows Subsystem for Linux distribution.
+        /// </summary>
+        /// <param name="path">Path to test.</param>
+        /// <returns>True if <paramref name="path"/> is a WSL path, false otherwise.</returns>
+        public static bool IsWslPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+
+            return path.StartsWith(WslUncPrefix, StringComparison.OrdinalIgnoreCase) &&
+                   path.Length > WslUncPrefix.Length;
+        }
+
+        /// <summary>
+        /// Create a command to be executed in a Windows Subsystem for Linux distribution.
+        /// </summary>
+        /// <param name="distribution">WSL distribution name.</param>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="workingDirectory">Optional working directory.</param>
+        /// <returns><see cref="Process"/> object ready to start.</returns>
+        public static Process CreateWslProcess(string distribution, string command, string workingDirectory = null)
+        {
+            var args = new StringBuilder();
+            args.AppendFormat("--distribution {0} ", distribution);
+            args.AppendFormat("--exec {0}", command);
+
+            string wslExePath = GetWslPath();
+
+            var psi = new ProcessStartInfo(wslExePath, args.ToString())
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory ?? string.Empty
+            };
+
+            return new Process { StartInfo = psi };
+        }
+
+        public static string ConvertToDistroPath(string path, out string distribution)
+        {
+            if (!IsWslPath(path)) throw new ArgumentException("Must provide a WSL path", nameof(path));
+
+            int distroStart = WslUncPrefix.Length;
+            int distroEnd = path.IndexOf('\\', distroStart);
+
+            if (distroEnd < 0) distroEnd = path.Length;
+
+            distribution = path.Substring(distroStart, distroEnd - distroStart);
+
+            if (path.Length > distroEnd)
+            {
+                return path.Substring(distroEnd).Replace('\\', '/');
+            }
+
+            return "/";
+        }
+
+        internal /*for testing purposes*/ static string GetWslPath()
+        {
+            // WSL is only supported on 64-bit operating systems
+            if (!Environment.Is64BitOperatingSystem)
+            {
+                throw new Exception("WSL is not supported on 32-bit operating systems");
+            }
+
+            //
+            // When running as a 32-bit application on a 64-bit operating system, we cannot access the real
+            // C:\Windows\System32 directory because the OS will redirect us transparently to the
+            // C:\Windows\SysWOW64 directory (containing 32-bit executables).
+            //
+            // In order to access the real 64-bit System32 directory, we must access via the pseudo directory
+            // C:\Windows\SysNative that does **not** experience any redirection for 32-bit applications.
+            //
+            // HOWEVER, if we're running as a 64-bit application on a 64-bit operating system, the SysNative
+            // directory does not exist! This means if running as a 32-bit application on a 64-bit OS we must
+            // use the System32 directory name directly.
+            //
+            var sysDir = Environment.ExpandEnvironmentVariables(
+                Environment.Is64BitProcess
+                    ? @"%WINDIR%\System32"
+                    : @"%WINDIR%\SysNative"
+            );
+
+            return Path.Combine(sysDir, WslCommandName);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/WslUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/WslUtils.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Git.CredentialManager
             // C:\Windows\SysNative that does **not** experience any redirection for 32-bit applications.
             //
             // HOWEVER, if we're running as a 64-bit application on a 64-bit operating system, the SysNative
-            // directory does not exist! This means if running as a 32-bit application on a 64-bit OS we must
+            // directory does not exist! This means if running as a 64-bit application on a 64-bit OS we must
             // use the System32 directory name directly.
             //
             var sysDir = Environment.ExpandEnvironmentVariables(

--- a/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
+++ b/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects
@@ -31,6 +32,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
             Variables = new Dictionary<string, string>(_envarComparer);
             Symlinks = new Dictionary<string, string>(_pathComparer);
+            CreatedProcesses = new List<ProcessStartInfo>();
         }
 
         public IDictionary<string, string> Variables { get; set; }
@@ -51,6 +53,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
             set => Variables["PATH"] = string.Join(_envPathSeparator, value);
         }
+
+        public IList<ProcessStartInfo> CreatedProcesses { get; set; }
 
         #region IEnvironment
 
@@ -95,6 +99,22 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 
             path = null;
             return false;
+        }
+
+        public Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
+        {
+            var psi = new ProcessStartInfo(path, args)
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = useShellExecute,
+                WorkingDirectory = workingDirectory ?? string.Empty
+            };
+
+            CreatedProcesses.Add(psi);
+
+            return new Process { StartInfo = psi };
         }
 
         #endregion


### PR DESCRIPTION
This PR enables GCM to understand values of `GIT_EXEC_PATH` that point to a Windows Subsystem for Linux (WSL) path, for example `\\wsl$\ubuntu\usr\libexec\git-core`.

This can use useful for scenarios where the user does not want to install Git for Windows or use it's configuration files, but rather use the WSL Git's view of the world.

Also add a piece of documentation that outlines how to correctly configure GCM and WSL.