### PR TITLE
Add diagnostic command for debugging issues

### DIFF
--- a/src/shared/GitHub/Diagnostics/GitHubApiDiagnostic.cs
+++ b/src/shared/GitHub/Diagnostics/GitHubApiDiagnostic.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager.Diagnostics;
+
+namespace GitHub.Diagnostics
+{
+    public class GitHubApiDiagnostic : Diagnostic
+    {
+        private readonly IGitHubRestApi _api;
+
+        public GitHubApiDiagnostic(IGitHubRestApi api)
+            : base("GitHub API")
+        {
+            _api = api;
+        }
+
+        protected override async Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
+        {
+            var targetUri = new Uri("https://github.com");
+            log.AppendLine($"Using '{targetUri}' as API target.");
+
+            log.Append("Querying '/meta' endpoint...");
+            GitHubMetaInfo metaInfo = await _api.GetMetaInfoAsync(targetUri);
+            log.AppendLine(" OK");
+
+            return true;
+        }
+    }
+}

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using GitHub.Diagnostics;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication.OAuth;
+using Microsoft.Git.CredentialManager.Diagnostics;
 
 namespace GitHub
 {
-    public class GitHubHostProvider : HostProvider
+    public class GitHubHostProvider : HostProvider, IDiagnosticProvider
     {
         private static readonly string[] GitHubOAuthScopes =
         {
@@ -293,6 +295,11 @@ namespace GitHub
             _gitHubApi.Dispose();
             _gitHubAuth.Dispose();
             base.ReleaseManagedResources();
+        }
+
+        public IEnumerable<IDiagnostic> GetDiagnostics()
+        {
+            yield return new GitHubApiDiagnostic(_gitHubApi);
         }
 
         #region Private Methods

--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
             return new MsalResult(result);
         }
 
-        private MicrosoftAuthenticationFlowType GetFlowType()
+        internal MicrosoftAuthenticationFlowType GetFlowType()
         {
             if (Context.Settings.TryGetSetting(
                 Constants.EnvironmentVariables.MsAuthFlow,
@@ -368,7 +368,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
             }
         }
 
-        private StorageCreationProperties CreateTokenCacheProps(bool useLinuxFallback)
+        internal StorageCreationProperties CreateTokenCacheProps(bool useLinuxFallback)
         {
             const string cacheFileName = "msal.cache";
             string cacheDirectory;

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Git.CredentialManager.Commands
                 new FileSystemDiagnostic(context.FileSystem),
                 new NetworkingDiagnostic(context.HttpClientFactory),
                 new GitDiagnostic(context.Git),
+                new CredentialStoreDiagnostic(context.CredentialStore),
             };
 
             AddOption(

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Git.CredentialManager.Commands
                 // Add standard diagnostics
                 new EnvironmentDiagnostic(context.Environment),
                 new FileSystemDiagnostic(context.FileSystem),
+                new NetworkingDiagnostic(context.HttpClientFactory),
             };
 
             AddOption(

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager.Diagnostics;
+
+namespace Microsoft.Git.CredentialManager.Commands
+{
+    public class DiagnoseCommand : Command
+    {
+        private const string TestOutputIndent = "    ";
+
+        private readonly ICommandContext _context;
+        private readonly ICollection<IDiagnostic> _diagnostics;
+
+        public DiagnoseCommand(ICommandContext context)
+            : base("diagnose", "Run diagnostics and gather logs to diagnose problems with Git Credential Manager")
+        {
+            EnsureArgument.NotNull(context, nameof(context));
+
+            _context = context;
+            _diagnostics = new List<IDiagnostic>();
+
+            AddOption(
+                new Option<string>(new []{"--output", "-o"}, "Output directory for diagnostic logs.")
+            );
+
+            Handler = CommandHandler.Create<string>(ExecuteAsync);
+        }
+
+        public void AddDiagnostic(IDiagnostic diagnostic)
+        {
+            _diagnostics.Add(diagnostic);
+        }
+
+        private async Task<int> ExecuteAsync(string output)
+        {
+            // Don't use IStandardStreams for writing output in this command as we
+            // cannot trust any component on the ICommandContext is working correctly.
+            Console.WriteLine($"Running diagnostics...{Environment.NewLine}");
+
+            if (_diagnostics.Count == 0)
+            {
+                Console.WriteLine("No diagnostics to run.");
+                return 0;
+            }
+
+            int numFailed = 0;
+            int numSkipped = 0;
+
+            string currentDir = Directory.GetCurrentDirectory();
+            string outputDir;
+            if (string.IsNullOrWhiteSpace(output))
+            {
+                outputDir = currentDir;
+            }
+            else
+            {
+                if (!Directory.Exists(output))
+                {
+                    Directory.CreateDirectory(output);
+                }
+
+                outputDir = Path.GetFullPath(Path.Combine(currentDir, output));
+            }
+
+            string logFilePath = Path.Combine(outputDir, "gcm-diagnose.log");
+            var extraLogs = new List<string>();
+
+            using var fullLog = new StreamWriter(logFilePath, append: false, Encoding.UTF8);
+            fullLog.WriteLine("Diagnose log at {0:s}Z", DateTime.UtcNow);
+            fullLog.WriteLine();
+            fullLog.WriteLine($"Executable: {_context.ApplicationPath}");
+            fullLog.WriteLine(
+                TryGetAssemblyVersion(out string version)
+                    ? $"Version: {version}"
+                    : "Version: [!] Failed to get version information [!]"
+            );
+            fullLog.WriteLine();
+
+            foreach (IDiagnostic diagnostic in _diagnostics)
+            {
+                fullLog.WriteLine("------------");
+                fullLog.WriteLine($"Diagnostic: {diagnostic.Name}");
+
+                if (!diagnostic.CanRun())
+                {
+                    fullLog.WriteLine("Skipped: True");
+                    fullLog.WriteLine();
+
+                    Console.Write(" ");
+                    ConsoleEx.WriteColor("[SKIP]", ConsoleColor.Gray);
+                    Console.WriteLine(" {0}", diagnostic.Name);
+
+                    numSkipped++;
+                    continue;
+                }
+
+                string inProgressMsg = $"  >>>>  {diagnostic.Name}";
+                Console.Write(inProgressMsg);
+
+                fullLog.WriteLine("Skipped: False");
+                DiagnosticResult result = await diagnostic.RunAsync();
+                fullLog.WriteLine("Success: {0}", result.IsSuccess);
+
+                if (result.Exception is null)
+                {
+                    fullLog.WriteLine("Exception: None");
+                }
+                else
+                {
+                    fullLog.WriteLine("Exception:");
+                    fullLog.WriteLine(result.Exception.ToString());
+                }
+
+                fullLog.WriteLine("Log:");
+                fullLog.WriteLine(result.DiagnosticLog);
+
+                Console.Write(new string('\b', inProgressMsg.Length - 1));
+                ConsoleEx.WriteColor(
+                    result.IsSuccess ? "[ OK ]" : "[FAIL]",
+                    result.IsSuccess ? ConsoleColor.DarkGreen : ConsoleColor.Red
+                );
+                Console.WriteLine(" {0}", diagnostic.Name);
+
+                if (!result.IsSuccess)
+                {
+                    numFailed++;
+
+                    if (result.Exception is not null)
+                    {
+                        Console.WriteLine();
+                        ConsoleEx.WriteLineIndent("[!] Encountered an exception [!]");
+                        ConsoleEx.WriteLineIndent(result.Exception.ToString());
+                    }
+
+                    Console.WriteLine();
+                    ConsoleEx.WriteLineIndent("[*] Diagnostic test log [*]");
+                    ConsoleEx.WriteLineIndent(result.DiagnosticLog);
+
+                    Console.WriteLine();
+                }
+
+                foreach (string filePath in result.AdditionalFiles)
+                {
+                    string fileName = Path.GetFileName(filePath);
+                    string destPath = Path.Combine(outputDir, fileName);
+                    try
+                    {
+                        File.Copy(filePath, destPath, overwrite: true);
+                    }
+                    catch
+                    {
+                        ConsoleEx.WriteLineIndent($"Failed to copy additional file '{filePath}'");
+                    }
+
+                    extraLogs.Add(destPath);
+                }
+
+                fullLog.Flush();
+            }
+
+            Console.WriteLine();
+            string summary = $"Diagnostic summary: {_diagnostics.Count - numFailed} passed, {numSkipped} skipped, {numFailed} failed.";
+            Console.WriteLine(summary);
+            Console.WriteLine("Log files:");
+            Console.WriteLine($"  {logFilePath}");
+            foreach (string log in extraLogs)
+            {
+                Console.WriteLine($"  {log}");
+            }
+            Console.WriteLine();
+            Console.WriteLine("Caution: Log files may include sensitive information - redact before sharing.");
+            Console.WriteLine();
+
+            if (numFailed > 0)
+            {
+                Console.WriteLine("Diagnostics indicate a possible problem with your installation.");
+                Console.WriteLine($"Please open an issue at {Constants.HelpUrls.GcmNewIssue} and include log files.");
+                Console.WriteLine();
+            }
+
+            fullLog.Close();
+            return numFailed;
+        }
+
+        private bool TryGetAssemblyVersion(out string version)
+        {
+            try
+            {
+                var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+                var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                version = assemblyVersionAttribute is null
+                    ? assembly.GetName().Version.ToString()
+                    : assemblyVersionAttribute.InformationalVersion;
+                return true;
+            }
+            catch
+            {
+                version = null;
+                return false;
+            }
+        }
+
+        private static class ConsoleEx
+        {
+            public static void WriteLineIndent(string str)
+            {
+                string[] lines = str?.Split('\n', '\r');
+
+                if (lines is null) return;
+
+                foreach (string line in lines)
+                {
+                    Console.Write(TestOutputIndent);
+                    Console.WriteLine(line);
+                }
+            }
+
+            public static  void WriteColor(string str, ConsoleColor fgColor)
+            {
+                var initFgColor = Console.ForegroundColor;
+                Console.ForegroundColor = fgColor;
+                Console.Write(str);
+                Console.ForegroundColor = initFgColor;
+            }
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Git.CredentialManager.Commands
             EnsureArgument.NotNull(context, nameof(context));
 
             _context = context;
-            _diagnostics = new List<IDiagnostic>();
+            _diagnostics = new List<IDiagnostic>
+            {
+                // Add standard diagnostics
+                new EnvironmentDiagnostic(context.Environment),
+            };
 
             AddOption(
                 new Option<string>(new []{"--output", "-o"}, "Output directory for diagnostic logs.")

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Git.CredentialManager.Commands
                 new EnvironmentDiagnostic(context.Environment),
                 new FileSystemDiagnostic(context.FileSystem),
                 new NetworkingDiagnostic(context.HttpClientFactory),
+                new GitDiagnostic(context.Git),
             };
 
             AddOption(

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Git.CredentialManager.Commands
             {
                 // Add standard diagnostics
                 new EnvironmentDiagnostic(context.Environment),
+                new FileSystemDiagnostic(context.FileSystem),
             };
 
             AddOption(

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/DiagnoseCommand.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Git.CredentialManager.Commands
                 new NetworkingDiagnostic(context.HttpClientFactory),
                 new GitDiagnostic(context.Git),
                 new CredentialStoreDiagnostic(context.CredentialStore),
+                new MicrosoftAuthenticationDiagnostic(context)
             };
 
             AddOption(

--- a/src/shared/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Constants.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Git.CredentialManager
         public static class HelpUrls
         {
             public const string GcmProjectUrl          = "https://aka.ms/gcmcore";
+            public const string GcmNewIssue            = "https://aka.ms/gcmcore-bug";
             public const string GcmAuthorityDeprecated = "https://aka.ms/gcmcore-authority";
             public const string GcmHttpProxyGuide      = "https://aka.ms/gcmcore-httpproxy";
             public const string GcmTlsVerification     = "https://aka.ms/gcmcore-tlsverify";

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/CredentialStoreDiagnostic.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/CredentialStoreDiagnostic.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public class CredentialStoreDiagnostic : Diagnostic
+    {
+        private readonly ICredentialStore _credentialStore;
+
+        public CredentialStoreDiagnostic(ICredentialStore credentialStore)
+            : base("Credential storage")
+        {
+            EnsureArgument.NotNull(credentialStore, nameof(credentialStore));
+
+            _credentialStore = credentialStore;
+        }
+
+        protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
+        {
+            log.AppendLine($"ICredentialStore instance is of type: {_credentialStore.GetType().Name}");
+
+            // Create a service that is guaranteed to be unique
+            string service = $"https://example.com/{Guid.NewGuid():N}";
+            const string account = "john.doe";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
+
+            try
+            {
+                log.Append("Writing test credential...");
+                _credentialStore.AddOrUpdate(service, account, password);
+                log.AppendLine(" OK");
+
+                log.Append("Reading test credential...");
+                ICredential outCredential = _credentialStore.Get(service, account);
+                if (outCredential is null)
+                {
+                    log.AppendLine(" Failed");
+                    log.AppendLine("Test credential object is null!");
+                    return Task.FromResult(false);
+                }
+
+                log.AppendLine(" OK");
+
+                if (!StringComparer.Ordinal.Equals(account, outCredential.Account))
+                {
+                    log.Append("Test credential account did not match!");
+                    log.AppendLine($"Expected: {account}");
+                    log.AppendLine($"Actual: {outCredential.Account}");
+                    return Task.FromResult(false);
+                }
+
+                if (!StringComparer.Ordinal.Equals(password, outCredential.Password))
+                {
+                    log.Append("Test credential password did not match!");
+                    log.AppendLine($"Expected: {password}");
+                    log.AppendLine($"Actual: {outCredential.Password}");
+                    return Task.FromResult(false);
+                }
+            }
+            finally
+            {
+                log.Append("Deleting test credential...");
+                _credentialStore.Remove(service, account);
+                log.AppendLine(" OK");
+            }
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/Diagnostic.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/Diagnostic.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public interface IDiagnostic
+    {
+        string Name { get; }
+
+        bool CanRun();
+
+        Task<DiagnosticResult> RunAsync();
+    }
+
+    public abstract class Diagnostic : IDiagnostic
+    {
+        protected Diagnostic(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public virtual bool CanRun()
+        {
+            return true;
+        }
+
+        public async Task<DiagnosticResult> RunAsync()
+        {
+            var log = new StringBuilder();
+
+            bool success = false;
+            Exception exception = null;
+            var additionalFiles = new List<string>();
+            try
+            {
+                success = await RunInternalAsync(log, additionalFiles);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            return new DiagnosticResult
+            {
+                IsSuccess = success,
+                DiagnosticLog = log.ToString(),
+                Exception = exception,
+                AdditionalFiles = additionalFiles
+            };
+        }
+
+        protected abstract Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles);
+    }
+
+    public class DiagnosticResult
+    {
+        public bool IsSuccess { get; set; }
+        public Exception Exception { get; set; }
+        public string DiagnosticLog { get; set; }
+        public ICollection<string> AdditionalFiles { get; set; }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/EnvironmentDiagnostic.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/EnvironmentDiagnostic.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public class EnvironmentDiagnostic : Diagnostic
+    {
+        private readonly IEnvironment _env;
+
+        public EnvironmentDiagnostic(IEnvironment env)
+            : base("Environment")
+        {
+            EnsureArgument.NotNull(env, nameof(env));
+
+            _env = env;
+        }
+
+        protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
+        {
+            PlatformInformation platformInfo = PlatformUtils.GetPlatformInformation();
+            log.AppendLine($"OSType: {platformInfo.OperatingSystemType}");
+            log.AppendLine($"OSVersion: {platformInfo.OperatingSystemVersion}");
+
+            log.Append("Reading environment variables...");
+            IDictionary envars = Environment.GetEnvironmentVariables();
+            log.AppendLine(" OK");
+
+            log.AppendLine(" Variables:");
+            foreach (DictionaryEntry envar in envars)
+            {
+                log.AppendFormat("{0}={1}", envar.Key, envar.Value);
+                log.AppendLine();
+            }
+            log.AppendLine();
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/FileSystemDiagnostic.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/FileSystemDiagnostic.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public class FileSystemDiagnostic : Diagnostic
+    {
+        private readonly IFileSystem _fs;
+
+        public FileSystemDiagnostic(IFileSystem fs)
+            : base("File system")
+        {
+            EnsureArgument.NotNull(fs, nameof(fs));
+
+            _fs = fs;
+        }
+
+        protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
+        {
+            string tempDir = Path.GetTempPath();
+            log.AppendLine($"Temporary directory is '{tempDir}'...");
+
+            log.AppendLine("Checking basic file I/O...");
+            const string testContent = "Hello, GCM!";
+
+            string fileName = Guid.NewGuid().ToString("N").Substring(8);
+            string path = Path.Combine(tempDir, fileName);
+            log.Append($"Writing to temporary file '{path}'...");
+            File.WriteAllText(path, testContent);
+            log.AppendLine(" OK");
+
+            log.Append($"Reading from temporary file '{path}'...");
+            string actualContent = File.ReadAllText(path);
+            log.AppendLine(" OK");
+
+            if (!StringComparer.Ordinal.Equals(testContent, actualContent))
+            {
+                log.AppendLine("File data did not match!");
+                log.AppendLine($"Expected: {testContent}");
+                log.AppendLine($"Actual: {actualContent}");
+                return Task.FromResult(false);
+            }
+
+            log.Append($"Deleting temporary file '{path}'...");
+            File.Delete(path);
+            log.AppendLine(" OK");
+
+            log.AppendLine("Testing IFileSystem instance...");
+            log.AppendLine($"UserHomePath: {_fs.UserHomePath}");
+            log.AppendLine($"UserDataDirectoryPath: {_fs.UserDataDirectoryPath}");
+            log.AppendLine($"GetCurrentDirectory(): {_fs.GetCurrentDirectory()}");
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/GitDiagnostic.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/GitDiagnostic.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public class GitDiagnostic : Diagnostic
+    {
+        private readonly IGit _git;
+
+        public GitDiagnostic(IGit git)
+            : base("Git")
+        {
+            EnsureArgument.NotNull(git, nameof(git));
+
+            _git = git;
+        }
+
+        protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
+        {
+            log.Append("Getting Git version...");
+            GitVersion gitVersion =  _git.Version;
+            log.AppendLine(" OK");
+            log.AppendLine($"Git version is '{gitVersion.OriginalString}'");
+
+            log.Append("Locating current repository...");
+            string thisRepo =_git.GetCurrentRepository();
+            log.AppendLine(" OK");
+            log.AppendLine(thisRepo is null ? "Not inside a Git repository." : $"Git repository at '{thisRepo}'");
+
+            log.Append("Listing all Git configuration...");
+            Process configProc = _git.CreateProcess("config --list --show-origin");
+            configProc.Start();
+            configProc.WaitForExit();
+            string gitConfig = configProc.StandardOutput.ReadToEnd().TrimEnd();
+            log.AppendLine(" OK");
+            log.AppendLine("Git configuration:");
+            log.AppendLine(gitConfig);
+            log.AppendLine();
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/IDiagnosticProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/IDiagnosticProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public interface IDiagnosticProvider
+    {
+        IEnumerable<IDiagnostic> GetDiagnostics();
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager.Authentication;
+using Microsoft.Identity.Client.Extensions.Msal;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public class MicrosoftAuthenticationDiagnostic : Diagnostic
+    {
+        private readonly ICommandContext _context;
+
+        public MicrosoftAuthenticationDiagnostic(ICommandContext context)
+            : base("Microsoft authentication (AAD/MSA)")
+        {
+            EnsureArgument.NotNull(context, nameof(context));
+
+            _context = context;
+        }
+
+        protected override async Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
+        {
+            if (MicrosoftAuthentication.CanUseBroker(_context))
+            {
+                log.Append("Checking broker initialization state...");
+                if (MicrosoftAuthentication.IsBrokerInitialized)
+                {
+                    log.AppendLine(" Initialized");
+                }
+                else
+                {
+                    log.AppendLine("  Not initialized");
+                    log.Append("Initializing broker...");
+                    MicrosoftAuthentication.InitializeBroker();
+                    log.AppendLine("OK");
+                }
+            }
+            else
+            {
+                log.AppendLine("Broker not supported.");
+            }
+
+            var msAuth = new MicrosoftAuthentication(_context);
+            log.AppendLine($"Flow type is: {msAuth.GetFlowType()}");
+
+            log.Append("Gathering MSAL token cache data...");
+            StorageCreationProperties cacheProps = msAuth.CreateTokenCacheProps(true);
+            log.AppendLine(" OK");
+            log.AppendLine($"CacheDirectory: {cacheProps.CacheDirectory}");
+            log.AppendLine($"CacheFileName: {cacheProps.CacheFileName}");
+            log.AppendLine($"CacheFilePath: {cacheProps.CacheFilePath}");
+
+            if (PlatformUtils.IsMacOS())
+            {
+                log.AppendLine($"MacKeyChainAccountName: {cacheProps.MacKeyChainAccountName}");
+                log.AppendLine($"MacKeyChainServiceName: {cacheProps.MacKeyChainServiceName}");
+            }
+            else if (PlatformUtils.IsLinux())
+            {
+                log.AppendLine($"KeyringCollection: {cacheProps.KeyringCollection}");
+                log.AppendLine($"KeyringSchemaName: {cacheProps.KeyringSchemaName}");
+                log.AppendLine($"KeyringSecretLabel: {cacheProps.KeyringSecretLabel}");
+                log.AppendLine($"KeyringAttribute1: ({cacheProps.KeyringAttribute1.Key},{cacheProps.KeyringAttribute1.Value})");
+                log.AppendLine($"KeyringAttribute2: ({cacheProps.KeyringAttribute2.Key},{cacheProps.KeyringAttribute2.Value})");
+            }
+
+            log.Append("Creating cache helper...");
+            var cacheHelper = await MsalCacheHelper.CreateAsync(cacheProps);
+            log.AppendLine(" OK");
+            try
+            {
+                log.Append("Verifying MSAL token cache persistence...");
+                cacheHelper.VerifyPersistence();
+                log.AppendLine(" OK");
+            }
+            catch (Exception)
+            {
+                log.AppendLine(" Failed");
+                throw;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Diagnostics/NetworkingDiagnostic.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Diagnostics/NetworkingDiagnostic.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Git.CredentialManager.Diagnostics
+{
+    public class NetworkingDiagnostic : Diagnostic
+    {
+        private readonly IHttpClientFactory _httpFactory;
+        private const string TestHttpUri = "http://example.com";
+        private const string TestHttpsUri = "https://example.com";
+
+        public NetworkingDiagnostic(IHttpClientFactory httpFactory)
+            : base("Networking")
+        {
+            EnsureArgument.NotNull(httpFactory, nameof(httpFactory));
+
+            _httpFactory = httpFactory;
+        }
+
+        protected override async Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
+        {
+            log.AppendLine("Checking basic networking and HTTP stack...");
+            log.Append("Creating HTTP client...");
+            using var rawHttpClient = new HttpClient();
+            log.AppendLine(" OK");
+
+            if (!await RunTestAsync(log, rawHttpClient)) return false;
+
+            log.AppendLine("Testing with IHttpClientFactory created HTTP client...");
+            log.Append("Creating HTTP client...");
+            using var contextHttpClient = _httpFactory.CreateClient();
+            log.AppendLine(" OK");
+
+            return await RunTestAsync(log, rawHttpClient);
+        }
+
+        private static async Task<bool> RunTestAsync(StringBuilder log, HttpClient httpClient)
+        {
+            bool hasNetwork = NetworkInterface.GetIsNetworkAvailable();
+            log.AppendLine($"IsNetworkAvailable: {hasNetwork}");
+
+            log.Append($"Sending HEAD request to {TestHttpUri}...");
+            using var httpResponse = await httpClient.HeadAsync(TestHttpUri);
+            log.AppendLine(" OK");
+
+            log.Append($"Sending HEAD request to {TestHttpsUri}...");
+            using var httpsResponse = await httpClient.HeadAsync(TestHttpsUri);
+            log.AppendLine(" OK");
+
+            log.Append("Acquiring free TCP port...");
+            var tcpListener = new TcpListener(IPAddress.Loopback, 0);
+            int tcpPort;
+            try
+            {
+                tcpListener.Start();
+                tcpPort = ((IPEndPoint) tcpListener.LocalEndpoint).Port;
+                log.AppendLine(" OK");
+            }
+            finally
+            {
+                tcpListener.Stop();
+            }
+
+            if (tcpPort <= 0)
+            {
+                log.AppendLine("Failed to acquire local TCP port - cannot test local HTTP loopback connections!");
+                return false;
+            }
+
+            log.AppendLine("Testing local HTTP loopback connections...");
+
+            const string responseContent = "Hello, GCM!";
+            byte[] responseData = Encoding.UTF8.GetBytes(responseContent);
+
+            var localAddress = $"http://localhost:{tcpPort}/";
+            log.Append($"Creating new HTTP listener for {localAddress}...");
+            var httpListener = new HttpListener {Prefixes = {localAddress}};
+            httpListener.Start();
+            log.AppendLine(" OK");
+
+            Task<HttpListenerContext> listenContextTask = httpListener.GetContextAsync();
+            Task<HttpResponseMessage> localResponseTask = httpClient.GetAsync(localAddress);
+
+            log.Append("Waiting for loopback connection...");
+            HttpListenerContext listenContext = await listenContextTask;
+            log.AppendLine(" OK");
+
+            log.Append("Writing response...");
+            listenContext.Response.ContentLength64 = responseData.Length;
+            listenContext.Response.OutputStream.Write(responseData, 0, responseData.Length);
+            listenContext.Response.Close();
+            log.AppendLine(" OK");
+
+            log.Append("Waiting for response data...");
+            using HttpResponseMessage localResponse = await localResponseTask;
+            byte[] actualResponseData = await localResponse.Content.ReadAsByteArrayAsync();
+            string actualResponseContent = Encoding.UTF8.GetString(actualResponseData);
+            log.AppendLine(" OK");
+
+            if (!StringComparer.Ordinal.Equals(responseContent, actualResponseContent))
+            {
+                log.AppendLine("Loopback connection data did not match!");
+                log.AppendLine($"Expected: {responseContent}");
+                log.AppendLine($"Actual: {actualResponseContent}");
+                return false;
+            }
+
+            log.AppendLine("Loopback connection data OK");
+
+            return true;
+        }
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Git.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Git.cs
@@ -14,6 +14,13 @@ namespace Microsoft.Git.CredentialManager
         GitVersion Version { get; }
 
         /// <summary>
+        /// Create a Git process object with the specified arguments.
+        /// </summary>
+        /// <param name="args">Arguments to pass to the Git process.</param>
+        /// <returns>Process object ready to be started.</returns>
+        Process CreateProcess(string args);
+
+        /// <summary>
         /// Return the path to the current repository, or null if this instance is not
         /// scoped to a Git repository.
         /// </summary>

--- a/src/shared/Microsoft.Git.CredentialManager/GitVersion.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GitVersion.cs
@@ -6,24 +6,27 @@ namespace Microsoft.Git.CredentialManager
 {
     public class GitVersion : IComparable, IComparable<GitVersion>
     {
-        private List<int> components;
+        private readonly string _originalString;
+        private List<int> _components;
 
         public GitVersion(string versionString)
         {
             if (versionString is null)
             {
-                components = new List<int>();
+                _components = new List<int>();
                 return;
             }
 
+            _originalString = versionString;
+
             string[] splitVersion = versionString.Split('.');
-            components = new List<int>(splitVersion.Length);
+            _components = new List<int>(splitVersion.Length);
 
             foreach (string part in splitVersion)
             {
                 if (Int32.TryParse(part, out int component))
                 {
-                    components.Add(component);
+                    _components.Add(component);
                 }
                 else
                 {
@@ -35,12 +38,25 @@ namespace Microsoft.Git.CredentialManager
 
         public GitVersion(params int[] components)
         {
-            this.components = components.ToList();
+            _components = components.ToList();
         }
 
         public override string ToString()
         {
-            return string.Join(".", this.components);
+            return string.Join(".", _components);
+        }
+
+        public string OriginalString
+        {
+            get
+            {
+                if (_originalString is null)
+                {
+                    return ToString();
+                }
+
+                return _originalString;
+            }
         }
 
         public int CompareTo(object obj)
@@ -68,11 +84,11 @@ namespace Microsoft.Git.CredentialManager
 
             // Compare for as many components as the two versions have in common. If a
             // component does not exist in a components list, it is assumed to be 0.
-            int thisCount = this.components.Count, otherCount = other.components.Count;
+            int thisCount = _components.Count, otherCount = other._components.Count;
             for (int i = 0; i < Math.Max(thisCount, otherCount); i++)
             {
-                int thisComponent = i < thisCount ? this.components[i] : 0;
-                int otherComponent = i < otherCount ? other.components[i] : 0;
+                int thisComponent = i < thisCount ? _components[i] : 0;
+                int otherComponent = i < otherCount ? other._components[i] : 0;
                 if (thisComponent != otherComponent)
                 {
                     return thisComponent.CompareTo(otherComponent);

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -7,6 +8,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
     public class TestGit : IGit
     {
+        public GitVersion Version { get; set; } = new GitVersion("2.32.0.test.0");
+
         public string CurrentRepository { get; set; }
 
         public IList<GitRemote> Remotes { get; set; } = new List<GitRemote>();
@@ -22,7 +25,13 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         }
 
         #region IGit
-        GitVersion IGit.Version => new GitVersion(2, 33, 0);
+
+        GitVersion IGit.Version => Version;
+
+        public Process CreateProcess(string args)
+        {
+            throw new NotImplementedException();
+        }
 
         string IGit.GetCurrentRepository() => CurrentRepository;
 


### PR DESCRIPTION
Introduce a new command `diagnose` that can be run to execute various diagnostic tests. Tests exercise various parts of the product and dump out verbose environment/system information.

This can be useful for debugging problems in the wild by allowing an easy way to narrow down crashing bugs, and to gather important environment information.

In addition, this diagnostic work is extensible so that host providers can create their own diagnostics to test their host-specific components and logic.

Sample output:
```shell
$ git-credential-manager-core diagnose
Running diagnostics...

 [ OK ] Environment
 [ OK ] File system
 [ OK ] Networking
 [ OK ] Git
 [ OK ] Credential storage
 [ OK ] Microsoft authentication (AAD/MSA)
 [ OK ] GitHub API

Diagnostic summary: 7 passed, 0 skipped, 0 failed.
Log files:
  /Users/$USER/myrepo/gcm-diagnose.log

Caution: Log files may include sensitive information - redact before sharing.
```