### PR TITLE
Correctly detect Windows 11 version numbers

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -54,8 +54,8 @@ namespace Microsoft.Git.CredentialManager.Authentication
 
             IsBrokerInitialized = true;
 
-            // Broker is only supported on Windows 10
-            if (!PlatformUtils.IsWindows10())
+            // Broker is only supported on Windows 10 and later
+            if (!PlatformUtils.IsWindows10OrGreater())
             {
                 return;
             }
@@ -287,8 +287,8 @@ namespace Microsoft.Git.CredentialManager.Authentication
                 appBuilder.WithParentActivityOrWindow(() => new IntPtr(hWndInt));
             }
 
-            // On Windows 10 & .NET Framework try and use the WAM broker
-            if (enableBroker && PlatformUtils.IsWindows10())
+            // On Windows 10+ & .NET Framework try and use the WAM broker
+            if (enableBroker && PlatformUtils.IsWindows10OrGreater())
             {
 #if NETFRAMEWORK
                 appBuilder.WithExperimentalFeatures();
@@ -460,7 +460,7 @@ namespace Microsoft.Git.CredentialManager.Authentication
         {
 #if NETFRAMEWORK
             // We only support the broker on Windows 10 and require an interactive session
-            if (!context.SessionManager.IsDesktopSession || !PlatformUtils.IsWindows10())
+            if (!context.SessionManager.IsDesktopSession || !PlatformUtils.IsWindows10OrGreater())
             {
                 return false;
             }

--- a/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/PlatformUtils.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Git.CredentialManager
             return new PlatformInformation(osType, cpuArch, clrVersion);
         }
 
-        public static bool IsWindows10()
+        public static bool IsWindows10OrGreater()
         {
             if (!IsWindows())
             {
@@ -36,7 +36,7 @@ namespace Microsoft.Git.CredentialManager
                 return false;
             }
 
-            return (int) osvi.dwMajorVersion == 10;
+            return (int) osvi.dwMajorVersion >= 10;
         }
 
         /// <summary>


### PR DESCRIPTION
Expand existing checks for "is Windows 10" to "is at least Windows 10" to also capture Windows 11.
Right now we're only using Win10 detection for WAM; Win11 also supports WAM.