### PR TITLE
Match libcurl lowercase proxy environment variable behaviour 

### DIFF
--- a/docs/netconfig.md
+++ b/docs/netconfig.md
@@ -49,21 +49,35 @@ GCM Core supports other ways of configuring a proxy for convenience and compatib
 1. GCM-specific configuration options (_**only** respected by GCM; **deprecated**_):
    - `credential.httpProxy`
    - `credential.httpsProxy`
-1. cURL environment variables (_also respected by Git_):
-   - `HTTP_PROXY`
-   - `HTTPS_PROXY`
-   - `ALL_PROXY`
-1. `GCM_HTTP_PROXY` environment variable (_**only** respected by GCM; **deprecated**_)
+2. cURL environment variables (_also respected by Git_):
+   - `http_proxy`
+   - `https_proxy`/`HTTPS_PROXY`
+   - `all_proxy`/`ALL_PROXY`
+3. `GCM_HTTP_PROXY` environment variable (_**only** respected by GCM; **deprecated**_)
+
+Note that with the cURL environment variables there are both lowercase and
+uppercase variants.
+
+**_Lowercase variants take precedence over the uppercase form._** This is
+consistent with how libcurl (and therefore Git) operates.
+
+The `http_proxy` variable exists only in the lowercase variant and libcurl does
+_not_ consider any uppercase form. _GCM Core also reflects this behavior._
+
+See <https://everything.curl.dev/usingcurl/proxies#proxy-environment-variables>
+for more information.
 
 ### Bypassing addresses
 
 In some circumstances you may wish to bypass a configured proxy for specific
-addresses. GCM Core supports the cURL environment variable `NO_PROXY` for this
-scenariom, as does Git itself.
+addresses. GCM Core supports the cURL environment variable `no_proxy` (and
+`NO_PROXY`) for this scenario, as does Git itself.
 
-The `NO_PROXY` environment variable should contain a comma (`,`) or space (` `)
-separated list of host names that should not be proxied (should connect
-directly).
+Like with the [other cURL proxy environment variables](#other-proxy-options),
+the lowercase variant will take precedence over the uppercase form.
+
+This environment variable should contain a comma (`,`) or space (` `) separated
+list of host names that should not be proxied (should connect directly).
 
 GCM Core attempts to match [libcurl's behaviour](https://curl.se/libcurl/c/CURLOPT_NOPROXY.html),
 which is briefly summarized here:
@@ -88,7 +102,7 @@ Hostname|Matches?
 **Example:**
 
 ```text
-NO_PROXY="contoso.com,www.fabrikam.com"
+no_proxy="contoso.com,www.fabrikam.com"
 ```
 
 ## TLS Verification

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -53,10 +53,24 @@ namespace GitCredentialManager
             public const string GcmAuthority          = "GCM_AUTHORITY";
             public const string GitTerminalPrompts    = "GIT_TERMINAL_PROMPT";
             public const string GcmAllowWia           = "GCM_ALLOW_WINDOWSAUTH";
-            public const string CurlNoProxy           = "NO_PROXY";
-            public const string CurlAllProxy          = "ALL_PROXY";
-            public const string CurlHttpProxy         = "HTTP_PROXY";
-            public const string CurlHttpsProxy        = "HTTPS_PROXY";
+
+            /*
+             * Unlike other environment variables, these proxy variables are normally lowercase only.
+             * However, libcurl also implemented checks for the uppercase variants! The lowercase
+             * variants should take precedence over the uppercase ones since the former are quasi-standard.
+             *
+             * One exception to this is that libcurl does not even look for the uppercase variant of
+             * http_proxy (for some security reasons).
+             */
+            public const string CurlNoProxy           = "no_proxy";
+            public const string CurlNoProxyUpper      = "NO_PROXY";
+            public const string CurlHttpsProxy        = "https_proxy";
+            public const string CurlHttpsProxyUpper   = "HTTPS_PROXY";
+            public const string CurlHttpProxy         = "http_proxy";
+            // Note there is no uppercase variant of the http_proxy since libcurl doesn't use it
+            public const string CurlAllProxy          = "all_proxy";
+            public const string CurlAllProxyUpper     = "ALL_PROXY";
+
             public const string GcmHttpProxy          = "GCM_HTTP_PROXY";
             public const string GitSslNoVerify        = "GIT_SSL_NO_VERIFY";
             public const string GitSslCaInfo          = "GIT_SSL_CAINFO";


### PR DESCRIPTION
libcurl supports multiple different environment variables<sup>1</sup> to configure proxy behaviour: http_proxy, https_proxy, all_proxy, and no_proxy.

Unlike most other environment variables these proxy envars are normally _lowercase_, not uppercase. This convention was set by libwww back in the early 1990s. When libcurl was first released however, it was not aware of this schism and only implemented checks for uppercase variants of these envars: HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, and NO_PROXY.

In time, libcurl learned to also read the lowercase variants, and gives them precedence over the uppercase forms (since the former are quasi-standards).

However, to further complicate the matter, libcurl no longer reads the uppercase HTTP_PROXY variable specifically. This change was made to address a security concern with some CGI webservers<sup>2</sup>.

The problem is that today GCM only reads the uppercase variants of the environment variables! This is inconsistent with libcurl, and therefore Git's behaviour (that we aim to be consistent/co-operative with).

We change GCM's behaviour to match that of libcurl/Git in that the lowercase proxy envars are preferred to the uppercase ones, and the uppercase HTTP_PROXY variable is ignored.

Dropping support for the HTTP_PROXY uppercase envar is technically a breaking change, but if the user had only set this uppercase envar then Git would not be proxying the actual remote calls, only GCM, which is most likely not what the user wanted.

1. https://everything.curl.dev/usingcurl/proxies#proxy-environment-variables
2. https://everything.curl.dev/usingcurl/proxies#http_proxy-in-lower-case-only