### PR TITLE
Set `credential.provider` after successful auto detection probe

### DIFF
--- a/docs/autodetect.md
+++ b/docs/autodetect.md
@@ -31,6 +31,11 @@ hostname can be made. Only one HTTP `HEAD` call is made per credential request
 received by Git. To avoid this network call, please [explicitly configure](#explicit-configuration)
 the host provider for your self-hosted instance.
 
+After a successful detection of the host provider, GCM will automatically set
+the [`credential.provider` configuration entry](configuration.md#credentialprovider)
+for that remote to avoid needing to perform this expensive network call in
+future requests.
+
 ### Timeout
 
 You can control how long GCM will wait for a response to the remote network call
@@ -41,7 +46,7 @@ Git configuration setting to the maximum number of milliseconds to wait.
 The default value is 2000 milliseconds (2 seconds). You can prevent the network
 call altogether by setting a zero or negative value, for example -1.
 
-## Explicit configuration
+## Manual configuration
 
 If the auto-detection mechanism fails to select the correct host provider, or
 if the remote probing network call is causing performance issues, you can


### PR DESCRIPTION
After we've detected the host provider from an auto-detection network probe, set the `credential.provider` setting so we can avoid the expensive operation in the future. This greatly improves the performance of subsequent credential requests.

If we fail to set this then warn the user and ask them to set the configuration manually.

Fixes #507