### PR TITLE
Added missing quotes in WSL instructions

### DIFF
--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -22,7 +22,7 @@ _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:
 
 ```shell
-git config --global credential.helper /mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe"
 ```
 
 If you intend to use Azure DevOps you must _also_ set the following Git


### PR DESCRIPTION
One of the commands for WSL configuration was missing quotes which resulted in invalid configuration.