### PR TITLE
Update to MSAL.NET 4.37

### DIFF
--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -13,13 +13,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.31.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.37.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.31.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.4" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.19.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 


### PR DESCRIPTION
Update our MSAL.NET dependency to 4.37 from 4.31. This should come with the following updates/fixes that we care about:

- Can set embedded web view (legacy) window title to custom message
- Fixes some problems with WAM dialogs appearing behind parent windows
- Moves WAM to no longer being experimental
- Better MSA-PT support when used with WAM
- Numerous performance improvements with authority discovery
- Various WAM bug fixes

Fixes #239

**Embedded window before:**
![image](https://user-images.githubusercontent.com/5658207/139827792-6227cf59-64e1-4c34-a3fd-0a987a27f1f2.png)

**..and after:**
![image](https://user-images.githubusercontent.com/5658207/139827826-706421e3-dcf4-4749-a596-492ce3acbbbf.png)
