### PR TITLE
Update System.CommandLine to 2.0.0-beta1.21216.1

### DIFF
--- a/src/shared/Core.UI/HelperApplication.cs
+++ b/src/shared/Core.UI/HelperApplication.cs
@@ -49,7 +49,7 @@ namespace GitCredentialManager.UI
                 WriteException(ex);
             }
 
-            invocationContext.ResultCode = -1;
+            invocationContext.ExitCode = -1;
         }
 
         private bool WriteException(Exception ex)

--- a/src/shared/Core/Application.cs
+++ b/src/shared/Core/Application.cs
@@ -128,7 +128,7 @@ namespace GitCredentialManager
                 WriteException(ex);
             }
 
-            invocationContext.ResultCode = -1;
+            invocationContext.ExitCode = -1;
         }
 
         private bool WriteException(Exception ex)

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.19.2" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update the System.CommandLine package to [2.0.0-beta1.21216.1](https://github.com/dotnet/command-line-api/releases/tag/v2.0.0-beta1.21216.1) to hopefully fix some problems with dotnet-suggest registration caused by `Process::UseShellExecute` differences between .NET Framework and .NET (Core).

https://github.com/jonsequitur/command-line-api/commit/ad22b69ac8944fe29fd3433c4072828f3398d5af
https://github.com/dotnet/command-line-api/issues/1254

Fixes #505