### PR TITLE
README: add information on removal from  MSFT Ubuntu feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Download the latest [.deb package](https://github.com/microsoft/Git-Credential-M
 sudo dpkg -i <path-to-package>
 git-credential-manager-core configure
 ```
+__Note:__ Although packages were previously offered on certain
+[Microsoft Ubuntu package feeds](https://packages.microsoft.com/repos/),
+GCM no longer publishes to these repositories. Please install the
+Debian package using the above instructions instead.
 
 #### Other distributions
 


### PR DESCRIPTION
As part of the migration of GCM  out of the microsoft org, we removed
packages from the Microsoft Hirsute/Bionic feeds. Adding a note to the
README informing users that these packages are no longer available and
that installing the debian package from the releases page is the preferred
mode at this time.