### PR TITLE
Match `NO_PROXY` formats to libcurl behaviour

### DIFF
--- a/docs/netconfig.md
+++ b/docs/netconfig.md
@@ -62,8 +62,28 @@ addresses. GCM Core supports the cURL environment variable `NO_PROXY` for this
 scenariom, as does Git itself.
 
 The `NO_PROXY` environment variable should contain a comma (`,`) or space (` `)
-separated list of regular expressions to match hosts that should not be proxied
-(should connect directly).
+separated list of host names that should not be proxied (should connect
+directly).
+
+GCM Core attempts to match [libcurl's behaviour](https://curl.se/libcurl/c/CURLOPT_NOPROXY.html),
+which is briefly summarized here:
+
+- a value of `*` disables proxying for all hosts;
+- other wildcard use is **not** supported;
+- each name in the list is matched as a domain which contains the hostname,
+  or the hostname itself
+- a leading period/dot `.` matches against the provided hostname
+
+For example, setting `NO_PROXY` to `example.com` results in the following:
+
+Hostname|Matches?
+-|-
+`example.com`|:white_check_mark:
+`example.com:80`|:white_check_mark:
+`www.example.com`|:white_check_mark:
+`notanexample.com`|:x:
+`www.notanexample.com`|:x:
+`example.com.othertld`|:x:
 
 **Example:**
 


### PR DESCRIPTION
We aim to be compatible with the behaviour of Git as much as possible when it comes to network settings. This enables users to setup Git proxy settings and get the same setup "for free" with GCM.

Git uses libcurl to provide it's HTTP interactions. The `NO_PROXY` setting is used by libcurl to disable proxy settings for specific hosts.

We previously attempted to plumb the value of NO_PROXY through to the .NET `WebProxy` class' list of "bypassed addresses" (the set of hosts that should not be proxied). However, the .NET class expects a set of _regular expressions_ which is unlike libcurl!

As a result, libcurl permitted values for `NO_PROXY` were throwing errors inside of GCM since they are not valid regexs.

In this commit we perform a transformation of the `NO_PROXY` list and construct a set of regular expressions that match addresses in the same way as libcurl does.

The transformation is as follows:

1. strip any leading periods `.` or wildcards `*.`
2. escape the remaining input to match literally (e.g.: `.` becomes `\.`)
3. prepend a group that matches either a period '.' or a URI scheme delimiter `://` - this prevents partial domain matching
4. append a end-of-string symbol `$` to ensure we only match to the specified TLD and port

See the libcurl documentation on `NO_PROXY` behaviour: https://curl.se/libcurl/c/CURLOPT_NOPROXY.html

Fixes #497 