### PR TITLE
Use wslview to launch browser in Windows from WSL

### DIFF
--- a/src/shared/Core/BrowserUtils.cs
+++ b/src/shared/Core/BrowserUtils.cs
@@ -39,7 +39,11 @@ namespace GitCredentialManager
                 //
                 // We try and use the same 'shell execute' utilities as the Framework does,
                 // searching for them in the same order until we find one.
-                foreach (string shellExec in new[] {"xdg-open", "gnome-open", "kfmclient"})
+                //
+                // One additional 'shell execute' utility we also attempt to use is `wslview`
+                // that is commonly found on WSL (Windows Subsystem for Linux) distributions that
+                // opens the browser on the Windows host.
+                foreach (string shellExec in new[] {"xdg-open", "gnome-open", "kfmclient", "wslview"})
                 {
                     if (environment.TryLocateExecutable(shellExec, out string shellExecPath))
                     {


### PR DESCRIPTION
When installed inside of a Linux environment we typically look for a set of utilities to open the user's preferred browser (xdg-open, gnome-open, kfmclient).

However, if we are actually in a WSL (Windows Subsystem for Linux) distribution, these utilties may not be/are not present. Instead we can try and use the `wslview` utility that will launch the user's browser on the _Windows host_.

Appending `wslview` to the list of utilities to open the browser means no behaviour change for existing Linux users, but for WSL distros we now have a chance to still open the browser.

Fixes #515