### PR TITLE
Include all shared libraries in Debian package

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -173,10 +173,8 @@ Description: Cross Platform Git Credential Manager Core command line utility.
  For more information see https://aka.ms/gcmcore
 EOF
 
-# Copy GCM Core & UI helper binaries to target installation location
-cp "$PAYLOAD/git-credential-manager-core" "$INSTALL_TO" || exit 1
-cp "$PAYLOAD/Atlassian.Bitbucket.UI" "$INSTALL_TO" || exit 1
-cp "$PAYLOAD/GitHub.UI" "$INSTALL_TO" || exit 1
+# Copy all binaries and shared libraries to target installation location
+cp -R "$PAYLOAD" "$INSTALL_TO" || exit 1
 
 # Create symlinks
 ln -s -r "$INSTALL_TO/git-credential-manager-core" \


### PR DESCRIPTION
Include missing Avalonia native shared libraries in the Debian package.

They are already being included in the tarball, but omited from the Debian package. Change the build script to do a recursive copy `cp -R` so that as dependencies change over time, we don't miss any!

Fixes #506 