### PR TITLE
Fix release builds

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   configuration: Release
-  signPool: VSEng-MicroBuildVS2019
+  signPool: MSEngSS-MicroBuild2019-1ES
   winImage: vs2017-win2016
   osxImage: macos-latest
 

--- a/.azure-pipelines/templates/osx/pack.signed/step2-signpayload.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step2-signpayload.yml
@@ -1,5 +1,5 @@
 steps:
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
     displayName: Install signing plugin
     inputs:
       signType: '$(SignType)'

--- a/.azure-pipelines/templates/osx/pack.signed/step2-signpayload.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step2-signpayload.yml
@@ -1,4 +1,9 @@
 steps:
+  - task: NuGetAuthenticate@0
+    displayName: Authenticate to MicroBuild NuGet feed
+    inputs:
+      nuGetServiceConnections: 'MicroBuild Toolset Nuget Feed (Read)'
+
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
     displayName: Install signing plugin
     inputs:

--- a/.azure-pipelines/templates/osx/pack.signed/step4-signpack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step4-signpack.yml
@@ -1,5 +1,5 @@
 steps:
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
     displayName: Install signing plugin
     inputs:
       signType: '$(SignType)'

--- a/.azure-pipelines/templates/osx/pack.signed/step4-signpack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step4-signpack.yml
@@ -1,4 +1,9 @@
 steps:
+  - task: NuGetAuthenticate@0
+    displayName: Authenticate to MicroBuild NuGet feed
+    inputs:
+      nuGetServiceConnections: 'MicroBuild Toolset Nuget Feed (Read)'
+
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
     displayName: Install signing plugin
     inputs:

--- a/.azure-pipelines/templates/windows/compile.signed.yml
+++ b/.azure-pipelines/templates/windows/compile.signed.yml
@@ -1,4 +1,9 @@
 steps:
+  - task: NuGetAuthenticate@0
+    displayName: Authenticate to MicroBuild NuGet feed
+    inputs:
+      nuGetServiceConnections: 'MicroBuild Toolset Nuget Feed (Read)'
+
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
     displayName: Install signing plugin
     condition: and(succeeded(), eq(variables['SignType'], 'real'))

--- a/.azure-pipelines/templates/windows/compile.signed.yml
+++ b/.azure-pipelines/templates/windows/compile.signed.yml
@@ -1,5 +1,5 @@
 steps:
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
     displayName: Install signing plugin
     condition: and(succeeded(), eq(variables['SignType'], 'real'))
     inputs:

--- a/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
+++ b/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <!-- Development dependency only -->
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Tools.InnoSetup" Version="6.0.5" />
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/windows/Payload.Windows/Payload.Windows.csproj
+++ b/src/windows/Payload.Windows/Payload.Windows.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Recent changes to the release build agent pool configuration means we have to update a few parts of our release build:

1. Use the new agent pool
2. Update NuGet packages and Azure DevOps tasks
3. Explicit authentication for NuGet feeds